### PR TITLE
Add configurable CSV export columns with drag-and-drop ordering

### DIFF
--- a/edit_csv_columns.php
+++ b/edit_csv_columns.php
@@ -11,6 +11,7 @@ $all_columns_def = [
     ['id' => 'artist',       'label' => '歌手名'],
     ['id' => 'singer',       'label' => '歌った人'],
     ['id' => 'comment',      'label' => 'コメント'],
+    ['id' => 'worker',       'label' => '動画制作者'],
 ];
 
 function load_csv_columns($config_file, $all_columns_def) {

--- a/edit_csv_columns.php
+++ b/edit_csv_columns.php
@@ -4,14 +4,14 @@ require_once 'commonfunc.php';
 $config_file = 'csv_export_columns.json';
 
 $all_columns_def = [
-    ['id' => 'num',          'label' => '順番'],
-    ['id' => 'songfile',     'label' => '曲名（ファイル名）'],
-    ['id' => 'keychange',    'label' => 'キー'],
-    ['id' => 'program_name', 'label' => '作品名'],
-    ['id' => 'artist',       'label' => '歌手名'],
-    ['id' => 'singer',       'label' => '歌った人'],
-    ['id' => 'comment',      'label' => 'コメント'],
-    ['id' => 'worker',       'label' => '動画制作者'],
+    ['id' => 'num',          'label' => '順番',           'default' => true],
+    ['id' => 'songfile',     'label' => '曲名（ファイル名）', 'default' => true],
+    ['id' => 'program_name', 'label' => '作品名',          'default' => true],
+    ['id' => 'artist',       'label' => '歌手名',          'default' => true],
+    ['id' => 'singer',       'label' => '歌った人',         'default' => true],
+    ['id' => 'comment',      'label' => 'コメント',         'default' => true],
+    ['id' => 'keychange',    'label' => 'キー',            'default' => false],
+    ['id' => 'worker',       'label' => '動画制作者',       'default' => false],
 ];
 
 function load_csv_columns($config_file, $all_columns_def) {
@@ -22,14 +22,14 @@ function load_csv_columns($config_file, $all_columns_def) {
             $saved_ids = array_column($saved, 'id');
             foreach ($all_columns_def as $col) {
                 if (!in_array($col['id'], $saved_ids)) {
-                    $saved[] = ['id' => $col['id'], 'label' => $col['label'], 'enabled' => true];
+                    $saved[] = ['id' => $col['id'], 'label' => $col['label'], 'enabled' => $col['default']];
                 }
             }
             return $saved;
         }
     }
     return array_map(function($col) {
-        return ['id' => $col['id'], 'label' => $col['label'], 'enabled' => true];
+        return ['id' => $col['id'], 'label' => $col['label'], 'enabled' => $col['default']];
     }, $all_columns_def);
 }
 

--- a/edit_csv_columns.php
+++ b/edit_csv_columns.php
@@ -1,0 +1,176 @@
+<?php
+require_once 'commonfunc.php';
+
+$config_file = 'csv_export_columns.json';
+
+$all_columns_def = [
+    ['id' => 'num',          'label' => '順番'],
+    ['id' => 'songfile',     'label' => '曲名（ファイル名）'],
+    ['id' => 'keychange',    'label' => 'キー'],
+    ['id' => 'program_name', 'label' => '作品名'],
+    ['id' => 'artist',       'label' => '歌手名'],
+    ['id' => 'singer',       'label' => '歌った人'],
+    ['id' => 'comment',      'label' => 'コメント'],
+];
+
+function load_csv_columns($config_file, $all_columns_def) {
+    if (file_exists($config_file)) {
+        $json = file_get_contents($config_file);
+        $saved = json_decode($json, true);
+        if ($saved !== null) {
+            $saved_ids = array_column($saved, 'id');
+            foreach ($all_columns_def as $col) {
+                if (!in_array($col['id'], $saved_ids)) {
+                    $saved[] = ['id' => $col['id'], 'label' => $col['label'], 'enabled' => true];
+                }
+            }
+            return $saved;
+        }
+    }
+    return array_map(function($col) {
+        return ['id' => $col['id'], 'label' => $col['label'], 'enabled' => true];
+    }, $all_columns_def);
+}
+
+$saved_message = false;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['columns'])) {
+    $columns_order = $_POST['columns'];
+    $enabled_set = isset($_POST['enabled']) ? $_POST['enabled'] : [];
+    $all_ids = array_column($all_columns_def, 'id');
+    $label_map = array_column($all_columns_def, 'label', 'id');
+
+    $new_config = [];
+    foreach ($columns_order as $col_id) {
+        if (!in_array($col_id, $all_ids)) continue;
+        $new_config[] = [
+            'id'      => $col_id,
+            'label'   => $label_map[$col_id],
+            'enabled' => in_array($col_id, $enabled_set),
+        ];
+    }
+    file_put_contents($config_file, json_encode($new_config, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+    $saved_message = true;
+}
+
+$columns = load_csv_columns($config_file, $all_columns_def);
+?>
+<!doctype html>
+<html lang="ja">
+<head>
+<?php print_meta_header(); ?>
+<title>CSV出力列設定</title>
+<link type="text/css" rel="stylesheet" href="css/bootstrap.min.css" />
+<link type="text/css" rel="stylesheet" href="css/style.css" />
+<style>
+.column-list { list-style: none; padding: 0; max-width: 480px; }
+.column-item {
+    display: flex;
+    align-items: center;
+    padding: 10px 14px;
+    margin: 5px 0;
+    background: #f9f9f9;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    cursor: grab;
+    user-select: none;
+}
+.column-item.dragging { opacity: 0.4; background: #e0e0e0; }
+.column-item.drag-over-top    { border-top: 3px solid #337ab7; }
+.column-item.drag-over-bottom { border-bottom: 3px solid #337ab7; }
+.drag-handle { margin-right: 12px; color: #aaa; font-size: 20px; line-height: 1; }
+.column-item label { margin: 0; flex: 1; cursor: pointer; font-weight: normal; }
+.column-item input[type=checkbox] { margin-right: 8px; transform: scale(1.2); }
+</style>
+</head>
+<body style="padding-top: 20px;">
+
+<?php if ($saved_message): ?>
+<div class="container">
+  <div class="alert alert-success">設定を保存しました。</div>
+</div>
+<?php endif; ?>
+
+<div class="container">
+  <h3>CSV出力列設定</h3>
+  <p>出力する列のチェックを入れ、ドラッグ＆ドロップで順番を変更してください。</p>
+
+  <form method="post" action="edit_csv_columns.php" id="columns-form">
+    <ul class="column-list" id="column-list">
+      <?php foreach ($columns as $col): ?>
+      <li class="column-item" draggable="true" data-id="<?= htmlspecialchars($col['id']) ?>">
+        <span class="drag-handle">&#9776;</span>
+        <input type="checkbox"
+               name="enabled[]"
+               value="<?= htmlspecialchars($col['id']) ?>"
+               id="cb_<?= htmlspecialchars($col['id']) ?>"
+               <?= $col['enabled'] ? 'checked' : '' ?>>
+        <label for="cb_<?= htmlspecialchars($col['id']) ?>">
+          <?= htmlspecialchars($col['label']) ?>
+        </label>
+        <input type="hidden" name="columns[]" value="<?= htmlspecialchars($col['id']) ?>">
+      </li>
+      <?php endforeach; ?>
+    </ul>
+
+    <div style="margin-top: 16px;">
+      <button type="submit" class="btn btn-primary">保存</button>
+      &nbsp;
+      <a href="init.php" class="btn btn-default">設定画面に戻る</a>
+      &nbsp;
+      <a href="simplelistexport_utf8.php" class="btn btn-default">CSVエクスポート</a>
+    </div>
+  </form>
+</div>
+
+<script>
+(function() {
+    var list = document.getElementById('column-list');
+    var dragging = null;
+
+    list.addEventListener('dragstart', function(e) {
+        dragging = e.target.closest('.column-item');
+        setTimeout(function() { dragging.classList.add('dragging'); }, 0);
+    });
+
+    list.addEventListener('dragend', function() {
+        if (dragging) dragging.classList.remove('dragging');
+        document.querySelectorAll('.column-item.drag-over-top, .column-item.drag-over-bottom')
+            .forEach(function(el) {
+                el.classList.remove('drag-over-top', 'drag-over-bottom');
+            });
+        dragging = null;
+        syncHiddenInputs();
+    });
+
+    list.addEventListener('dragover', function(e) {
+        e.preventDefault();
+        var target = e.target.closest('.column-item');
+        if (!target || target === dragging) return;
+
+        document.querySelectorAll('.column-item.drag-over-top, .column-item.drag-over-bottom')
+            .forEach(function(el) {
+                el.classList.remove('drag-over-top', 'drag-over-bottom');
+            });
+
+        var rect = target.getBoundingClientRect();
+        if (e.clientY < rect.top + rect.height / 2) {
+            target.classList.add('drag-over-top');
+            list.insertBefore(dragging, target);
+        } else {
+            target.classList.add('drag-over-bottom');
+            list.insertBefore(dragging, target.nextSibling);
+        }
+    });
+
+    function syncHiddenInputs() {
+        var items = list.querySelectorAll('.column-item');
+        items.forEach(function(item) {
+            var id = item.getAttribute('data-id');
+            item.querySelector('input[type=hidden]').value = id;
+        });
+    }
+})();
+</script>
+</body>
+</html>

--- a/init.php
+++ b/init.php
@@ -295,6 +295,10 @@ print '</pre>';
     <a href ="init.php?clearauth=1" class="btn btn-default" > ログイン情報クリア (対応ブラウザのみ)</a>
   </p>
   <p>
+  <h3>CSV出力列設定</h3>
+    <a href="edit_csv_columns.php" class="btn btn-default" > CSV出力列設定 </a>
+  </p>
+  <p>
   <h3>製作者優先表示設定 <small>（りすたーDB検索のみ有効）</small></h3>
     <a href="edit_search_sort_priority.php" class="btn btn-default" > 製作者優先表示設定 </a>
   </p>

--- a/simplelistexport_utf8.php
+++ b/simplelistexport_utf8.php
@@ -36,6 +36,7 @@ $all_columns_def = [
     'artist'       => '歌手名',
     'singer'       => '歌った人',
     'comment'      => 'コメント',
+    'worker'       => '動画制作者',
 ];
 
 // 列設定ファイル読み込み
@@ -168,6 +169,12 @@ foreach ($allrequest as $row) {
         $artist = $songdataarray["song_artist"];
     }
 
+    // 動画制作者
+    $worker = '';
+    if (!empty($songdataarray["found_worker"])) {
+        $worker = $songdataarray["found_worker"];
+    }
+
     // 列設定に従って行データを生成
     $row_data = [];
     foreach ($active_columns as $col_id) {
@@ -179,6 +186,7 @@ foreach ($allrequest as $row) {
             case 'artist':       $row_data[] = $artist; break;
             case 'singer':       $row_data[] = $row["singer"]; break;
             case 'comment':      $row_data[] = $row["comment"]; break;
+            case 'worker':       $row_data[] = $worker; break;
         }
     }
     $csvarray[] = $row_data;

--- a/simplelistexport_utf8.php
+++ b/simplelistexport_utf8.php
@@ -1,8 +1,7 @@
 <?php
-/*** 仮作成 ***/
 require_once('commonfunc.php');
 require_once('function_search_listerdb.php');
-//die();
+
 function arr2csv($arr) {
     $fp = fopen('php://temp', 'r+b');
     foreach ($arr as $fields) {
@@ -28,26 +27,52 @@ if(empty($dbname)){
   $dbname = 'data';
 }
 
+// 列定義（id => ヘッダーラベル）
+$all_columns_def = [
+    'num'          => '順番',
+    'songfile'     => '曲名（ファイル名）',
+    'keychange'    => 'キー',
+    'program_name' => '作品名',
+    'artist'       => '歌手名',
+    'singer'       => '歌った人',
+    'comment'      => 'コメント',
+];
 
+// 列設定ファイル読み込み
+function load_export_columns($config_file, $all_columns_def) {
+    if (file_exists($config_file)) {
+        $json = file_get_contents($config_file);
+        $saved = json_decode($json, true);
+        if ($saved !== null) {
+            $active = [];
+            foreach ($saved as $col) {
+                if (!empty($col['enabled']) && isset($all_columns_def[$col['id']])) {
+                    $active[] = $col['id'];
+                }
+            }
+            if (!empty($active)) return $active;
+        }
+    }
+    return array_keys($all_columns_def);
+}
+
+$active_columns = load_export_columns('csv_export_columns.json', $all_columns_def);
 
 function getsonginfofromfilename($filename){
   global $config_ini;
 
   if(empty($filename)) return false;
-  // ListerDBのファイルの設定があるかどうかのチェック
   $res = array_key_exists("listerDBPATH",$config_ini);
   if ($res === false ) {
      print( "config not found");
      return false;
   }
   $lister_dbpath = urldecode($config_ini["listerDBPATH"]);
-  // ListerDBのファイルのがあるかどうかのチェック
   if(!file_exists($lister_dbpath) ){
      print( "Listerdb file :". $lister_dbpath." not found");
      return false;
   }
 
-  // DB初期化
   $lister = new ListerDB();
   $lister->listerdbfile = $lister_dbpath;
   $listerdb = $lister->initdb();
@@ -63,15 +88,12 @@ function getsonginfofromfilename($filename){
       $sql = 'SELECT * FROM t_found '. $select_where.';';
       @$songdbdata = $lister->select($sql);
       if(!$songdbdata){
-//     print $sql;
          return false;
       }
-
+  }
+  return $songdbdata;
 }
-return $songdbdata;
-}
 
-// 1つでもlisterDBに登録情報があるかどうかのチェック
 function listerdbfoundcheck($alldata){
    foreach($alldata as $row){
      $songdataarray_all = getsonginfofromfilename($row["fullpath"]);
@@ -92,70 +114,79 @@ if(array_key_exists("listerDBPATH",$config_ini) ) {
     }
 }
 
+header('Content-Type: application/octet-stream');
+header('Content-Disposition: attachment; filename=list_'.$dbname.'.csv');
 
-  header('Content-Type: application/octet-stream');
-  header('Content-Disposition: attachment; filename=list_'.$dbname.'.csv');
-  
-    $num = 1;
-  $csvarray = array();
+$num = 1;
+$csvarray = array();
 
-  if($listerdbenabled && listerdbfoundcheck($allrequest) ){
-// りすたーDBに登録された情報が1つでもある
-    $csvarray[] = array( "順番" , "曲名（ファイル名）" ,"キー", "作品名" ,"歌手名" , "歌った人" ,  "コメント" );
-    foreach($allrequest as $row){
-    $songdataarray = array();
-    $songdataarray_all = getsonginfofromfilename($row["fullpath"]);
-    if(isset($songdataarray_all[0])) $songdataarray = $songdataarray_all[0];
-    if(!empty($songdataarray["song_name"] ) ){
-        $songname=$songdataarray["song_name"] ;
-        if(!empty($songdataarray["found_comment"] ) ){
-            $showcomment=preg_replace('/\,\/\/.*/', "",$songdataarray["found_comment"]);
-            if(!empty($showcomment))
-            $songname=$songname.'【'.$showcomment.'】' ;
-        }
-    }else{
-        $songname=$row["songfile"];
+// ヘッダー行
+$header = [];
+foreach ($active_columns as $col_id) {
+    $header[] = $all_columns_def[$col_id];
+}
+$csvarray[] = $header;
+
+$use_listerdb = $listerdbenabled && listerdbfoundcheck($allrequest);
+
+foreach ($allrequest as $row) {
+    // ListerDB情報の取得
+    $songdataarray = [];
+    if ($use_listerdb) {
+        $songdataarray_all = getsonginfofromfilename($row["fullpath"]);
+        if (isset($songdataarray_all[0])) $songdataarray = $songdataarray_all[0];
     }
-    
-    $program_name='';
-    if(!empty($songdataarray["program_name"] ) ){
-      if( $songdataarray["program_name"] == "その他" ) {
-        $program_name='-';
-      } else {
-        $program_name=$songdataarray["program_name"];
-        if(!empty($songdataarray["song_op_ed"] ) ){
-          $program_name=$program_name.' '.$songdataarray["song_op_ed"];
+
+    // 曲名
+    if (!empty($songdataarray["song_name"])) {
+        $songname = $songdataarray["song_name"];
+        if (!empty($songdataarray["found_comment"])) {
+            $showcomment = preg_replace('/\,\/\/.*/', "", $songdataarray["found_comment"]);
+            if (!empty($showcomment))
+                $songname = $songname . '【' . $showcomment . '】';
         }
-      }
+    } else {
+        $songname = $row["songfile"];
     }
-    
+
+    // 作品名
+    $program_name = '';
+    if (!empty($songdataarray["program_name"])) {
+        if ($songdataarray["program_name"] == "その他") {
+            $program_name = '-';
+        } else {
+            $program_name = $songdataarray["program_name"];
+            if (!empty($songdataarray["song_op_ed"])) {
+                $program_name = $program_name . ' ' . $songdataarray["song_op_ed"];
+            }
+        }
+    }
+
+    // 歌手名
     $artist = '';
-    if(!empty($songdataarray["song_artist"] ) ){
+    if (!empty($songdataarray["song_artist"])) {
         $artist = $songdataarray["song_artist"];
     }
-    
 
-      $csvarray[] = array( $num, $songname , $row["keychange"],$program_name,$artist ,$row["singer"] ,  $row["comment"] );
-      $num++;
+    // 列設定に従って行データを生成
+    $row_data = [];
+    foreach ($active_columns as $col_id) {
+        switch ($col_id) {
+            case 'num':          $row_data[] = $num; break;
+            case 'songfile':     $row_data[] = $songname; break;
+            case 'keychange':    $row_data[] = $row["keychange"]; break;
+            case 'program_name': $row_data[] = $program_name; break;
+            case 'artist':       $row_data[] = $artist; break;
+            case 'singer':       $row_data[] = $row["singer"]; break;
+            case 'comment':      $row_data[] = $row["comment"]; break;
+        }
     }
-      
+    $csvarray[] = $row_data;
+    $num++;
+}
 
-  }else {
-  
-    $num = 1;
-    /* print csv header */
-    $csvarray[] = array( "順番" , "曲名（ファイル名）" ,"キー",  "歌った人" ,  "コメント" );
-    
-    foreach($allrequest as $row){
-      $csvarray[] = array( $num, $row["songfile"] , $row["keychange"] ,$row["singer"] ,  $row["comment"] );
-      $num++;
-    }
-  }
-  $stream = fopen('php://output', 'wb');
-  fwrite($stream, pack('C*',0xEF,0xBB,0xBF));//BOM書き込み
-    // rewind($stream);
-    // var_dump($csvarray);
-    fwrite ($stream, arr2csv($csvarray));
-  fclose($stream);
-
+$stream = fopen('php://output', 'wb');
+fwrite($stream, pack('C*', 0xEF, 0xBB, 0xBF)); // BOM
+fwrite($stream, arr2csv($csvarray));
+fclose($stream);
 ?>


### PR DESCRIPTION
## Summary
This PR adds a new feature to customize which columns are exported in CSV files and their order. Users can now enable/disable columns and reorder them via a drag-and-drop interface.

## Key Changes

- **New configuration file support**: CSV export columns are now configurable via `csv_export_columns.json`, allowing persistent storage of user preferences
- **New admin page** (`edit_csv_columns.php`): Provides a UI for managing CSV export columns with:
  - Checkbox toggles to enable/disable each column
  - Drag-and-drop interface to reorder columns
  - Support for 8 columns: number, song file, program name, artist, singer, comment, key change, and video creator
- **Refactored CSV export logic** (`simplelistexport_utf8.php`):
  - Replaced hardcoded column logic with dynamic column configuration
  - Simplified conditional branching by unifying ListerDB and non-ListerDB export paths
  - Added support for new "worker" (video creator) column from ListerDB
  - Improved code readability with clearer variable naming and structure
- **Updated settings page** (`init.php`): Added link to the new CSV column configuration page

## Implementation Details

- Column definitions are stored as JSON with id, label, and enabled status
- The export script dynamically generates CSV headers and rows based on active columns
- Default column set includes: number, song file, program name, artist, singer, and comment
- Optional columns (key change, video creator) are disabled by default
- Drag-and-drop functionality uses vanilla JavaScript with visual feedback during reordering

https://claude.ai/code/session_01AM2vFfwtogT3FNfKpH9zAH