### PR TITLE
Add video details extraction and display functionality

### DIFF
--- a/func_audiotracklist.php
+++ b/func_audiotracklist.php
@@ -132,7 +132,7 @@ function getvideodetails($filename) {
     }
 
     if (!empty($info['video']['frame_rate'])) {
-        $details['frame_rate'] = $info['video']['frame_rate'];
+        $details['frame_rate'] = round($info['video']['frame_rate'], 2);
     }
 
     return $details;

--- a/func_audiotracklist.php
+++ b/func_audiotracklist.php
@@ -105,6 +105,39 @@ function getaudiotracklist($filename){
     return $audiotracklist;
 }
 
+function getvideodetails($filename) {
+    $getID3 = new getID3();
+    $details = array();
+    $workencode = 'UTF-8';
+
+    if (getphpversion_fa() < 70100) {
+        $workencode = 'SJIS-win';
+    }
+    $filename_host = mb_convert_encoding($filename, $workencode, 'UTF-8');
+    setlocale(LC_CTYPE, 'Japanese_Japan.932');
+    if (!file_exist_check_japanese($filename_host)) return $details;
+
+    $error_level = error_reporting();
+    error_reporting($error_level - E_WARNING);
+    $info = $getID3->analyze($filename_host);
+    error_reporting($error_level);
+
+    getid3_lib::CopyTagsToComments($info);
+
+    if (!empty($info['playtime_seconds'])) {
+        $total_seconds = (int)round($info['playtime_seconds']);
+        $minutes = (int)($total_seconds / 60);
+        $secs = $total_seconds % 60;
+        $details['duration'] = sprintf('%d:%02d', $minutes, $secs);
+    }
+
+    if (!empty($info['video']['frame_rate'])) {
+        $details['frame_rate'] = $info['video']['frame_rate'];
+    }
+
+    return $details;
+}
+
 // function from manage-mpc.php
 
 function file_exist_check_japanese($filename){

--- a/request_confirm.php
+++ b/request_confirm.php
@@ -512,6 +512,34 @@ EOT;
 EOT;
 }
 
+if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8)) {
+    $videodetails = getvideodetails($fullpath_utf8);
+    if (!empty($videodetails)) {
+        print '<div class="panel panel-default" style="margin-top:8px;">'."\n";
+        print '<div class="panel-heading" role="tab" id="videoDetailsHeading">'."\n";
+        print '<h4 class="panel-title">'."\n";
+        print '<a role="button" data-toggle="collapse" data-target="#videoDetailsCollapse" '.
+              'aria-expanded="false" aria-controls="videoDetailsCollapse" class="collapsed">'."\n";
+        print '動画詳細情報 ▼'."\n";
+        print '</a>'."\n";
+        print '</h4>'."\n";
+        print '</div>'."\n";
+        print '<div id="videoDetailsCollapse" class="panel-collapse collapse" role="tabpanel">'."\n";
+        print '<div class="panel-body">'."\n";
+        print '<dl class="dl-horizontal" style="margin-bottom:0;">'."\n";
+        if (isset($videodetails['duration'])) {
+            print '<dt>曲の長さ</dt><dd>'.htmlspecialchars($videodetails['duration']).'</dd>'."\n";
+        }
+        if (isset($videodetails['frame_rate'])) {
+            print '<dt>フレームレート</dt><dd>'.htmlspecialchars($videodetails['frame_rate']).' fps</dd>'."\n";
+        }
+        print '</dl>'."\n";
+        print '</div>'."\n";
+        print '</div>'."\n";
+        print '</div>'."\n";
+    }
+}
+
 ?>
 
 


### PR DESCRIPTION
## Summary
This PR adds functionality to extract and display video metadata (duration and frame rate) for video files in the request confirmation interface.

## Key Changes
- **New function `getvideodetails()`** in `func_audiotracklist.php`:
  - Extracts video metadata using getID3 library
  - Handles character encoding for Japanese filenames (UTF-8 to SJIS-win conversion for PHP < 7.1)
  - Extracts duration (formatted as MM:SS) and frame rate (rounded to 2 decimal places)
  - Returns an associative array with video details

- **Video details display** in `request_confirm.php`:
  - Conditionally displays video metadata when a video file is selected (filetype == 1)
  - Only shows for non-karaoke shops (shop_karaoke != 1)
  - Renders details in a collapsible Bootstrap panel with Japanese labels
  - Displays duration as "曲の長さ" (Song Length) and frame rate as "フレームレート" (Frame Rate)
  - Properly escapes output using `htmlspecialchars()`

## Implementation Details
- Reuses existing patterns from `getaudiotracklist()` function for consistency
- Handles file existence checks and error reporting suppression during analysis
- Uses Bootstrap panel collapse component for UI consistency with existing interface
- Safely handles missing or empty video metadata fields

https://claude.ai/code/session_01HzNLDRx3xaeMPP3GVwLoMq