### PR TITLE
simplelist.php のモバイル対応デザイン刷新とフィルタリング機能追加

### DIFF
--- a/simplelist.php
+++ b/simplelist.php
@@ -303,7 +303,8 @@ $use_listerdb = $listerdbenabled && listerdbfoundcheck($allrequest);
   <h2 class="page-title">再生曲リスト</h2>
   <div class="filter-bar">
     <span class="filter-icon">&#128269;</span>
-    <input type="text" id="filter-input" placeholder="曲名・作品名・歌った人などで絞り込み…" autocomplete="off">
+    <input type="text" id="filter-input" placeholder="曲名・作品名・歌った人などで絞り込み…" autocomplete="off"
+      value="<?= htmlspecialchars(trim($_GET['q'] ?? ''), ENT_QUOTES) ?>">
     <button type="button" class="filter-clear-btn" id="filter-clear">&#x2715;</button>
     <span class="filter-count" id="filter-count"></span>
   </div>
@@ -445,6 +446,11 @@ $use_listerdb = $listerdbenabled && listerdbfoundcheck($allrequest);
       $('#filter-clear').on('click', function() {
         $('#filter-input').val('').trigger('input').focus();
       });
+
+      // GETパラメータ ?q= による初期絞り込み
+      if ($('#filter-input').val() !== '') {
+        $('#filter-input').trigger('input');
+      }
     });
     </script>
   </body>


### PR DESCRIPTION
## 変更概要

`simplelist.php`（再生曲リスト）のデザインをPCとスマホの両方で見やすくなるよう刷新し、絞り込み検索機能を追加しました。

## 変更内容

### レスポンシブデザイン対応
- **PC（768px以上）**: ダークヘッダー付きのすっきりしたテーブル表示
- **スマホ（767px以下）**: 各行をカード形式で表示
  - 常時表示：番号・曲名・作品名
  - 「詳細を見る ▼」ボタンで歌手名・歌った人・コメントをアコーディオン展開

### リアルタイムフィルタリング
- テーブル上部に絞り込み検索バーを追加
- 曲名・作品名・歌手名・歌った人・コメントを横断検索
- 入力と同時にリアルタイムで絞り込み
- 件数表示・クリアボタン（×）・「該当なし」メッセージ

### GETパラメータ対応
- `simplelist.php?q=田中` のようなURLでアクセスすると、初期状態から絞り込みが適用される
- リンクや外部ページからの誘導に活用可能