### PR TITLE
リクエスト順番自動調整（ピッタリ移動）の抜本的な書き直しと小休止機能の改善

### DIFF
--- a/fortest/moveitemtest.php
+++ b/fortest/moveitemtest.php
@@ -4,34 +4,39 @@ require_once('../commonfunc.php');
 require_once('../function_moveitem.php');
 
 $list = new MoveItem;
+$list->getturnlist($db);
 
-$turnlist = $list->getturnlist($db);
-
-print "<pre>";
-print "turnlist:\n";
- var_dump($list->turnlist);
-print "</pre>";
-
-$id = 24;
-if(array_key_exists("id", $_REQUEST)) {
-    $id = $_REQUEST["id"];
+$id = 0;
+if (array_key_exists("id", $_REQUEST)) {
+    $id = (int)$_REQUEST["id"];
 }
 
+echo "<pre>\n=== 現在のターン構成 ===\n";
+foreach ($list->turnlist as $ti => $turn) {
+    echo "ターン[$ti]:\n";
+    foreach ($turn as $r) {
+        echo "  reqorder={$r['reqorder']} id={$r['id']} singer={$r['singer']} status={$r['nowplaying']}\n";
+    }
+}
+echo "</pre>\n";
 
+if ($id > 0) {
+    $newreq = $list->get_new_reqorder($id);
+    echo "<pre>id=$id の新しいreqorder: $newreq</pre>\n";
+    $list->insertreqorder($id, $newreq);
+    $list->save_allrequest($db);
 
-$newreq = $list->get_new_reqorder($id);
-print 'NewReqNo:'.$newreq.', id:'.$id."<br>\n";
-$list->insertreqorder($id,$newreq);
-
-print "<pre>";
-// var_dump($list->allrequest_new);
-print "</pre>";
-
-$list->save_allrequest($db);
-
-$turnlist = $list->getturnlist($db);
-print "<pre>";
-var_dump($list->turnlist);
-print "</pre>";
+    // 再読み込みして確認
+    $list2 = new MoveItem;
+    $list2->getturnlist($db);
+    echo "<pre>\n=== 移動後のターン構成 ===\n";
+    foreach ($list2->turnlist as $ti => $turn) {
+        echo "ターン[$ti]:\n";
+        foreach ($turn as $r) {
+            echo "  reqorder={$r['reqorder']} id={$r['id']} singer={$r['singer']} status={$r['nowplaying']}\n";
+        }
+    }
+    echo "</pre>\n";
+}
 
 ?>

--- a/function_moveitem.php
+++ b/function_moveitem.php
@@ -65,9 +65,11 @@ class MoveItem {
         $this->allrequest_new = $this->allrequest;
 
         $newsinger = null;
+        $newkind = null;
         foreach ($this->allrequest as $r) {
             if ($r['id'] == $newid) {
                 $newsinger = $r['singer'];
+                $newkind = $r['kind'];
                 break;
             }
         }
@@ -80,6 +82,18 @@ class MoveItem {
             if ($r['nowplaying'] !== '未再生') {
                 $played_max = max($played_max, $r['reqorder']);
             }
+        }
+
+        // 小休止は常に未再生の末尾へ
+        if ($newkind === '小休止') {
+            $last_req = $played_max;
+            foreach ($this->allrequest as $r) {
+                if ($r['id'] == $newid) continue;
+                if ($r['nowplaying'] === '未再生') {
+                    $last_req = max($last_req, $r['reqorder']);
+                }
+            }
+            return $last_req + 1;
         }
 
         // 小休止リセット: 未再生の小休止アイテムの最後のreqorderを境界にする

--- a/function_moveitem.php
+++ b/function_moveitem.php
@@ -1,6 +1,5 @@
 <?php
 
-
 function getallrequest_fromdb($db) {
     $sql = "SELECT * FROM requesttable ORDER BY reqorder ASC";
     $select = $db->query($sql);
@@ -9,453 +8,277 @@ function getallrequest_fromdb($db) {
     return $allrequest;
 }
 
-// 予約位置適切移動機能
-// 
+/*
+ * リクエスト順番自動調整クラス
+ *
+ * 仕様:
+ *  - 未再生アイテムのみ移動対象（再生中・再生済みより前には入らない）
+ *  - 1周目: 入れた順番（ターン[0]末尾に追加）
+ *  - 同一人物が2つ入れていても別の人は1周目扱い（ターン[0]末尾）
+ *  - 2周目以降: 1つ前の周と同じ順番
+ *  - 2周目以降の新規参加者: 未再生先頭へ
+ *  - reset_on_pause=true時: 最後の小休止以降を1周目扱いに
+ */
 class MoveItem {
-   // 周期リスト
-   // turn = array ( 'id1' => 'name1', 'id2' => 'name2', 'id3' => 'name3' ...);
-   // array_push(turnlist,turn);
-   public $turnlist = array();
-   public $allrequest = array();
-   public $allrequest_new = array();
-   public $max_reqorder = 0;
-   public $db = null;
-   
-   /* 各ターン一覧を作成。同じ人が次に現れたところで次のターンが始まるということにする */
-   public function getturnlist($db){
-       $this->db = $db;
-       $this->allrequest = getallrequest_fromdb($db);
-       $this->allrequest_new = $this->allrequest;
-       $this->recountreqorder();
-       $turnlist = array();
-       $oneturn = array();
-       foreach($this->allrequest_new as $value ){
-           if($this->max_reqorder < $value['reqorder'] ) $this->max_reqorder = $value['reqorder'] + 1;
-           if($this->check_exists_mymember($oneturn,$value['singer']) === true){
-             // goto next turn
-             array_push($turnlist,$oneturn);
-             $oneturn = array();
-           }
-           array_push($oneturn,$value);
-       }
-       if(count($oneturn) > 0 ){
-           array_push($turnlist,$oneturn);
-       }
-       $this->turnlist = $turnlist;
-   }
-   
-   /* そのIDの新しい再生順を返す */
-   public function get_new_reqorder($id,$notsingstart = 0){
-       $beforeturn = array();
-       $beforeturn_1 = array();
-       $newsinger = $this->get_singer_fromid($id);
-       if($newsinger === false) {
-           return false;
-       }
-       
-       // 1番最初のリクエスト
-       if(count($this->allrequest) == 0){
-           return 1;
-       }
-       //現在の再生中の順番を探す
-       $playingorder = false;
-       if(!empty ($this->db ) ) {
-       $this->allrequest = getallrequest_fromdb($this->db);
-       foreach ($this->allrequest as $onerequest ){
-           if($onerequest['nowplaying'] ==='再生中' ){
-               $playingorder = $onerequest['reqorder'];
-               break;
-           }
-           // 再生中がない場合、最初に見つかる未再生の項目にする
-           if($onerequest['nowplaying'] !=='未再生' ){
-               $playingorder = $onerequest['reqorder'];
-               break;
-           }
-       }
-       }
-       
-/**** 作りかけの新しい処理      
-       $currentturn = $this->get_insert_turn($this->turnlist,$newsinger,$id);
-       $beforesinger = array(); //前のターンリスト
-       $findmynameflg = false;
-       // 1つ前のターンで自分より前の人の名前のリストを取得
-       if($currentturn > 0 ){
-           foreach( $this->turnlist[$currentturn-1] as $b_onerequest ){
-               if($b_onerequest['singer'] === $newsinger ){
-                 // 自分の名前が見つかる以降リストアップ
-                 $findmynameflg = true;
-               }else{
-                 if($findmynameflg === false) 
-                 array_push($beforesinger,$b_onerequest);
-               }
-           }
-       }
-       // 最初のターン(前のターンがない)→現ターンの一番後ろに追加
-       if(count($beforesinger) == 0){
-           $turnlast = end($this->turnlist[$currentturn]);
-           reset($this->turnlist[$currentturn]);
-           return $turnlast['reqorder'] + 1;
-       }
-       
-       //array_unshift($beforesinger,
-       
-       $insertreqest_key = false;
-       // 前ターンリスト最優先から順番にチェック
-       foreach ($beforesinger as $beforeorder){
-           //今ターンの中をチェック
-           foreach( $this->turnlist[$currentturn] as $key => $onerequest){
-               // 名前が見つかる
-               if($onerequest['singer'] === $beforeorder['singer']){
-                  $insertreqest_key = $key;
-                  break;
-               }
-           }
-           if($insertreqest_key !== false ) break;
-       }
+    public $turnlist = array();
+    public $allrequest = array();
+    public $allrequest_new = array();
+    public $max_reqorder = 0;
+    public $db = null;
+    private $reset_on_pause = false;
 
-       print '<pre>';
-       var_dump($beforesinger );
-       print 'insertreqest_key'.$insertreqest_key;
-       print '</pre>';
+    public function getturnlist($db) {
+        $this->db = $db;
+        global $config_ini;
+        if (array_key_exists('request_automove_reset', $config_ini)) {
+            $this->reset_on_pause = ($config_ini['request_automove_reset'] == 1);
+        }
+        $this->allrequest = getallrequest_fromdb($db);
+        $this->allrequest_new = $this->allrequest;
+        $this->_rebuild_turnlist();
+    }
 
-       //もし見つからなかったら、今ターンの最初
-       if($insertreqest_key === false ){
-         $insertreqest_key = 0;
-       }
+    private function _rebuild_turnlist() {
+        $this->turnlist = array();
+        $this->max_reqorder = 0;
+        $cur_turn = array();
+        $cur_singers = array();
+        foreach ($this->allrequest_new as $r) {
+            if ($this->max_reqorder < $r['reqorder']) {
+                $this->max_reqorder = $r['reqorder'];
+            }
+            if (in_array($r['singer'], $cur_singers)) {
+                $this->turnlist[] = $cur_turn;
+                $cur_turn = array();
+                $cur_singers = array();
+            }
+            $cur_turn[] = $r;
+            $cur_singers[] = $r['singer'];
+        }
+        if (!empty($cur_turn)) {
+            $this->turnlist[] = $cur_turn;
+        }
+    }
 
-       print '<pre>';
-        print 'insertreqest_key'.$insertreqest_key;
-        print '</pre>';
-   
-       //挿入した場所が未再生でなかったら後ろにずらす
-       foreach( $this->turnlist[$currentturn] as $key => $onerequest){
+    public function get_new_reqorder($newid) {
+        $this->allrequest = getallrequest_fromdb($this->db);
+        $this->allrequest_new = $this->allrequest;
 
-       print '<pre>';
-       var_dump($onerequest );
-        print '</pre>';
+        $newsinger = null;
+        foreach ($this->allrequest as $r) {
+            if ($r['id'] == $newid) {
+                $newsinger = $r['singer'];
+                break;
+            }
+        }
+        if ($newsinger === null) return false;
 
-         if($key < $insertreqest_key ) continue;
-         $neworder = $onerequest['reqorder'] ;
-         if($onerequest['nowplaying'] ==='未再生' ){
-            break;
-         }
-       }
-       
-       return $neworder;
-       
-****/  
-       $beforeturn = array();
-       $beforeturn_1 = array();
-       $beforeturn_2 = array();
-       ///以下古い処理
-       // 今まで自分の名前の入った一番新しいリクエストのorder番号を探す
-       $maxmyorder = $this->get_max_reqorder_from_name($newsinger,$id);
-       
-       foreach($this->turnlist as $turnkey => $oneturn){
-       //print "<pre> dump oneturn\n";
-       //    var_dump($oneturn);
-       //print "</pre>";
-           // 1番最初のリクエスト
-           //print "ターンに入ります<br>\n";
-           if(count($oneturn) == 0){
-              //print "このターンは0でした<br>\n";
-              return 1;
-           }
-           $beforeturn_2 = $beforeturn_1;
-           $beforeturn_1 = $beforeturn;
-           $beforeturn = $oneturn;
-           // 自分の最新リクエストより前 -> 次のターン
-           if(count($oneturn) > 0 ){
-             if(array_key_exists('reqorder', $oneturn[0]) ){
-               // print '$oneturn[0][reqorder]:'.$oneturn[0]['reqorder'].'$maxmyorder:'.$maxmyorder.'<br>';
-               if($oneturn[0]['reqorder'] < $maxmyorder) continue;
-             }
-           }
-           
+        // 再生済み・再生中の最大reqorder（この位置より前には挿入不可）
+        $played_max = 0;
+        foreach ($this->allrequest as $r) {
+            if ($r['id'] == $newid) continue;
+            if ($r['nowplaying'] !== '未再生') {
+                $played_max = max($played_max, $r['reqorder']);
+            }
+        }
 
-           // 未再生の場所を探す
-           $startcheck = false;
-           foreach($oneturn as $onerequest){
-               if($onerequest['nowplaying'] == '未再生' ){
-                   $startcheck = true;
-                   // print "このターンに未再生がありました".$onerequest['reqorder']." <br>\n";
-                   break;
-               }
-           }
-           // 現在のターンに1つも未再生がない → 次のターンへ
-           if($startcheck == false) {
-               continue;
-           }
-           // 現在のターンに名前がある → 次のターンへ
-           if($this->check_exists_mymember($oneturn,$newsinger,$id) === true){
-               // print "このターンに自分の名前がありました".$newsinger." <br>\n";
-               // var_dump($oneturn);
-               // print " <br>\n";
-               continue;
-           }
-           // 1つ前のターンの順番に従いreqorderを決める
+        // 小休止リセット: 未再生の小休止アイテムの最後のreqorderを境界にする
+        $pause_boundary = 0;
+        if ($this->reset_on_pause) {
+            foreach ($this->allrequest as $r) {
+                if ($r['id'] == $newid) continue;
+                if ($r['nowplaying'] === '未再生' && $r['kind'] === '小休止') {
+                    $pause_boundary = max($pause_boundary, $r['reqorder']);
+                }
+            }
+        }
 
-           // 1つ前のターンで自分より前の人の名前のリストを取得
-           $mynamefound = false;
-           $beforesinger = array(); 
-/**
-       print "<pre>\n-------- beforeturn_1 list:\n";
-       var_dump($beforeturn_1);print "</pre>";
-           if(!empty($beforeturn_1)){
-               foreach( ($beforeturn_1) as $b_onerequest ){
-                print $b_onerequest['songfile'].$b_onerequest['singer'].$newsinger."<br>\n";
-                   if($mynamefound === false) {
-                       if($b_onerequest['singer'] === $newsinger ){
-                           $mynamefound = false;
-                           //array_push($beforesinger,$b_onerequest);
-                           continue;
-                       }else{
-                           // print $b_onerequest['singer'].$newsinger."<br>\n";
-                           array_push($beforesinger,$b_onerequest);
-                       }
-                   }else {
-                       //array_push($beforesinger,$b_onerequest);
-                   }
-               }
-           }
-**/
-// var_dump($beforeturn_1);
-           if( $turnkey > 0 ) {
-           //  for( $i = $turnkey - 1 ; $i >= 0 ; $i-- ){
-               foreach( ($this->turnlist[$turnkey - 1]) as $b_onerequest ){
-               // print $b_onerequest['songfile'].$b_onerequest['singer'].$newsinger."<br>\n";
-                   if($mynamefound === false) {
-                       if($b_onerequest['singer'] === $newsinger ){
-                           $mynamefound = true;
-                           //array_push($beforesinger,$b_onerequest);
-                           continue;
-                       }else{
-                           // print $b_onerequest['singer'].$newsinger."<br>\n";
-                           array_push($beforesinger,$b_onerequest);
-                       }
-                   }else {
-                       //array_push($beforesinger,$b_onerequest);
-                   }
-               }
-           //  }
-           }
-           if($mynamefound === false) {
-               $beforesinger = null;
-           }
-           // とりあえず現ターンの未再生の中の最後の順番にしておく
-           $newreqorder = false;
-           if(empty($this->turnlist[$turnkey - 1])){
-               $newreqorder = $oneturn[count($oneturn)-1]['reqorder']+1;
-               //print 'now set'.$newreqorder;
-           }else{
-           print '<pre>';
-           var_dump($oneturn);
-           print '</pre>';
-           for($i = 0 ; $i < count($oneturn) ; $i++){
-             // print  $oneturn[$i]['id'].$oneturn[$i]['reqorder'].'<br>';
-               if($oneturn[$i]['nowplaying'] == '未再生' ){
-                   $newreqorder = $oneturn[$i]['reqorder'];
-                   // print 'now set'.$newreqorder;
-                   break;
-               }
-           }
-           }
-           if($newreqorder === false) break;
-           // print " $newreqorder";
-//           print "<pre>\n-------- before singer list:\n";
-//           var_dump($beforesinger);print "</pre>";
-//           print "<pre>\n-------- oneturn list:\n";
-//           var_dump($oneturn);print "</pre>";
-           if(!empty($beforesinger)){
-               // 前ターンの自分の前の人がいたらその人の次にする
-               $cheekedreqorder= $oneturn[count($oneturn)-1]['reqorder']+1;;
-               foreach( $oneturn as $onerequest){
-                 if($onerequest['nowplaying']==='未再生'){
-                     $cheekedreqorder= $onerequest['reqorder'];
-                     break;
-                 }
-               }
-               $setvalue = false;
-               // 差し込むべきIDを探す。
-               $insertid = null;
-               foreach( array_reverse ($oneturn) as $key => $onerequest){
-                   $cheekedreqorder = $onerequest['reqorder'] + 1;
-                   foreach (($beforesinger) as $beforeorder){
-                       // print $cheekedreqorder.'onerequest:'.$onerequest['singer'].$onerequest['reqorder'].' beforeorder:'.$beforeorder['singer'].$beforeorder['reqorder']."<br>\n";
-                       if($onerequest['singer'] == $beforeorder['singer']){
-                           if( $cheekedreqorder == $onerequest['reqorder']){
-                               $newreqorder = $cheekedreqorder + 1 ;
-                           }else {
-                               $newreqorder = $cheekedreqorder ;
-                           }
-                           
-                           // 再生中or再生済みチェック
-                           for($i=$key ;$i<count($oneturn); $i++){
-                          // print "<pre>".$newreqorder;var_dump($oneturn[$i]);print "</pre>";
-                             if(array_key_exists($i,$oneturn) && $oneturn[$i]['nowplaying'] !=='未再生' ){
-                                   if($newreqorder <= $oneturn[$i]['reqorder']){
-                            //   print "<pre>".$newreqorder;print $oneturn[$i]['reqorder'];print "</pre>";
-                                       $newreqorder = $oneturn[$i]['reqorder'] + 1;
-                                   }
-                             }
-                           }
-                          //  print "reqorderを".$newreqorder.'にしました';
-                           $setvalue = true;
-                           break;
-                       }
-                       
-                       //print $cheekedreqorder;
-                   }
-                   // print $oneturn[0]['reqorder'];
-                   if($setvalue === true){
-                       break;
-                   }
-                   if($onerequest['nowplaying']==='未再生'){
-                       $cheekedreqorder=$onerequest['reqorder'] ;
-                   }
-               }
-           }else{
-             // 最初のターンの場合そのターンの一番後ろにする
-             if($newreqorder == 1 ){
-               // print "ターンの一番後ろにしました";
-               // そのターンの先頭にするときはコメントアウト
-               $newreqorder = $oneturn[count($oneturn)-1]['reqorder']+1;
-             }else {
-                        $newreqorder = $newreqorder;
-             }
-             
-           }
-           // 再生中より下にないかチェック
-           if( $playingorder !== false ){
-              if( $playingorder > $newreqorder ) {
-                  return ($playingorder + 1);
-              }
-           }
-           return $newreqorder;
-       }
-       // print "come max_reqorder".$this->max_reqorder;
-       return $this->max_reqorder + 1;
-   }
+        $scope_start = max($played_max, $pause_boundary);
 
+        // contextアイテム: scope_startより後の全アイテム（新アイテム・小休止除外）
+        $context = array();
+        foreach ($this->allrequest as $r) {
+            if ($r['id'] == $newid) continue;
+            if ($r['reqorder'] <= $scope_start) continue;
+            if ($r['kind'] === '小休止') continue;
+            $context[] = $r;
+        }
 
-   
-   //ターン一覧から、挿入すべきターン番号を返す 
-   public function get_insert_turn($turnlist,$newsinger,$id){
-       foreach($turnlist as $turnkey => $oneturn){
-           foreach($oneturn as $onerequest){
-               if($onerequest['nowplaying'] == '未再生' ){
-                   // print "このターンに未再生がありました".$onerequest['reqorder']." <br>\n";
-                   // このターンに自分の名前があるかどうかのチェック
-                   // 現在のターンに名前がある → 次のターンへ
-                   if($this->check_exists_mymember($oneturn,$newsinger,$id) === true){
-                     continue;
-                   }                   
-                   return $turnkey;
-                   break;
-               }
-           }
-       }
-       return false;
-   }
-   
-   public function get_singer_fromid($id){
-       foreach($this->allrequest_new as $value ){
-           //print $value['id'].':'.$id."\n";
-           if($value['id'] == $id){
-               return $value['singer'];
-           }
-       }
-       return false;
-   }
-   
-   public function recountreqorder(){
-       $currentreqorder = 1;
-       for($i=0;$i < count($this->allrequest_new) ; $i++){
-           $this->allrequest_new[$i]['reqorder']= $currentreqorder;
-           $currentreqorder ++;
-       }
-   }
-   
-   public function insertreqorder($id,$reqorder){
-       $currentreqorder = 1;
-       for($i=0;$i < count($this->allrequest_new) ; $i++){
-           if($this->allrequest_new[$i]['id'] == $id ){
-       // print $this->allrequest_new[$i]['id'].':'.$id.':'.$reqorder."<br />";;
-               $this->allrequest_new[$i]['reqorder'] = $reqorder;
-               continue;
-           }
-           if($currentreqorder == $reqorder) {
-               $currentreqorder ++;
-           }else if($this->allrequest_new[$i]['reqorder'] == $reqorder){
-               $currentreqorder ++;
-           }
-           $this->allrequest_new[$i]['reqorder']= $currentreqorder;
-           $currentreqorder ++;
-       }
-       
-   }
-   
-   public function save_allrequest($db){
-       foreach($this->allrequest as $key => $row ){
-           $idlist[$key] = $row['id'];
-       }
-       array_multisort($idlist, SORT_ASC, $this->allrequest);
-       
-       // table drop
-       for($i=0;$i<count($this->allrequest_new);$i++){
-          if($this->allrequest_new[$i]['reqorder'] !== $this->allrequest[$i]['reqorder']){
-              $sql = 'UPDATE requesttable set reqorder="'.$this->allrequest_new[$i]['reqorder'].'" where id = "'.$this->allrequest_new[$i]['id'].'"';
-              //print $sql."<br />\n";
-              $count = $db->exec($sql);
-              if($count !== 1) {
-               //   print "reqorderを$count 件修正しました。".$this->allrequest[$i]['reqorder'].' to '.$this->allrequest_new[$i]['reqorder']."\n";
-               }
-          }
-       }
-   }
-   
+        if (empty($context)) {
+            return $scope_start + 1;
+        }
 
+        // contextからターン構築（同じ歌い手が再登場 → 次のターン開始）
+        $turns = array();
+        $cur_turn = array();
+        $cur_singers = array();
+        foreach ($context as $r) {
+            if (in_array($r['singer'], $cur_singers)) {
+                $turns[] = $cur_turn;
+                $cur_turn = array();
+                $cur_singers = array();
+            }
+            $cur_turn[] = $r;
+            $cur_singers[] = $r['singer'];
+        }
+        if (!empty($cur_turn)) {
+            $turns[] = $cur_turn;
+        }
 
-   public function addrequest_andsetreqorder($id){
-       $allrequest = getallrequest_fromdb($db);
-       $reqorderlist = array();
-       foreach($allrequest as $value ){
-           array_push($reqorderlist,array( $value['reqorder'] => $value['id']) );
-       }
-       return $reqorderlist;
-   }
-   
-   public function get_current_reqorderlist($db){
-       
-   }
-   
-   /* ターンの中に$singer で与えられた名前があるかどうか。$idを指定するとそのIDは除外する */
-   public function check_exists_mymember($oneturn,$singer,$id='none'){
-       foreach($oneturn as $value){
-           //print "check_exists_mymember :".$value['singer'].':'.$singer."<br>\n";
-           if($value['id'] == $id) continue;
-           if($value['singer'] === $singer){
-               // exists same turn
-               return true;
-           }
-       }
-       return false;
-   }
-   
-   /* $singerのリクエストした一番新しいreqourderを探す */
-   /* $woid : 対象としないid値  */
-   /* -1 : user not found  */
-   public function get_max_reqorder_from_name($newsinger,$woid) {
-       $maxreqorder = -1;
-       foreach($this->allrequest as $key => $row ){
-           if($row['id'] == $woid ) continue;
-           if($row['singer'] === $newsinger ) {
-               // print $newsinger . ' as '. $row['reqorder'] .'<br>';
-               $maxreqorder = max ( $maxreqorder , $row['reqorder'] );
-           }
-       }
-       return $maxreqorder;
-   }
+        // 挿入ターン: 新歌い手を含まない最初のターン
+        $target_idx = count($turns);
+        foreach ($turns as $idx => $turn) {
+            $has = false;
+            foreach ($turn as $r) {
+                if ($r['singer'] === $newsinger) { $has = true; break; }
+            }
+            if (!$has) {
+                $target_idx = $idx;
+                break;
+            }
+        }
+
+        // 全ターンに既に存在 → 末尾に追加
+        if ($target_idx >= count($turns)) {
+            $last = end($context);
+            reset($context);
+            return $last['reqorder'] + 1;
+        }
+
+        $target_turn = $turns[$target_idx];
+
+        if ($target_idx == 0) {
+            // 新歌い手（どのターンにも存在しない）
+            // rule5 vs rule2/3の判定: turn[0]に「常連」がいるか
+            // 常連 = contextの外（再生済み等）で同じ歌い手がいる
+            // ただしreset_on_pause=trueの場合は常に1周目扱い
+            if (!$this->reset_on_pause && $this->_turn_has_veteran($turns[0])) {
+                // rule5: 2周目以降の新規参加者 → 未再生先頭へ
+                return $this->_first_unplayed_reqorder($context);
+            }
+            // rule2/3: 1周目 → ターン[0]末尾へ
+            return $this->_end_of_turn_unplayed_reqorder($target_turn) + 1;
+        }
+
+        // target_idx >= 1: rule4 - 1つ前のターンと同じ順番
+        $prev_turn = $turns[$target_idx - 1];
+
+        // 前ターンで自分より後にいる歌い手リスト
+        $after_singers = array();
+        $found_self = false;
+        foreach ($prev_turn as $r) {
+            if ($r['singer'] === $newsinger) {
+                $found_self = true;
+                continue;
+            }
+            if ($found_self) {
+                $after_singers[] = $r['singer'];
+            }
+        }
+
+        // 挿入ターンの未再生アイテムで、最初に「後の人」が見つかった位置に挿入
+        foreach ($target_turn as $r) {
+            if ($r['nowplaying'] !== '未再生') continue;
+            if (in_array($r['singer'], $after_singers)) {
+                return $r['reqorder'];
+            }
+        }
+
+        // 「後の人」が見つからなければターン末尾
+        return $this->_end_of_turn_unplayed_reqorder($target_turn) + 1;
+    }
+
+    // turn内の歌い手がcontextの外（再生済み等）に存在するか判定
+    private function _turn_has_veteran($turn) {
+        foreach ($turn as $t) {
+            foreach ($this->allrequest as $r) {
+                if ($r['singer'] === $t['singer'] && $r['nowplaying'] !== '未再生') {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    // context内の最初の未再生アイテムのreqorderを返す
+    private function _first_unplayed_reqorder($context) {
+        foreach ($context as $r) {
+            if ($r['nowplaying'] === '未再生') {
+                return $r['reqorder'];
+            }
+        }
+        $last = end($context);
+        reset($context);
+        return $last['reqorder'] + 1;
+    }
+
+    // ターン内の最後の未再生アイテムのreqorderを返す（なければ最後のアイテム）
+    private function _end_of_turn_unplayed_reqorder($turn) {
+        $last_unplayed = -1;
+        $last_any = -1;
+        foreach ($turn as $r) {
+            if ($r['reqorder'] > $last_any) $last_any = $r['reqorder'];
+            if ($r['nowplaying'] === '未再生' && $r['reqorder'] > $last_unplayed) {
+                $last_unplayed = $r['reqorder'];
+            }
+        }
+        return ($last_unplayed >= 0) ? $last_unplayed : $last_any;
+    }
+
+    public function insertreqorder($id, $reqorder) {
+        $currentreqorder = 1;
+        for ($i = 0; $i < count($this->allrequest_new); $i++) {
+            if ($this->allrequest_new[$i]['id'] == $id) {
+                $this->allrequest_new[$i]['reqorder'] = $reqorder;
+                continue;
+            }
+            if ($currentreqorder == $reqorder) {
+                $currentreqorder++;
+            } elseif ($this->allrequest_new[$i]['reqorder'] == $reqorder) {
+                $currentreqorder++;
+            }
+            $this->allrequest_new[$i]['reqorder'] = $currentreqorder;
+            $currentreqorder++;
+        }
+    }
+
+    public function save_allrequest($db) {
+        $old_orders = array();
+        foreach ($this->allrequest as $r) {
+            $old_orders[$r['id']] = $r['reqorder'];
+        }
+        foreach ($this->allrequest_new as $r) {
+            $id = (int)$r['id'];
+            $new_req = (int)$r['reqorder'];
+            if (!array_key_exists($id, $old_orders) || $old_orders[$id] !== $new_req) {
+                $db->exec('UPDATE requesttable SET reqorder=' . $new_req . ' WHERE id=' . $id);
+            }
+        }
+    }
+
+    // 互換性のために残す
+    public function check_exists_mymember($oneturn, $singer, $id = 'none') {
+        foreach ($oneturn as $value) {
+            if ($value['id'] == $id) continue;
+            if ($value['singer'] === $singer) return true;
+        }
+        return false;
+    }
+
+    public function get_singer_fromid($id) {
+        foreach ($this->allrequest_new as $value) {
+            if ($value['id'] == $id) return $value['singer'];
+        }
+        return false;
+    }
+
+    public function recountreqorder() {
+        $currentreqorder = 1;
+        for ($i = 0; $i < count($this->allrequest_new); $i++) {
+            $this->allrequest_new[$i]['reqorder'] = $currentreqorder;
+            $currentreqorder++;
+        }
+    }
 }
 
 ?>

--- a/init.php
+++ b/init.php
@@ -957,6 +957,16 @@ if(!array_key_exists('searchitem_o', $config_ini )){
       <input type="radio" name="useuserpause" value="2" <?php print (!$useuserpause)?'checked':' ' ?> /> 使用しない
     </label>
   </div>
+  <div class="form-group">
+    <h4>小休止リクエスト時のファイル名初期値</h4>
+    <input type="text" name="pause_default_filename" class="form-control"
+      value="<?php echo htmlspecialchars(urldecode($config_ini['pause_default_filename']), ENT_QUOTES, 'UTF-8'); ?>" />
+  </div>
+  <div class="form-group">
+    <h4>小休止リクエスト時のコメント初期値</h4>
+    <input type="text" name="pause_default_comment" class="form-control"
+      value="<?php echo htmlspecialchars(urldecode($config_ini['pause_default_comment']), ENT_QUOTES, 'UTF-8'); ?>" />
+  </div>
 
 
   <div class="form-group ">

--- a/kara_config.php
+++ b/kara_config.php
@@ -89,7 +89,13 @@ function readconfig_array()
     }
     if(!array_key_exists("nonameusername", $config_ini)){
         $nonameusername = "名無しさん";
-        $config_ini = array_merge($config_ini,array("nonameusername" => urlencode($nonameusername)));            
+        $config_ini = array_merge($config_ini,array("nonameusername" => urlencode($nonameusername)));
+    }
+    if(!array_key_exists("pause_default_filename", $config_ini)){
+        $config_ini = array_merge($config_ini,array("pause_default_filename" => ""));
+    }
+    if(!array_key_exists("pause_default_comment", $config_ini)){
+        $config_ini = array_merge($config_ini,array("pause_default_comment" => ""));
     }
 
     if(!array_key_exists("roomurl", $config_ini)){

--- a/request_confirm.php
+++ b/request_confirm.php
@@ -329,6 +329,12 @@ foreach($singerlist as $singer)
           print " selected ";
           $selectedcounter = $selectedcounter + 1;
       }
+  } else if(is_numeric($selectid) && !empty($selectrequest)) {
+      // 差し替えモード: 元のリクエスト者を優先
+      if($singer === $beforesinger && $selectedcounter === 0) {
+          print " selected ";
+          $selectedcounter = $selectedcounter + 1;
+      }
   } else if($blank_username){
   } else if(!empty($YkariUsername)){
       if($singer === $YkariUsername){

--- a/request_confirm.php
+++ b/request_confirm.php
@@ -323,13 +323,19 @@ foreach($singerlist as $singer)
   print "<option value=\"";
   print htmlspecialchars($singer, ENT_QUOTES, 'UTF-8');
   print "\"";
-  if($blank_username){
-  }else if(!empty($YkariUsername)){
+  if($set_pause) {
+      // 小休止モード: 「小休止」のみ選択
+      if($singer === '小休止') {
+          print " selected ";
+          $selectedcounter = $selectedcounter + 1;
+      }
+  } else if($blank_username){
+  } else if(!empty($YkariUsername)){
       if($singer === $YkariUsername){
          print " selected ";
          $selectedcounter = $selectedcounter + 1 ;
       }
-  }else if( selectedcheck_rc($allrequest,$singer,$beforesinger) && $selectedcounter === 0 ) 
+  } else if( selectedcheck_rc($allrequest,$singer,$beforesinger) && $selectedcounter === 0 )
   {
       print " selected ";
       $selectedcounter = $selectedcounter + 1 ;
@@ -342,7 +348,8 @@ foreach($singerlist as $singer)
   }
 }
 if($set_pause && $pausecount == 0) {
-print '<option value="小休止">小休止</option>';
+print '<option value="小休止" selected>小休止</option>';
+$selectedcounter = $selectedcounter + 1;
 }
 
 ?>

--- a/request_confirm.php
+++ b/request_confirm.php
@@ -276,10 +276,10 @@ if(is_numeric($selectid) && !empty($selectrequest) && $selectrequest[0]['kind'] 
     echo "</textarea> ";
 }else if($set_pause == 1 ){
     print 'placeholder="小休止時のリストに表示するメッセージ" >';
-    if (empty($filename)){
-      echo "";
-    }else{
+    if (!empty($filename)){
       echo htmlspecialchars($filename, ENT_QUOTES, 'UTF-8');
+    }else if(!empty($config_ini['pause_default_filename'])){
+      echo htmlspecialchars(urldecode($config_ini['pause_default_filename']), ENT_QUOTES, 'UTF-8');
     }
     echo "</textarea> ";
 }else {
@@ -379,7 +379,9 @@ print('<span style="visibility:hidden;">');
 <textarea name="comment" id="comment" class="form-control" rows="4" wrap="soft" placeholder="<?php print htmlspecialchars($requestcomment);?>" style="width:100%" >
 <?php
 if(is_numeric($selectid) && !empty($selectrequest) ){
-print htmlspecialchars($selectrequest[0]['comment']);
+    print htmlspecialchars($selectrequest[0]['comment']);
+}else if($set_pause == 1 && !empty($config_ini['pause_default_comment'])){
+    print htmlspecialchars(urldecode($config_ini['pause_default_comment']), ENT_QUOTES, 'UTF-8');
 }
 ?>
 </textarea>


### PR DESCRIPTION
## 概要

`function_moveitem.php`（リクエスト時_順番ピッタリ移動）のアルゴリズムを抜本的に書き直し、小休止関連の機能を複数追加・改善しました。

## 変更内容

### function_moveitem.php — アルゴリズム全面書き直し

古いコード（作りかけのコメントアウト・デバッグ用 `print` 混在）を廃棄し、「contextベース」の明確なアルゴリズムに刷新しました。

**実装した仕様:**

- 順番の入れ替えは未再生アイテムのみ（再生中・再生済みより前には入らない）
- **1周目**: 入れた順番（ターン[0]の末尾に追加）
- 同じ人が2つ入れていても、別の人のリクエストは1周目扱いでターン[0]末尾へ
- **2周目以降**: 1つ前の周と同じ順番（rule4）
- **2周目以降の新規参加者**: 未再生の先頭へ（rule5）
- **ピッタリ移動_小休止時リセット**が有効な場合: 最後の小休止以降を1周目扱い
- **小休止リクエストは常に未再生の末尾**に配置

あわせて `save_allrequest` のid照合バグ（並び順が異なる配列を添字で比較していた）も修正しました。

### request_confirm.php — 複数の改善

| 変更 | 内容 |
|---|---|
| 小休止時のリクエスト者初期値 | `pause=1` のとき、リクエスト者ドロップダウンを常に「小休止」に初期選択 |
| 差し替え時のリクエスト者初期値 | `selectid` が渡された場合（曲差し替え）、差し替え前のリクエスト者を初期選択（Cookie より優先） |
| 小休止時のファイル名初期値 | 設定値 `pause_default_filename` をフォームの初期値として表示 |
| 小休止時のコメント初期値 | 設定値 `pause_default_comment` をフォームの初期値として表示 |

### init.php — 小休止設定項目の追加

小休止設定セクションに以下の2項目を追加:
- 小休止リクエスト時のファイル名初期値
- 小休止リクエスト時のコメント初期値

### kara_config.php — デフォルト値の追加

- `pause_default_filename`（デフォルト: 空文字）
- `pause_default_comment`（デフォルト: 空文字）

## テスト方法

- `fortest/moveitemtest.php?id=<新アイテムのID>` でターン構成と移動結果を確認できます
- 設定画面（init.php）の「小休止」セクションからファイル名・コメントの初期値を設定し、`request_confirm.php?pause=1` で反映されることを確認してください