### PR TITLE
スワイプ操作対応リクエスト一覧UI (requestlist_swipe.php)

### DIFF
--- a/changeplaystatus.php
+++ b/changeplaystatus.php
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<META http-equiv="refresh" content="1; url=requestlist_only.php">
+<META http-equiv="refresh" content="1; url=requestlist_top.php">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <!-- Bootstrap -->

--- a/commentedit.php
+++ b/commentedit.php
@@ -84,7 +84,7 @@ $db = null;
 
 print_meta_header();
 if($addcommentsuccessflg == 1){
-  print '<META http-equiv="refresh" content="1; url=requestlist_only.php">';
+  print '<META http-equiv="refresh" content="1; url=requestlist_top.php">';
 }
 ?>
 <link type="text/css" rel="stylesheet" href="css/style.css" />

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1199,16 +1199,12 @@ EOD;
 
 
 
-    $requestlist_page = 'requestlist_only.php';
-    if(array_key_exists('usenewrequestlist', $config_ini) && $config_ini['usenewrequestlist'] == 1){
-        $requestlist_page = 'requestlist_swipe.php';
-    }
     print '     <li ';
-    if($page == 'requestlist_only.php' || $page == 'requestlist_swipe.php')
+    if($page == 'requestlist_only.php' || $page == 'requestlist_swipe.php' || $page == 'requestlist_top.php')
     {
         print 'class="active" ';
     }
-    print '><a href="'.$prefix.$requestlist_page.'">予約一覧 </a></li>';
+    print '><a href="'.$prefix.'requestlist_top.php">予約一覧 </a></li>';
 //    print '     <li ';
     print '     <li class="dropdown "';
     if($page == 'searchreserve.php')

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1199,12 +1199,16 @@ EOD;
 
 
 
+    $requestlist_page = 'requestlist_only.php';
+    if(array_key_exists('usenewrequestlist', $config_ini) && $config_ini['usenewrequestlist'] == 1){
+        $requestlist_page = 'requestlist_swipe.php';
+    }
     print '     <li ';
-    if($page == 'requestlist_only.php')
+    if($page == 'requestlist_only.php' || $page == 'requestlist_swipe.php')
     {
         print 'class="active" ';
     }
-    print '><a href="'.$prefix.'requestlist_only.php">予約一覧 </a></li>';
+    print '><a href="'.$prefix.$requestlist_page.'">予約一覧 </a></li>';
 //    print '     <li ';
     print '     <li class="dropdown "';
     if($page == 'searchreserve.php')

--- a/delete.php
+++ b/delete.php
@@ -1,7 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 
-<META http-equiv="refresh" content="1; url=requestlist_only.php">
+<META http-equiv="refresh" content="1; url=requestlist_top.php">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <!-- Bootstrap -->

--- a/edit_priority.php
+++ b/edit_priority.php
@@ -110,7 +110,7 @@ $(function(priority_list) { $("#priority_list").dataTable({
 <p>
 <a href="init.php" >設定画面に戻る </a>
 &nbsp; 
-<a href="requestlist_only.php" >トップに戻る </a>
+<a href="requestlist_top.php" >トップに戻る </a>
 </p>
 </body>
 </html>

--- a/edit_search_sort_priority.php
+++ b/edit_search_sort_priority.php
@@ -314,7 +314,7 @@ $priorities = load_sort_priorities($priority_file);
   <p>
     <a href="init.php" class="btn btn-default">設定画面に戻る</a>
     &nbsp;
-    <a href="requestlist_only.php" class="btn btn-default">トップに戻る</a>
+    <a href="requestlist_top.php" class="btn btn-default">トップに戻る</a>
   </p>
 </div>
 </body>

--- a/exec.php
+++ b/exec.php
@@ -243,7 +243,7 @@ if(isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUE
    print<<<EOT
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<META http-equiv="refresh" content="1; url=requestlist_only.php" />
+<META http-equiv="refresh" content="1; url=requestlist_top.php" />
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>DB登録中</title>
 </head>
@@ -254,7 +254,7 @@ EOT;
    print<<<EOT
 </pre>
 
-<a href="requestlist_only.php" > リクエストページに戻る <a><br>
+<a href="requestlist_top.php" > リクエストページに戻る <a><br>
 EOT;
     $sql = "SELECT * FROM requesttable ORDER BY id DESC";
     if(!empty($DEBUG)){

--- a/exec.php
+++ b/exec.php
@@ -243,7 +243,7 @@ if(isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUE
    print<<<EOT
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<META http-equiv="refresh" content="1; url=requestlist_top.php" />
+<META http-equiv="refresh" content="1; url=requestlist_top.php?showid=<?php echo (int)$newid; ?>" />
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>DB登録中</title>
 </head>

--- a/exec.php
+++ b/exec.php
@@ -243,7 +243,7 @@ if(isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUE
    print<<<EOT
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<META http-equiv="refresh" content="1; url=requestlist_top.php?showid=<?php echo (int)$newid; ?>" />
+<META http-equiv="refresh" content="1; url=requestlist_top.php?showid=$newid" />
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>DB登録中</title>
 </head>

--- a/index.php
+++ b/index.php
@@ -1,11 +1,5 @@
 <?php
-$configfile = 'config.ini';
-$config = file_exists($configfile) ? parse_ini_file($configfile) : [];
-
-$locationurl = (isset($config['usenewrequestlist']) && $config['usenewrequestlist'] == '1')
-    ? 'requestlist_swipe.php'
-    : 'requestlist_only.php';
-
+$locationurl = 'requestlist_top.php';
 if (array_key_exists("easypass", $_REQUEST)) {
     $locationurl .= '?easypass=' . urlencode($_REQUEST["easypass"]);
 }

--- a/index.php
+++ b/index.php
@@ -1,10 +1,14 @@
 <?php
-$password = false;
-$locationurl='requestlist_only.php';
-if(array_key_exists("easypass", $_REQUEST)){
-    $password = $_REQUEST["easypass"];
-    $locationurl = $locationurl.'?easypass='.$password;
+$configfile = 'config.ini';
+$config = file_exists($configfile) ? parse_ini_file($configfile) : [];
+
+$locationurl = (isset($config['usenewrequestlist']) && $config['usenewrequestlist'] == '1')
+    ? 'requestlist_swipe.php'
+    : 'requestlist_only.php';
+
+if (array_key_exists("easypass", $_REQUEST)) {
+    $locationurl .= '?easypass=' . urlencode($_REQUEST["easypass"]);
 }
- header('location: '.$locationurl);
- exit();
+header('location: ' . $locationurl);
+exit();
 ?>

--- a/init.php
+++ b/init.php
@@ -338,7 +338,7 @@ print '<button type="button" class="btn btn-default" id="listerbt" '.$addattr.'>
 ?>
   </p>
 
-  <a href="requestlist_only.php" class="btn btn-default" > リクエストTOP画面に戻る　</a>
+  <a href="requestlist_top.php" class="btn btn-default" > リクエストTOP画面に戻る　</a>
 </div>
 
 <hr />

--- a/init.php
+++ b/init.php
@@ -526,6 +526,29 @@ print ' value="10" ';
   </label>
   </div>
 
+<!---- スワイプ操作対応リクエスト一覧UI ----->
+  <?php
+      $usenewrequestlist = false;
+      if(array_key_exists("usenewrequestlist",$config_ini)){
+          if($config_ini["usenewrequestlist"] == 1 ){
+             $usenewrequestlist = true;
+          }
+      }
+  ?>
+  <div class="form-group">
+    <h4 class="radio control-label"> スワイプ操作対応リクエスト一覧UI </h4>
+    <label class="radio control-label"><small>ドラッグハンドルで並べ替え・左スワイプでアクションメニューを表示するリクエスト一覧画面を使用します。</small></label>
+    <label class="radio-inline">
+      <input type="radio" name="usenewrequestlist" value="1" <?php print ($usenewrequestlist)?'checked':' ' ?> /> 使用する
+    </label>
+    <label class="radio-inline">
+      <input type="radio" name="usenewrequestlist" value="2" <?php print (!$usenewrequestlist)?'checked':' ' ?> /> 使用しない
+    </label>
+    <label>
+      <a href="requestlist_swipe.php"> スワイプUIリクエスト一覧へのリンク </a>
+    </label>
+  </div>
+
 <!---- ページ背景色設定 ----->
   <?php
       $bgcolor='#F8ECE0';

--- a/js/requsetlist_confirm.js
+++ b/js/requsetlist_confirm.js
@@ -47,9 +47,9 @@ $(document).ready(function()
             success : function( data ) {
                 try{
                   newid = JSON.parse(data);
-                  window.location.href = 'requestlist_only.php?username=' + newname + '&showid=' + newid.newid;
+                  window.location.href = 'requestlist_top.php?username=' + newname + '&showid=' + newid.newid;
                 } catch(e){
-                  window.location.href = 'requestlist_only.php?username=' + newname;
+                  window.location.href = 'requestlist_top.php?username=' + newname;
                 }
             },
             // 応答後

--- a/kara_config.php
+++ b/kara_config.php
@@ -139,7 +139,10 @@ function readconfig_array()
     if(!array_key_exists("usebgv", $config_ini)){
         $usebgv = 2;
         $config_ini = array_merge($config_ini,array("usebgv" => $usebgv));
-    }    
+    }
+    if(!array_key_exists("usenewrequestlist", $config_ini)){
+        $config_ini = array_merge($config_ini,array("usenewrequestlist" => 2));
+    }
 
     if($config_ini["playerpath_select"] == urlencode("その他PATH指定" )) {
         $config_ini = array_merge($config_ini,array("playerpath" => ($config_ini["playerpath_any"])));

--- a/listclear.php
+++ b/listclear.php
@@ -27,7 +27,7 @@ if (! $retval ) {
   <meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0">
 <?php
 if($retval){
-print '<META http-equiv="refresh" content="1; url=requestlist_only.php">';
+print '<META http-equiv="refresh" content="1; url=requestlist_top.php">';
 }
 ?>  
 

--- a/listimport.php
+++ b/listimport.php
@@ -93,6 +93,6 @@ if( strcmp($l_importtype,'add' ) === 0 ){
 </head>
 <body>
 <p> dbインポート完了 </p>
-<a href="requestlist_only.php" >トップに戻る </a>
+<a href="requestlist_top.php" >トップに戻る </a>
 </body>
 </html>

--- a/listtimesclear.php
+++ b/listtimesclear.php
@@ -35,7 +35,7 @@ if (! $retval ) {
   <meta http-equiv="Content-Style-Type" content="text/css" />
   <meta http-equiv="Content-Script-Type" content="text/javascript" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0">
-  <META http-equiv="refresh" content="1; url=requestlist_only.php">
+  <META http-equiv="refresh" content="1; url=requestlist_top.php">
   
 
   <title>再生回数クリア</title>
@@ -43,6 +43,6 @@ if (! $retval ) {
 </head>
 <body>
 <p> 再生回数<?php echo htmlspecialchars((string)$l_times, ENT_QUOTES, 'UTF-8'); ?>クリア完了 </p>
-<a href="requestlist_only.php" >トップに戻る </a>
+<a href="requestlist_top.php" >トップに戻る </a>
 </body>
 </html>

--- a/localfile.php
+++ b/localfile.php
@@ -1,3 +1,3 @@
 <?php
-  http_redirect("requestlist_only.php");
+  http_redirect("requestlist_top.php");
 ?>

--- a/notfoundrequest/delete_notfound_request.php
+++ b/notfoundrequest/delete_notfound_request.php
@@ -38,7 +38,7 @@ if (! $ret ) {
 
 ?>
 &nbsp;
-<a href="../requestlist_only.php" >トップに戻る </a>
+<a href="../requestlist_top.php" >トップに戻る </a>
 
 </body>
 </html>

--- a/notfoundrequest/modify_notfound_request.php
+++ b/notfoundrequest/modify_notfound_request.php
@@ -116,7 +116,7 @@ try{
 
 
 ?>
-<a href="../requestlist_only.php" > リクエストページに戻る <a><br>
+<a href="../requestlist_top.php" > リクエストページに戻る <a><br>
 
 </body>
 </html>

--- a/notfoundrequest/notfoundrequest.php
+++ b/notfoundrequest/notfoundrequest.php
@@ -120,7 +120,7 @@ if(!count($allrequest) == 0 ){
 ?>
 </tbody>
 </table>
-<a href="../requestlist_only.php" >トップに戻る </a>
+<a href="../requestlist_top.php" >トップに戻る </a>
 
 </body>
 </html>

--- a/request_confirm.php
+++ b/request_confirm.php
@@ -645,7 +645,7 @@ print '</div>';
 通常検索に戻る
 </button> 
 
-<button type="button" onclick="location.href='requestlist_only.php' " class="btn btn-default " >
+<button type="button" onclick="location.href='requestlist_top.php' " class="btn btn-default " >
 トップに戻る
 </button> 
 </div>

--- a/request_confirm_url.php
+++ b/request_confirm_url.php
@@ -395,7 +395,7 @@ print '<input type="hidden" name="urlreq" id="urlreq"  value="1" />'."\n";
 通常検索に戻る
 </button> 
 
-<button type="button" onclick="location.href='requestlist_only.php' " class="btn btn-default " >
+<button type="button" onclick="location.href='requestlist_top.php' " class="btn btn-default " >
 トップに戻る
 </button> 
 </div>

--- a/requestlist_reorder.php
+++ b/requestlist_reorder.php
@@ -1,0 +1,49 @@
+<?php
+require_once 'commonfunc.php';
+require_once 'easyauth_class.php';
+require_once 'function_updatenotice.php';
+$easyauth = new EasyAuth();
+$easyauth->do_eashauthcheck();
+
+header('Content-Type: application/json; charset=utf-8');
+
+$raw = file_get_contents('php://input');
+$input = json_decode($raw, true);
+$ids = $input['ids'] ?? [];
+
+// Validate: positive integers only
+$ids = array_values(array_filter($ids, function ($v) {
+    return is_numeric($v) && (int)$v > 0;
+}));
+
+if (empty($ids)) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'No valid IDs']);
+    exit;
+}
+
+$total = count($ids);
+try {
+    $db->beginTransaction();
+    $stmt = $db->prepare("UPDATE requesttable SET reqorder = :reqorder WHERE id = :id");
+    foreach ($ids as $index => $id) {
+        // First item gets highest reqorder (displayed first, ORDER BY reqorder DESC)
+        $reqorder = ($total - $index) * 10;
+        $stmt->bindValue(':reqorder', $reqorder, PDO::PARAM_INT);
+        $stmt->bindValue(':id', (int)$id, PDO::PARAM_INT);
+        $stmt->execute();
+    }
+    $db->commit();
+} catch (PDOException $e) {
+    $db->rollBack();
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => 'DB error']);
+    exit;
+}
+
+$un = new UpdateNotice();
+$un->initdb();
+$un->updaterequestlist();
+$un->closedb();
+
+echo json_encode(['status' => 'ok']);

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -100,7 +100,7 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
   cursor: default;
 }
 .request-card.swipe-open .card-main {
-  transform: translateX(-210px);
+  transform: translateX(-240px);
 }
 
 /* ドラッグハンドル */
@@ -127,13 +127,13 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
   line-height: 1.4;
 }
 .card-meta {
-  font-size: 12px;
-  color: #888;
+  font-size: 14px;
+  color: #666;
   margin-top: 3px;
 }
 .card-label {
-  color: #bbb;
-  font-size: 11px;
+  color: #aaa;
+  font-size: 12px;
 }
 
 /* 右カラム（バッジ＋曲終了ボタン） */
@@ -155,8 +155,8 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
 }
 /* コメント欄 */
 .card-comment-area {
-  font-size: 12px;
-  color: #666;
+  font-size: 13px;
+  color: #555;
   cursor: pointer;
   padding: 2px 0;
   min-height: 18px;
@@ -360,11 +360,12 @@ function createCardHTML(item) {
     var replaceLabel = (item.kind === 'カラオケ配信' && USE_BGV) ? 'BGV選択' : '曲差し替え';
 
     // コメント欄
-    var commentHtml = '<div class="card-comment-area" data-id="' + item.id + '" data-comment="' + esc(item.comment) + '">';
+    var commentHtml = '<div class="card-comment-area" data-id="' + item.id + '" data-comment="' + esc(item.comment) + '">'
+        + '<span class="card-label">コメント：</span>';
     if (item.comment) {
         commentHtml += esc(item.comment) + ' <small>&#9998;</small>';
     } else {
-        commentHtml += '<span class="card-comment-placeholder">コメントを追加...</span>';
+        commentHtml += '<span class="card-comment-placeholder">（なし）</span>';
     }
     commentHtml += '</div>';
 
@@ -510,7 +511,7 @@ function initSwipe() {
         var main = card.querySelector('.card-main');
         if (!main) return;
 
-        var OPEN_WIDTH = 210; // px：アクション幅（3ボタン×70px）
+        var OPEN_WIDTH = 240; // px：アクション幅（3ボタン×80px）
         var DIR_THR   = 10;  // px：方向判定閾値
         var SNAP_THR  = 60;  // px：スナップ閾値
 

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -127,13 +127,13 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
   line-height: 1.4;
 }
 .card-meta {
-  font-size: 14px;
-  color: #666;
-  margin-top: 3px;
+  font-size: 16px;
+  color: #555;
+  margin-top: 4px;
 }
 .card-label {
   color: #aaa;
-  font-size: 12px;
+  font-size: 13px;
 }
 
 /* 右カラム（バッジ＋曲終了ボタン） */
@@ -365,7 +365,7 @@ function createCardHTML(item) {
     if (item.comment) {
         commentHtml += esc(item.comment) + ' <small>&#9998;</small>';
     } else {
-        commentHtml += '<span class="card-comment-placeholder">（なし）</span>';
+        commentHtml += '<span class="card-comment-placeholder">コメントを追加...</span>';
     }
     commentHtml += '</div>';
 

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -85,6 +85,7 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
 .action-replace { background: #27ae60; }
 .action-next    { background: #e67e22; }
 .action-delete  { background: #e74c3c; }
+.action-change  { background: #7f8c8d; }
 .action-icon    { font-size: 18px; }
 
 /* カード本体（スワイプで左にスライド） */
@@ -102,6 +103,9 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
 }
 .request-card.swipe-open .card-main {
   transform: translateX(-240px);
+}
+.request-card.admin-card.swipe-open .card-main {
+  transform: translateX(-320px);
 }
 
 /* ドラッグハンドル */
@@ -378,16 +382,6 @@ function createCardHTML(item) {
     }
     commentHtml += '</div>';
 
-    // 管理者用「変更」ボタン
-    var changeBtn = '';
-    if (IS_ADMIN) {
-        changeBtn = '<form method="post" action="change.php" style="margin:0">'
-            + '<input type="hidden" name="id" value="' + item.id + '">'
-            + '<input type="hidden" name="songfile" value="' + esc(item.songfile) + '">'
-            + '<button type="submit" class="btn btn-default btn-xs card-ctrl-btn">変更</button>'
-            + '</form>';
-    }
-
     // 曲終了 / 曲開始ボタン
     var ctrlBtn = '';
     if (isPlaying(item.nowplaying)) {
@@ -410,8 +404,16 @@ function createCardHTML(item) {
         tweetHtml = '<a href="https://twitter.com/intent/tweet?text=' + encodeURIComponent(msg) + '" target="_blank" class="card-tweet-link">&#x1F426; Tweetする</a>';
     }
 
+    var adminChangeBtnHtml = IS_ADMIN ? [
+        '    <button class="action-btn action-change"',
+        '            data-id="'       + item.id              + '"',
+        '            data-songfile="' + esc(item.songfile)   + '">',
+        '      <span class="action-icon">&#9998;</span>変更',
+        '    </button>'
+    ].join('\n') : '';
+
     return [
-        '<div class="request-card"',
+        '<div class="request-card' + (IS_ADMIN ? ' admin-card' : '') + '"',
         '     data-id="'       + item.id              + '"',
         '     data-songfile="' + esc(item.songfile)   + '"',
         '     data-kind="'     + esc(item.kind)       + '"',
@@ -432,6 +434,7 @@ function createCardHTML(item) {
         '            data-songfile="' + esc(item.songfile)   + '">',
         '      <span class="action-icon">&#10005;</span>削除',
         '    </button>',
+        adminChangeBtnHtml,
         '  </div>',
         '  <div class="card-main">',
         '    <span class="drag-handle">&#8942;</span>',
@@ -449,7 +452,6 @@ function createCardHTML(item) {
         '        ' + statusBadge(item.nowplaying),
         '      </span>',
         '      ' + ctrlBtn,
-        '      ' + changeBtn,
         '    </div>',
         '  </div>',
         '</div>'
@@ -531,7 +533,7 @@ function initSwipe() {
         var main = card.querySelector('.card-main');
         if (!main) return;
 
-        var OPEN_WIDTH = 240; // px：アクション幅（3ボタン×80px）
+        var OPEN_WIDTH = card.classList.contains('admin-card') ? 320 : 240; // 管理者は4ボタン×80px
         var DIR_THR   = 10;  // px：方向判定閾値
         var SNAP_THR  = 60;  // px：スナップ閾値
 
@@ -654,6 +656,22 @@ function replaceSong(id) {
     location.href = 'searchreserve.php?id=' + id;
 }
 
+// 管理者用変更
+function changeItem(id, songfile) {
+    if (openCard) closeCard(openCard);
+    var form = document.createElement('form');
+    form.method = 'POST';
+    form.action = 'change.php';
+    var fid = document.createElement('input');
+    fid.type = 'hidden'; fid.name = 'id'; fid.value = id;
+    var fsong = document.createElement('input');
+    fsong.type = 'hidden'; fsong.name = 'songfile'; fsong.value = songfile;
+    form.appendChild(fid);
+    form.appendChild(fsong);
+    document.body.appendChild(form);
+    form.submit();
+}
+
 // 曲終了
 function songEnd() {
     fetch('playerctrl_portal.php?songnext=1').then(loadList);
@@ -756,6 +774,7 @@ document.getElementById('request-list').addEventListener('click', function (e) {
         if (btn.classList.contains('action-replace')) replaceSong(id);
         if (btn.classList.contains('action-next'))    playNext(id, songfile);
         if (btn.classList.contains('action-delete'))  deleteItem(id, songfile);
+        if (btn.classList.contains('action-change'))  changeItem(id, songfile);
         return;
     }
     // コメント欄タップ

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -208,9 +208,7 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
 #count-select {
   width: auto;
   display: inline-block;
-  margin-left: 10px;
-  padding-left: 10px;
-  border-left: 1px solid #ccc;
+  margin-left: auto;
 }
 
 @keyframes playing-pulse {
@@ -364,6 +362,33 @@ var sortable        = null;
 var currentLimit    = REQUESTLIST_NUM; // 0 = ALL
 var shownCount      = 0;
 var totalCount      = 0;
+
+// ---- 件数選択のcookie保存/復元 ----
+function getCountCookie() {
+    var m = document.cookie.match(/(?:^|; )swipe_count_limit=([^;]*)/);
+    if (!m) return null;
+    var v = parseInt(decodeURIComponent(m[1]), 10);
+    return isNaN(v) ? null : v;
+}
+function setCountCookie(val) {
+    var d = new Date();
+    d.setFullYear(d.getFullYear() + 1);
+    document.cookie = 'swipe_count_limit=' + encodeURIComponent(val)
+        + '; expires=' + d.toUTCString() + '; path=/';
+}
+(function applyCountCookie() {
+    if (REQUESTLIST_NUM <= 0) return; // 全件設定時はスキップ
+    var saved = getCountCookie();
+    if (saved === null) return;
+    var sel = document.getElementById('count-select');
+    if (!sel) return;
+    // 選択肢に存在する値のみ適用
+    var opts = Array.prototype.map.call(sel.options, function (o) { return parseInt(o.value, 10); });
+    if (opts.indexOf(saved) !== -1) {
+        currentLimit = saved;
+        sel.value = String(saved);
+    }
+})();
 
 // ---- ユーティリティ ----
 function esc(str) {
@@ -926,6 +951,7 @@ var countSelect = document.getElementById('count-select');
 if (countSelect) {
     countSelect.addEventListener('change', function () {
         currentLimit = parseInt(this.value, 10);
+        setCountCookie(currentLimit);
         loadList(true);
     });
 }

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -261,7 +261,7 @@ if (!empty($config_ini['noticeof_listpage'])) {
       <option value="0">ALL</option>
     </select>
 <?php endif; ?>
-    <a href="simplelistexport_utf8.php" class="btn btn-default btn-xs">CSV</a>
+    <a href="simplelistexport_utf8.php" class="btn btn-default btn-xs">リクエストリストCSV</a>
     <a href="simplelist.php" class="btn btn-default btn-xs">シンプルリスト</a>
   </div>
 </div>

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -218,6 +218,13 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
 .highlight-playing {
   animation: playing-pulse 0.7s ease 3;
 }
+@keyframes new-item-pulse {
+  0%, 100% { box-shadow: 0 1px 3px rgba(0,0,0,0.15); }
+  40%       { box-shadow: 0 0 0 4px rgba(39,174,96,0.7); }
+}
+.highlight-new {
+  animation: new-item-pulse 0.7s ease 4;
+}
 
 #empty-msg {
   text-align: center;
@@ -579,6 +586,10 @@ function renderList(items, total, hasMore) {
 
     initSortable();
     initSwipe();
+
+    var cb = afterRenderCallback;
+    afterRenderCallback = null;
+    if (cb) cb();
 }
 
 // ---- SortableJS（ドラッグ並べ替え） ----
@@ -894,6 +905,17 @@ document.getElementById('request-list').addEventListener('click', function (e) {
     if (e.target.closest('.song-start-btn')) { songStart(); return; }
 });
 
+// ---- カードハイライト共通処理 ----
+function highlightCard(card, cssClass) {
+    card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    card.classList.remove(cssClass);
+    void card.offsetWidth; // アニメーションリセット
+    card.classList.add(cssClass);
+    card.addEventListener('animationend', function () {
+        card.classList.remove(cssClass);
+    }, { once: true });
+}
+
 // ---- 再生中カードを探すセレクタ ----
 var PLAYING_SEL = [
     '[data-nowplaying="再生中"]',
@@ -905,15 +927,36 @@ var PLAYING_SEL = [
 function scrollToPlayingCard() {
     var card = document.querySelector(PLAYING_SEL);
     if (!card) return false;
-    card.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    card.classList.remove('highlight-playing');
-    // リフロー強制してアニメーションをリセット
-    void card.offsetWidth;
-    card.classList.add('highlight-playing');
-    card.addEventListener('animationend', function () {
-        card.classList.remove('highlight-playing');
-    }, { once: true });
+    highlightCard(card, 'highlight-playing');
     return true;
+}
+
+// ---- 新規追加アイテムへのスクロール ----
+var SHOW_ID = (function () {
+    var m = window.location.search.match(/[?&]showid=(\d+)/);
+    return m ? parseInt(m[1], 10) : null;
+})();
+
+var afterRenderCallback = null;
+
+function scrollToShowId() {
+    var card = document.querySelector('.request-card[data-id="' + SHOW_ID + '"]');
+    if (card) {
+        highlightCard(card, 'highlight-new');
+        return;
+    }
+    // ページ外の場合は全件ロードして探す
+    currentLimit = 0;
+    var countSel = document.getElementById('count-select');
+    if (countSel) countSel.value = '0';
+    fetch(buildUrl(0, 0))
+        .then(function (res) { return res.ok ? res.json() : Promise.reject(res.status); })
+        .then(function (data) {
+            renderList(data.items, data.total, data.has_more);
+            var c = document.querySelector('.request-card[data-id="' + SHOW_ID + '"]');
+            if (c) highlightCard(c, 'highlight-new');
+        })
+        .catch(function (e) { console.error('scrollToShowId error:', e); });
 }
 
 function goToPlaying() {
@@ -1003,6 +1046,7 @@ function reloadCurrent() {
 }
 
 // ---- 初期化 ----
+if (SHOW_ID) afterRenderCallback = scrollToShowId;
 loadList(true);
 initAutoReload();
 </script>

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -217,19 +217,20 @@ function esc(str) {
         .replace(/"/g, '&quot;');
 }
 
-var STATUS_MAP = {
-    '1': ['未再生',     'default'],
-    '2': ['再生中',     'success'],
-    '3': ['停止中',     'warning'],
-    '4': ['再生済',     'info'],
-    '5': ['再生済？',   'info'],
-    '6': ['再生待ち',   'warning'],
-    '7': ['変更中',     'danger']
+var STATUS_CLASS = {
+    '未再生':       'default',
+    '再生中':       'success',
+    '停止中':       'warning',
+    '再生済':       'info',
+    '再生済？':     'info',
+    '再生開始待ち': 'warning',
+    '変更中':       'danger'
 };
 
 function statusBadge(nowplaying) {
-    var info  = STATUS_MAP[String(nowplaying)] || ['不明', 'default'];
-    return '<span class="label label-' + info[1] + '">' + info[0] + '</span>';
+    if (!nowplaying) return '';
+    var cls = STATUS_CLASS[nowplaying] || 'default';
+    return '<span class="label label-' + cls + '">' + esc(nowplaying) + '</span>';
 }
 
 // ---- カード HTML 生成 ----

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -23,6 +23,7 @@ $useposttwitter  = configbool('useposttwitter', true);
 $playmode        = isset($config_ini['playmode']) ? (int)$config_ini['playmode'] : 3;
 $usebgv          = isset($config_ini['usebgv']) ? (int)$config_ini['usebgv'] : 2;
 $isAdmin         = ($user === 'admin');
+$requestlist_num = isset($config_ini['requestlist_num']) ? (int)$config_ini['requestlist_num'] : 10;
 ?>
 <!DOCTYPE html>
 <html lang="ja">
@@ -188,18 +189,38 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
 }
 
 /* ヘッダ行 */
-.list-header {
+.list-toolbar {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
   margin-bottom: 4px;
 }
-.list-header h4 { margin: 0; }
+.toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+}
+.toolbar-left h4 { margin: 0; white-space: nowrap; }
+.toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+#count-select { width: auto; display: inline-block; }
 
 #empty-msg {
   text-align: center;
   color: #aaa;
   padding: 30px 0;
   font-size: 15px;
+}
+#load-more-wrap {
+  text-align: center;
+  padding: 12px 0 4px;
 }
 </style>
 </head>
@@ -227,21 +248,29 @@ if (!empty($config_ini['noticeof_listpage'])) {
 
 <hr>
 
-<div class="list-header">
-  <h4>現在の登録状況</h4>
-  &nbsp;
-  <button class="btn btn-default btn-xs" id="refresh-btn">更新</button>
+<div class="list-toolbar">
+  <div class="toolbar-left">
+    <h4>現在の登録状況</h4>
+    <button class="btn btn-default btn-xs" id="refresh-btn">更新</button>
+  </div>
+  <div class="toolbar-right">
+<?php if ($requestlist_num > 0): ?>
+    <select id="count-select" class="form-control input-sm">
+      <option value="<?php echo $requestlist_num; ?>"><?php echo $requestlist_num; ?>件</option>
+      <option value="<?php echo $requestlist_num * 2; ?>"><?php echo $requestlist_num * 2; ?>件</option>
+      <option value="0">ALL</option>
+    </select>
+<?php endif; ?>
+    <a href="simplelistexport_utf8.php" class="btn btn-default btn-xs">CSV</a>
+    <a href="simplelist.php" class="btn btn-default btn-xs">シンプルリスト</a>
+  </div>
 </div>
 
 <div id="request-list"></div>
+<div id="load-more-wrap" style="display:none">
+  <button class="btn btn-default" id="load-more-btn">もっと見る</button>
+</div>
 <div id="empty-msg" style="display:none">リクエストはありません</div>
-
-<hr>
-<form method="get" action="simplelistexport_utf8.php">
-  <input type="submit" class="btn btn-primary" value="リクエストリスト(CSV)のダウンロード">
-  &nbsp;
-  <a href="simplelist.php" class="btn btn-primary">シンプルリクエストリスト表示(コピペ・公開用)</a>
-</form>
 
 </div><!-- /.container -->
 
@@ -316,11 +345,15 @@ var USE_POST_TWITTER   = <?php echo $useposttwitter ? 'true' : 'false'; ?>;
 var PLAYMODE           = <?php echo $playmode; ?>;
 var USE_BGV            = <?php echo ($usebgv == 1) ? 'true' : 'false'; ?>;
 var IS_ADMIN           = <?php echo $isAdmin ? 'true' : 'false'; ?>;
+var REQUESTLIST_NUM    = <?php echo $requestlist_num; ?>;
 
 // ---- 状態 ----
-var openCard   = null;
-var isDragging = false;
-var sortable   = null;
+var openCard        = null;
+var isDragging      = false;
+var sortable        = null;
+var currentLimit    = REQUESTLIST_NUM; // 0 = ALL
+var shownCount      = 0;
+var totalCount      = 0;
 
 // ---- ユーティリティ ----
 function esc(str) {
@@ -459,26 +492,56 @@ function createCardHTML(item) {
 }
 
 // ---- データ読み込みと描画 ----
-function loadList() {
-    fetch('requestlist_swipe_json.php')
-        .then(function (res) { return res.ok ? res.json() : Promise.reject(res.status); })
-        .then(function (items) { renderList(items); })
-        .catch(function (e)   { console.error('loadList error:', e); });
+function buildUrl(limit, offset) {
+    return 'requestlist_swipe_json.php?limit=' + limit + '&offset=' + offset;
 }
 
-function renderList(items) {
-    var container = document.getElementById('request-list');
-    var emptyMsg  = document.getElementById('empty-msg');
+// reset=true: 最初から描画し直す / reset=false: 追加読み込み
+function loadList(reset) {
+    if (reset === undefined || reset === true) {
+        var limit  = currentLimit;
+        var offset = 0;
+        fetch(buildUrl(limit, offset))
+            .then(function (res) { return res.ok ? res.json() : Promise.reject(res.status); })
+            .then(function (data) { renderList(data.items, data.total, data.has_more); })
+            .catch(function (e)   { console.error('loadList error:', e); });
+    } else {
+        // もっと見る: 現在表示分をまとめて再取得して全置き換え
+        var newLimit = (currentLimit > 0) ? shownCount + currentLimit : 0;
+        fetch(buildUrl(newLimit, 0))
+            .then(function (res) { return res.ok ? res.json() : Promise.reject(res.status); })
+            .then(function (data) { renderList(data.items, data.total, data.has_more); })
+            .catch(function (e)   { console.error('loadMore error:', e); });
+    }
+}
 
-    if (items.length === 0) {
+function renderList(items, total, hasMore) {
+    var container   = document.getElementById('request-list');
+    var emptyMsg    = document.getElementById('empty-msg');
+    var loadMoreWrap = document.getElementById('load-more-wrap');
+
+    totalCount = total || 0;
+
+    if (items.length === 0 && totalCount === 0) {
         container.innerHTML = '';
         emptyMsg.style.display = '';
+        loadMoreWrap.style.display = 'none';
         if (sortable) { sortable.destroy(); sortable = null; }
         return;
     }
 
     emptyMsg.style.display = 'none';
+    shownCount = items.length;
     container.innerHTML = items.map(createCardHTML).join('');
+
+    var remaining = totalCount - shownCount;
+    if (hasMore && remaining > 0) {
+        document.getElementById('load-more-btn').textContent = 'もっと見る（残り' + remaining + '件）';
+        loadMoreWrap.style.display = '';
+    } else {
+        loadMoreWrap.style.display = 'none';
+    }
+
     initSortable();
     initSwipe();
 }
@@ -529,7 +592,8 @@ function closeCard(card) {
 }
 
 function initSwipe() {
-    document.querySelectorAll('.request-card').forEach(function (card) {
+    document.querySelectorAll('.request-card:not([data-swipe])').forEach(function (card) {
+        card.setAttribute('data-swipe', '1');
         var main = card.querySelector('.card-main');
         if (!main) return;
 
@@ -796,7 +860,19 @@ document.getElementById('request-list').addEventListener('click', function (e) {
 });
 
 // ---- 更新ボタン ----
-document.getElementById('refresh-btn').addEventListener('click', loadList);
+document.getElementById('refresh-btn').addEventListener('click', function () { loadList(true); });
+
+// ---- もっと見るボタン ----
+document.getElementById('load-more-btn').addEventListener('click', function () { loadList(false); });
+
+// ---- 件数選択 ----
+var countSelect = document.getElementById('count-select');
+if (countSelect) {
+    countSelect.addEventListener('change', function () {
+        currentLimit = parseInt(this.value, 10);
+        loadList(true);
+    });
+}
 
 // ---- 自動リロード ----
 function shouldAutoReload() {
@@ -813,7 +889,7 @@ function initAutoReload() {
             // フォールバック：タイマー
             if (RELOAD_INTERVAL > 0) {
                 setInterval(function () {
-                    if (!isDragging && shouldAutoReload()) loadList();
+                    if (!isDragging && shouldAutoReload()) reloadCurrent();
                 }, RELOAD_INTERVAL);
             }
             return;
@@ -824,19 +900,28 @@ function initAutoReload() {
             if (e.data === 'Bye') { source.close(); return; }
             var nowkey = e.data;
             if (nowkey && nowkey !== 'None' && lastkey !== nowkey) {
-                if (!isDragging && shouldAutoReload()) loadList();
+                if (!isDragging && shouldAutoReload()) reloadCurrent();
                 lastkey = nowkey;
             }
         };
     } else {
         setInterval(function () {
-            if (!isDragging && shouldAutoReload()) loadList();
+            if (!isDragging && shouldAutoReload()) reloadCurrent();
         }, RELOAD_INTERVAL);
     }
 }
 
+// auto-reload: 現在表示中の件数で再取得（追加ロード分も含む）
+function reloadCurrent() {
+    var limit = (currentLimit > 0 && shownCount > 0) ? shownCount : currentLimit;
+    fetch(buildUrl(limit, 0))
+        .then(function (res) { return res.ok ? res.json() : Promise.reject(res.status); })
+        .then(function (data) { renderList(data.items, data.total, data.has_more); })
+        .catch(function (e)   { console.error('reload error:', e); });
+}
+
 // ---- 初期化 ----
-loadList();
+loadList(true);
 initAutoReload();
 </script>
 </body>

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -17,6 +17,11 @@ $bgcolor = '#F8ECE0';
 if (!empty($config_ini['bgcolor'])) {
     $bgcolor = urldecode($config_ini['bgcolor']);
 }
+
+$connectinternet = isset($config_ini['connectinternet']) ? (int)$config_ini['connectinternet'] : 1;
+$useposttwitter  = configbool('useposttwitter', true);
+$playmode        = isset($config_ini['playmode']) ? (int)$config_ini['playmode'] : 3;
+$usebgv          = isset($config_ini['usebgv']) ? (int)$config_ini['usebgv'] : 2;
 ?>
 <!DOCTYPE html>
 <html lang="ja">
@@ -76,9 +81,10 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
   padding: 0;
 }
 .action-btn:active { opacity: 0.8; }
-.action-next   { background: #e67e22; }
-.action-delete { background: #e74c3c; }
-.action-icon   { font-size: 18px; }
+.action-replace { background: #27ae60; }
+.action-next    { background: #e67e22; }
+.action-delete  { background: #e74c3c; }
+.action-icon    { font-size: 18px; }
 
 /* カード本体（スワイプで左にスライド） */
 .card-main {
@@ -94,7 +100,7 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
   cursor: default;
 }
 .request-card.swipe-open .card-main {
-  transform: translateX(-160px);
+  transform: translateX(-210px);
 }
 
 /* ドラッグハンドル */
@@ -130,10 +136,42 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
   margin-top: 2px;
 }
 
-/* 再生状況バッジ */
-.card-status {
+/* 右カラム（バッジ＋曲終了ボタン） */
+.card-right {
   flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 5px;
+  min-width: 64px;
 }
+.status-badge-btn {
+  cursor: pointer;
+}
+.status-badge-btn:hover .label { opacity: 0.8; }
+.card-ctrl-btn {
+  font-size: 12px;
+  padding: 2px 8px;
+}
+/* コメント欄 */
+.card-comment-area {
+  font-size: 12px;
+  color: #666;
+  cursor: pointer;
+  padding: 2px 0;
+  min-height: 18px;
+}
+.card-comment-area:hover { color: #337ab7; text-decoration: underline; }
+.card-comment-placeholder { color: #bbb; font-style: italic; }
+/* Tweet リンク */
+.card-tweet-link {
+  font-size: 11px;
+  color: #1da1f2;
+  text-decoration: none;
+  display: inline-block;
+  margin-top: 2px;
+}
+.card-tweet-link:hover { text-decoration: underline; color: #0c85d0; }
 
 /* SortableJS */
 .sortable-ghost {
@@ -195,12 +233,81 @@ if (!empty($config_ini['noticeof_listpage'])) {
 
 </div><!-- /.container -->
 
+<!-- コメント編集モーダル -->
+<div class="modal fade" id="comment-modal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+        <h4 class="modal-title">コメントへのレス＆編集</h4>
+      </div>
+      <div class="modal-body">
+        <form id="comment-edit-form">
+          <div class="form-group">
+            <label>コメント修正</label>
+            <textarea class="form-control" id="comment-edit-text" rows="3"></textarea>
+          </div>
+          <button type="submit" class="btn btn-default pull-right">修正</button>
+        </form>
+        <div class="clearfix" style="margin-bottom:10px;"></div>
+        <hr>
+        <form id="comment-reply-form">
+          <div class="form-group">
+            <label>レス <small>再生中にコメントするとその場で流れます</small></label>
+            <input type="text" class="form-control" id="comment-reply-text" placeholder="レス(コメントへの)">
+          </div>
+          <div class="form-group">
+            <label>名前</label>
+            <input type="text" class="form-control" id="comment-reply-name" placeholder="名前">
+          </div>
+          <button type="submit" class="btn btn-primary pull-right">送信</button>
+        </form>
+        <div class="clearfix"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 再生状況変更モーダル -->
+<div class="modal fade" id="status-modal" tabindex="-1">
+  <div class="modal-dialog modal-sm">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+        <h4 class="modal-title">再生状況を変更</h4>
+      </div>
+      <div class="modal-body">
+        <select class="form-control" id="status-select">
+          <option value="未再生">未再生</option>
+          <option value="再生中">再生中</option>
+          <option value="停止中">停止中</option>
+          <option value="再生済">再生済</option>
+          <option value="再生済？">再生済？</option>
+          <option value="再生開始待ち">再生開始待ち</option>
+          <option value="変更中">変更中</option>
+        </select>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">キャンセル</button>
+        <button type="button" class="btn btn-primary" id="status-submit">変更</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <script>
 $(function () { $('[data-toggle="tooltip"]').tooltip(); });
 
 // ---- 設定値（PHP から埋め込み） ----
-var USE_ACTIVE_RELOAD = <?php echo $useActiveReload ? 'true' : 'false'; ?>;
-var RELOAD_INTERVAL   = <?php echo $reloadInterval; ?> * 1000;
+var USE_ACTIVE_RELOAD  = <?php echo $useActiveReload ? 'true' : 'false'; ?>;
+var RELOAD_INTERVAL    = <?php echo $reloadInterval; ?> * 1000;
+var CONNECT_INTERNET   = <?php echo $connectinternet; ?>;
+var USE_POST_TWITTER   = <?php echo $useposttwitter ? 'true' : 'false'; ?>;
+var PLAYMODE           = <?php echo $playmode; ?>;
+var USE_BGV            = <?php echo ($usebgv == 1) ? 'true' : 'false'; ?>;
 
 // ---- 状態 ----
 var openCard   = null;
@@ -239,12 +346,67 @@ function statusBadge(nowplaying) {
 }
 
 // ---- カード HTML 生成 ----
+function getUsernameFromCookie() {
+    var m = document.cookie.match(/(?:^|; )YkariUsername=([^;]*)/);
+    return m ? decodeURIComponent(m[1]) : '';
+}
+
+function isPlaying(nowplaying) {
+    return nowplaying === '再生中' || nowplaying === '2';
+}
+function isWaiting(nowplaying) {
+    return nowplaying === '再生開始待ち' || nowplaying === '6';
+}
+function isUnplayed(nowplaying) {
+    return nowplaying === '未再生' || nowplaying === '1';
+}
+
 function createCardHTML(item) {
-    var meta = esc(item.singer);
-    if (item.comment) meta += ' &middot; ' + esc(item.comment);
+    var replaceLabel = (item.kind === 'カラオケ配信' && USE_BGV) ? 'BGV選択' : '曲差し替え';
+
+    // コメント欄
+    var commentHtml = '<div class="card-comment-area" data-id="' + item.id + '" data-comment="' + esc(item.comment) + '">';
+    if (item.comment) {
+        commentHtml += esc(item.comment) + ' <small>&#9998;</small>';
+    } else {
+        commentHtml += '<span class="card-comment-placeholder">コメントを追加...</span>';
+    }
+    commentHtml += '</div>';
+
+    // 曲終了 / 曲開始ボタン
+    var ctrlBtn = '';
+    if (isPlaying(item.nowplaying)) {
+        ctrlBtn = '<button class="btn btn-warning btn-xs card-ctrl-btn song-end-btn">曲終了</button>';
+    } else if (isWaiting(item.nowplaying) && item.kind === '動画') {
+        ctrlBtn = '<button class="btn btn-success btn-xs card-ctrl-btn song-start-btn">曲開始</button>';
+    }
+
+    // Tweet リンク
+    var tweetHtml = '';
+    if (CONNECT_INTERNET && USE_POST_TWITTER) {
+        var msg;
+        if (isPlaying(item.nowplaying)) {
+            msg = '「' + item.singer + '」は「' + item.display_name + '」を歌っています';
+        } else if (isUnplayed(item.nowplaying)) {
+            msg = '「' + item.singer + '」は「' + item.display_name + '」を歌います';
+        } else {
+            msg = '「' + item.singer + '」は「' + item.display_name + '」を歌いました';
+        }
+        tweetHtml = '<a href="https://twitter.com/intent/tweet?text=' + encodeURIComponent(msg) + '" target="_blank" class="card-tweet-link">&#x1F426; Tweetする</a>';
+    }
+
     return [
-        '<div class="request-card" data-id="' + item.id + '" data-songfile="' + esc(item.songfile) + '">',
+        '<div class="request-card"',
+        '     data-id="'       + item.id              + '"',
+        '     data-songfile="' + esc(item.songfile)   + '"',
+        '     data-kind="'     + esc(item.kind)       + '"',
+        '     data-nowplaying="' + esc(item.nowplaying) + '">',
         '  <div class="card-actions">',
+        '    <button class="action-btn action-replace"',
+        '            data-id="'       + item.id              + '"',
+        '            data-songfile="' + esc(item.songfile)   + '">',
+        '      <span class="action-icon">&#8635;</span>' + replaceLabel,
+        '    </button>',
         '    <button class="action-btn action-next"',
         '            data-id="'       + item.id              + '"',
         '            data-songfile="' + esc(item.songfile)   + '">',
@@ -260,9 +422,19 @@ function createCardHTML(item) {
         '    <span class="drag-handle">&#8942;</span>',
         '    <div class="card-info">',
         '      <div class="card-title">' + esc(item.display_name) + '</div>',
-        '      <div class="card-meta">'  + meta                   + '</div>',
+        '      <div class="card-meta">'  + esc(item.singer)       + '</div>',
+        '      ' + commentHtml,
+        '      ' + tweetHtml,
         '    </div>',
-        '    <div class="card-status">' + statusBadge(item.nowplaying) + '</div>',
+        '    <div class="card-right">',
+        '      <span class="status-badge-btn"',
+        '            data-id="'         + item.id              + '"',
+        '            data-songfile="'   + esc(item.songfile)   + '"',
+        '            data-nowplaying="' + esc(item.nowplaying) + '">',
+        '        ' + statusBadge(item.nowplaying),
+        '      </span>',
+        '      ' + ctrlBtn,
+        '    </div>',
         '  </div>',
         '</div>'
     ].join('\n');
@@ -343,7 +515,7 @@ function initSwipe() {
         var main = card.querySelector('.card-main');
         if (!main) return;
 
-        var OPEN_WIDTH = 160; // px：アクション幅
+        var OPEN_WIDTH = 210; // px：アクション幅（3ボタン×70px）
         var DIR_THR   = 10;  // px：方向判定閾値
         var SNAP_THR  = 60;  // px：スナップ閾値
 
@@ -459,6 +631,82 @@ function initSwipe() {
 }
 
 // ---- アクション実行 ----
+
+// 曲差し替え
+function replaceSong(id) {
+    if (openCard) closeCard(openCard);
+    location.href = 'searchreserve.php?id=' + id;
+}
+
+// 曲終了
+function songEnd() {
+    fetch('playerctrl_portal.php?songnext=1').then(loadList);
+}
+
+// 曲開始
+function songStart() {
+    fetch('playerctrl_portal.php?songstart=1').then(loadList);
+}
+
+// コメントモーダル
+var currentCommentId = null;
+function openCommentModal(id, comment) {
+    currentCommentId = id;
+    document.getElementById('comment-edit-text').value  = comment || '';
+    document.getElementById('comment-reply-text').value = '';
+    document.getElementById('comment-reply-name').value = getUsernameFromCookie();
+    $('#comment-modal').modal('show');
+}
+
+document.getElementById('comment-edit-form').addEventListener('submit', function (e) {
+    e.preventDefault();
+    if (!currentCommentId) return;
+    var comment = document.getElementById('comment-edit-text').value;
+    fetch('update.php?id=' + currentCommentId + '&comment=' + encodeURIComponent(comment) + '&edit=edit')
+        .then(function () { $('#comment-modal').modal('hide'); loadList(); });
+});
+
+document.getElementById('comment-reply-form').addEventListener('submit', function (e) {
+    e.preventDefault();
+    if (!currentCommentId) return;
+    var reply = document.getElementById('comment-reply-text').value;
+    var name  = document.getElementById('comment-reply-name').value;
+    fetch('commentedit.php?id=' + currentCommentId + '&addcomment=' + encodeURIComponent(reply) + '&name=' + encodeURIComponent(name) + '&add=add')
+        .then(function () { $('#comment-modal').modal('hide'); loadList(); });
+});
+
+// 再生状況変更モーダル
+var currentStatusId      = null;
+var currentStatusSongfile = null;
+function openStatusModal(id, songfile, nowplaying) {
+    currentStatusId       = id;
+    currentStatusSongfile = songfile;
+    var sel = document.getElementById('status-select');
+    // STATUS_LABEL を使って日本語ラベルに正規化してから選択
+    var label = STATUS_LABEL[String(nowplaying)] || nowplaying;
+    sel.value = label;
+    if (!sel.value) sel.value = '未再生';
+    $('#status-modal').modal('show');
+}
+
+document.getElementById('status-submit').addEventListener('click', function () {
+    if (!currentStatusId) return;
+    var val = document.getElementById('status-select').value;
+    fetch('changeplaystatus.php?id=' + currentStatusId + '&songfile=' + encodeURIComponent(currentStatusSongfile) + '&nowplaying=' + encodeURIComponent(val))
+        .then(function () { $('#status-modal').modal('hide'); loadList(); });
+});
+
+// モーダル表示中は自動リロードを抑制
+var storedAutoReload = true;
+$('#comment-modal, #status-modal').on('show.bs.modal', function () {
+    var cb = document.getElementById('autoreload');
+    storedAutoReload = cb ? cb.checked : true;
+    if (cb) cb.checked = false;
+}).on('hide.bs.modal', function () {
+    var cb = document.getElementById('autoreload');
+    if (cb) cb.checked = storedAutoReload;
+});
+
 function playNext(id, songfile) {
     fetch('delete.php?id=' + id + '&warikomi=warikomi&songfile=' + encodeURIComponent(songfile))
         .then(function () {
@@ -482,14 +730,34 @@ function deleteItem(id, songfile) {
         .catch(function (e) { console.error('deleteItem error:', e); });
 }
 
-// ---- イベント委譲（アクションボタン） ----
+// ---- イベント委譲 ----
 document.getElementById('request-list').addEventListener('click', function (e) {
+    // スワイプアクションボタン
     var btn = e.target.closest('.action-btn');
-    if (!btn) return;
-    var id       = parseInt(btn.dataset.id, 10);
-    var songfile = btn.dataset.songfile;
-    if (btn.classList.contains('action-next'))   playNext(id, songfile);
-    if (btn.classList.contains('action-delete')) deleteItem(id, songfile);
+    if (btn) {
+        var id       = parseInt(btn.dataset.id, 10);
+        var songfile = btn.dataset.songfile;
+        if (btn.classList.contains('action-replace')) replaceSong(id);
+        if (btn.classList.contains('action-next'))    playNext(id, songfile);
+        if (btn.classList.contains('action-delete'))  deleteItem(id, songfile);
+        return;
+    }
+    // コメント欄タップ
+    var ca = e.target.closest('.card-comment-area');
+    if (ca) {
+        openCommentModal(parseInt(ca.dataset.id, 10), ca.dataset.comment);
+        return;
+    }
+    // 再生状況バッジタップ
+    var sb = e.target.closest('.status-badge-btn');
+    if (sb) {
+        openStatusModal(parseInt(sb.dataset.id, 10), sb.dataset.songfile, sb.dataset.nowplaying);
+        return;
+    }
+    // 曲終了ボタン
+    if (e.target.closest('.song-end-btn'))   { songEnd();   return; }
+    // 曲開始ボタン
+    if (e.target.closest('.song-start-btn')) { songStart(); return; }
 });
 
 // ---- 更新ボタン ----

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -1,0 +1,534 @@
+<?php
+require_once 'commonfunc.php';
+require_once 'easyauth_class.php';
+$easyauth = new EasyAuth();
+$easyauth->do_eashauthcheck();
+
+$useActiveReload = configbool("requestlistactivereload", true);
+$reloadInterval  = isset($config_ini["reloadtime"]) ? (int)$config_ini["reloadtime"] : 20;
+
+$titlePrefix = '';
+if (!empty($config_ini['roomurl'])) {
+    $roomnames   = array_keys($config_ini['roomurl']);
+    $titlePrefix = $roomnames[0] . '：';
+}
+
+$bgcolor = '#F8ECE0';
+if (!empty($config_ini['bgcolor'])) {
+    $bgcolor = urldecode($config_ini['bgcolor']);
+}
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<?php print_meta_header(); ?>
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta http-equiv="Pragma"        content="no-cache">
+<meta http-equiv="cache-control" content="no-cache">
+<meta http-equiv="expires"       content="0">
+<title><?php echo htmlspecialchars($titlePrefix, ENT_QUOTES, 'UTF-8'); ?>リクエスト一覧</title>
+<link href="css/bootstrap.min.css" rel="stylesheet">
+<link href="css/style.css"         rel="stylesheet">
+<script src="js/jquery.js"></script>
+<script src="js/bootstrap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.3/Sortable.min.js"></script>
+<style>
+body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-8'); ?>; }
+
+#request-list {
+  margin-top: 8px;
+  padding-bottom: 20px;
+}
+
+/* ---- カード ---- */
+.request-card {
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 6px;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+  background: #fff;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+/* スワイプで現れるアクションボタン群 */
+.card-actions {
+  position: absolute;
+  top: 0; right: 0; bottom: 0;
+  display: flex;
+  z-index: 1;
+}
+
+.action-btn {
+  width: 80px;
+  border: none;
+  color: #fff;
+  font-size: 12px;
+  font-weight: bold;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  line-height: 1.2;
+  padding: 0;
+}
+.action-btn:active { opacity: 0.8; }
+.action-next   { background: #e67e22; }
+.action-delete { background: #e74c3c; }
+.action-icon   { font-size: 18px; }
+
+/* カード本体（スワイプで左にスライド） */
+.card-main {
+  position: relative;
+  z-index: 2;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  min-width: 0;
+  transition: transform 0.2s ease;
+  cursor: default;
+}
+.request-card.swipe-open .card-main {
+  transform: translateX(-160px);
+}
+
+/* ドラッグハンドル */
+.drag-handle {
+  flex-shrink: 0;
+  font-size: 20px;
+  color: #bbb;
+  cursor: grab;
+  padding: 0 2px;
+  touch-action: none;
+  line-height: 1;
+}
+.drag-handle:active { cursor: grabbing; }
+
+/* カード内テキスト */
+.card-info {
+  flex: 1;
+  min-width: 0;
+}
+.card-title {
+  font-size: 15px;
+  font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.card-meta {
+  font-size: 12px;
+  color: #888;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+}
+
+/* 再生状況バッジ */
+.card-status {
+  flex-shrink: 0;
+}
+
+/* SortableJS */
+.sortable-ghost {
+  opacity: 0.4;
+  background: #d9eaf7 !important;
+}
+.sortable-chosen {
+  box-shadow: 0 4px 12px rgba(0,0,0,0.25);
+}
+
+/* ヘッダ行 */
+.list-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 4px;
+}
+.list-header h4 { margin: 0; }
+
+#empty-msg {
+  text-align: center;
+  color: #aaa;
+  padding: 30px 0;
+  font-size: 15px;
+}
+</style>
+</head>
+<body>
+<div class="container">
+<?php
+shownavigatioinbar();
+showmode();
+
+if (!empty($config_ini['noticeof_listpage'])) {
+    echo '<div class="well">';
+    echo str_replace('#yukarihost#', $_SERVER['HTTP_HOST'], urldecode($config_ini['noticeof_listpage']));
+    echo '</div>';
+}
+?>
+
+<?php if ($reloadInterval != 0): ?>
+<div class="checkbox">
+  <label class="checkbox-inline" data-toggle="tooltip" data-placement="top"
+         title="コピペとかする時はチェックを外してください">
+    <input type="checkbox" id="autoreload" checked> 自動リロード
+  </label>
+</div>
+<?php endif; ?>
+
+<hr>
+
+<div class="list-header">
+  <h4>現在の登録状況</h4>
+  &nbsp;
+  <button class="btn btn-default btn-xs" id="refresh-btn">更新</button>
+</div>
+
+<div id="request-list"></div>
+<div id="empty-msg" style="display:none">リクエストはありません</div>
+
+</div><!-- /.container -->
+
+<script>
+$(function () { $('[data-toggle="tooltip"]').tooltip(); });
+
+// ---- 設定値（PHP から埋め込み） ----
+var USE_ACTIVE_RELOAD = <?php echo $useActiveReload ? 'true' : 'false'; ?>;
+var RELOAD_INTERVAL   = <?php echo $reloadInterval; ?> * 1000;
+
+// ---- 状態 ----
+var openCard   = null;
+var isDragging = false;
+var sortable   = null;
+
+// ---- ユーティリティ ----
+function esc(str) {
+    if (!str) return '';
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+var STATUS_MAP = {
+    '1': ['未再生',     'default'],
+    '2': ['再生中',     'success'],
+    '3': ['停止中',     'warning'],
+    '4': ['再生済',     'info'],
+    '5': ['再生済？',   'info'],
+    '6': ['再生待ち',   'warning'],
+    '7': ['変更中',     'danger']
+};
+
+function statusBadge(nowplaying) {
+    var info  = STATUS_MAP[String(nowplaying)] || ['不明', 'default'];
+    return '<span class="label label-' + info[1] + '">' + info[0] + '</span>';
+}
+
+// ---- カード HTML 生成 ----
+function createCardHTML(item) {
+    var meta = esc(item.singer);
+    if (item.comment) meta += ' &middot; ' + esc(item.comment);
+    return [
+        '<div class="request-card" data-id="' + item.id + '" data-songfile="' + esc(item.songfile) + '">',
+        '  <div class="card-actions">',
+        '    <button class="action-btn action-next"',
+        '            data-id="'       + item.id              + '"',
+        '            data-songfile="' + esc(item.songfile)   + '">',
+        '      <span class="action-icon">&#9654;</span>次に再生',
+        '    </button>',
+        '    <button class="action-btn action-delete"',
+        '            data-id="'       + item.id              + '"',
+        '            data-songfile="' + esc(item.songfile)   + '">',
+        '      <span class="action-icon">&#10005;</span>削除',
+        '    </button>',
+        '  </div>',
+        '  <div class="card-main">',
+        '    <span class="drag-handle">&#8942;</span>',
+        '    <div class="card-info">',
+        '      <div class="card-title">' + esc(item.display_name) + '</div>',
+        '      <div class="card-meta">'  + meta                   + '</div>',
+        '    </div>',
+        '    <div class="card-status">' + statusBadge(item.nowplaying) + '</div>',
+        '  </div>',
+        '</div>'
+    ].join('\n');
+}
+
+// ---- データ読み込みと描画 ----
+function loadList() {
+    fetch('requestlist_swipe_json.php')
+        .then(function (res) { return res.ok ? res.json() : Promise.reject(res.status); })
+        .then(function (items) { renderList(items); })
+        .catch(function (e)   { console.error('loadList error:', e); });
+}
+
+function renderList(items) {
+    var container = document.getElementById('request-list');
+    var emptyMsg  = document.getElementById('empty-msg');
+
+    if (items.length === 0) {
+        container.innerHTML = '';
+        emptyMsg.style.display = '';
+        if (sortable) { sortable.destroy(); sortable = null; }
+        return;
+    }
+
+    emptyMsg.style.display = 'none';
+    container.innerHTML = items.map(createCardHTML).join('');
+    initSortable();
+    initSwipe();
+}
+
+// ---- SortableJS（ドラッグ並べ替え） ----
+function initSortable() {
+    var container = document.getElementById('request-list');
+    if (sortable) sortable.destroy();
+
+    sortable = Sortable.create(container, {
+        handle:      '.drag-handle',
+        animation:    150,
+        ghostClass:  'sortable-ghost',
+        chosenClass: 'sortable-chosen',
+
+        onStart: function () {
+            isDragging = true;
+            if (openCard) closeCard(openCard);
+        },
+
+        onEnd: function (evt) {
+            isDragging = false;
+            if (evt.oldIndex === evt.newIndex) return;
+
+            var cards = container.querySelectorAll('.request-card');
+            var ids   = Array.prototype.map.call(cards, function (c) {
+                return parseInt(c.dataset.id, 10);
+            });
+
+            fetch('requestlist_reorder.php', {
+                method:  'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body:    JSON.stringify({ ids: ids })
+            }).catch(function (e) {
+                console.error('reorder error:', e);
+                loadList();
+            });
+        }
+    });
+}
+
+// ---- スワイプアクション ----
+function closeCard(card) {
+    card.classList.remove('swipe-open');
+    var main = card.querySelector('.card-main');
+    if (main) main.style.transform = '';
+    if (openCard === card) openCard = null;
+}
+
+function initSwipe() {
+    document.querySelectorAll('.request-card').forEach(function (card) {
+        var main = card.querySelector('.card-main');
+        if (!main) return;
+
+        var OPEN_WIDTH = 160; // px：アクション幅
+        var DIR_THR   = 10;  // px：方向判定閾値
+        var SNAP_THR  = 60;  // px：スナップ閾値
+
+        // ----- タッチ -----
+        var touchStartX, touchStartY, touchTracking = false, touchSwiping = false;
+
+        main.addEventListener('touchstart', function (e) {
+            if (e.target.closest('.drag-handle')) return;
+            touchStartX   = e.touches[0].clientX;
+            touchStartY   = e.touches[0].clientY;
+            touchTracking = true;
+            touchSwiping  = false;
+            main.style.transition = 'none';
+        }, { passive: true });
+
+        main.addEventListener('touchmove', function (e) {
+            if (!touchTracking) return;
+            var dx = e.touches[0].clientX - touchStartX;
+            var dy = e.touches[0].clientY - touchStartY;
+
+            if (!touchSwiping) {
+                if (Math.abs(dx) > DIR_THR && Math.abs(dx) > Math.abs(dy)) {
+                    touchSwiping = true;
+                    if (openCard && openCard !== card) closeCard(openCard);
+                } else if (Math.abs(dy) > DIR_THR) {
+                    touchTracking = false; // 縦スクロール → 解除
+                    main.style.transition = '';
+                    return;
+                }
+            }
+
+            if (touchSwiping) {
+                e.preventDefault();
+                var base = card.classList.contains('swipe-open') ? -OPEN_WIDTH : 0;
+                var x    = Math.max(-OPEN_WIDTH, Math.min(0, base + dx));
+                main.style.transform = 'translateX(' + x + 'px)';
+            }
+        }, { passive: false });
+
+        main.addEventListener('touchend', function (e) {
+            if (!touchTracking) return;
+            touchTracking = false;
+            main.style.transition = '';
+            if (!touchSwiping) return;
+
+            var dx     = e.changedTouches[0].clientX - touchStartX;
+            var isOpen = card.classList.contains('swipe-open');
+
+            main.style.transform = '';
+            if (!isOpen && dx < -SNAP_THR) {
+                card.classList.add('swipe-open');
+                openCard = card;
+            } else if (isOpen && dx > SNAP_THR) {
+                closeCard(card);
+            }
+        }, { passive: true });
+
+        // ----- マウス（デスクトップ） -----
+        var mouseStartX, mouseTracking = false, mouseSwiping = false;
+
+        main.addEventListener('mousedown', function (e) {
+            if (e.target.closest('.drag-handle') || e.button !== 0) return;
+            mouseStartX   = e.clientX;
+            mouseTracking = true;
+            mouseSwiping  = false;
+            main.style.transition = 'none';
+
+            document.addEventListener('mousemove', onMouseMove);
+            document.addEventListener('mouseup',   onMouseUp, { once: true });
+        });
+
+        function onMouseMove(e) {
+            if (!mouseTracking) return;
+            var dx = e.clientX - mouseStartX;
+
+            if (!mouseSwiping && Math.abs(dx) > DIR_THR) {
+                mouseSwiping = true;
+                if (openCard && openCard !== card) closeCard(openCard);
+            }
+            if (mouseSwiping) {
+                var base = card.classList.contains('swipe-open') ? -OPEN_WIDTH : 0;
+                var x    = Math.max(-OPEN_WIDTH, Math.min(0, base + dx));
+                main.style.transform = 'translateX(' + x + 'px)';
+            }
+        }
+
+        function onMouseUp(e) {
+            document.removeEventListener('mousemove', onMouseMove);
+            if (!mouseTracking) return;
+            mouseTracking = false;
+            main.style.transition = '';
+            if (!mouseSwiping) return;
+
+            var dx     = e.clientX - mouseStartX;
+            var isOpen = card.classList.contains('swipe-open');
+
+            main.style.transform = '';
+            if (!isOpen && dx < -SNAP_THR) {
+                card.classList.add('swipe-open');
+                openCard = card;
+            } else if (isOpen && dx > SNAP_THR) {
+                closeCard(card);
+            }
+        }
+    });
+
+    // カード外タップでアクションを閉じる
+    document.addEventListener('click', function (e) {
+        if (openCard && !e.target.closest('.request-card')) {
+            closeCard(openCard);
+        }
+    });
+}
+
+// ---- アクション実行 ----
+function playNext(id, songfile) {
+    fetch('delete.php?id=' + id + '&warikomi=warikomi&songfile=' + encodeURIComponent(songfile))
+        .then(function () {
+            if (openCard) closeCard(openCard);
+            loadList();
+        })
+        .catch(function (e) { console.error('playNext error:', e); });
+}
+
+function deleteItem(id, songfile) {
+    if (!confirm('削除しますか？')) return;
+    var fd = new FormData();
+    fd.append('id',       id);
+    fd.append('songfile', songfile);
+    fd.append('delete',   'delete');
+    fetch('delete.php', { method: 'POST', body: fd })
+        .then(function () {
+            if (openCard) closeCard(openCard);
+            loadList();
+        })
+        .catch(function (e) { console.error('deleteItem error:', e); });
+}
+
+// ---- イベント委譲（アクションボタン） ----
+document.getElementById('request-list').addEventListener('click', function (e) {
+    var btn = e.target.closest('.action-btn');
+    if (!btn) return;
+    var id       = parseInt(btn.dataset.id, 10);
+    var songfile = btn.dataset.songfile;
+    if (btn.classList.contains('action-next'))   playNext(id, songfile);
+    if (btn.classList.contains('action-delete')) deleteItem(id, songfile);
+});
+
+// ---- 更新ボタン ----
+document.getElementById('refresh-btn').addEventListener('click', loadList);
+
+// ---- 自動リロード ----
+function shouldAutoReload() {
+    var cb = document.getElementById('autoreload');
+    return !cb || cb.checked;
+}
+
+function initAutoReload() {
+    if (RELOAD_INTERVAL <= 0 && !USE_ACTIVE_RELOAD) return;
+
+    if (USE_ACTIVE_RELOAD) {
+        var ES = window.EventSource || window.MozEventSource;
+        if (!ES) {
+            // フォールバック：タイマー
+            if (RELOAD_INTERVAL > 0) {
+                setInterval(function () {
+                    if (!isDragging && shouldAutoReload()) loadList();
+                }, RELOAD_INTERVAL);
+            }
+            return;
+        }
+        var source  = new ES('requestlist_event.php?kind=requestlist');
+        var lastkey = 0;
+        source.onmessage = function (e) {
+            if (e.data === 'Bye') { source.close(); return; }
+            var nowkey = e.data;
+            if (nowkey && nowkey !== 'None' && lastkey !== nowkey) {
+                if (!isDragging && shouldAutoReload()) loadList();
+                lastkey = nowkey;
+            }
+        };
+    } else {
+        setInterval(function () {
+            if (!isDragging && shouldAutoReload()) loadList();
+        }, RELOAD_INTERVAL);
+    }
+}
+
+// ---- 初期化 ----
+loadList();
+initAutoReload();
+</script>
+</body>
+</html>

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -218,6 +218,14 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
   border-left: 1px solid #ccc;
 }
 
+@keyframes playing-pulse {
+  0%, 100% { box-shadow: 0 1px 3px rgba(0,0,0,0.15); }
+  40%       { box-shadow: 0 0 0 4px rgba(230,126,34,0.6); }
+}
+.highlight-playing {
+  animation: playing-pulse 0.7s ease 3;
+}
+
 #empty-msg {
   text-align: center;
   color: #aaa;
@@ -258,6 +266,7 @@ if (!empty($config_ini['noticeof_listpage'])) {
   <div class="toolbar-left">
     <h4>現在の登録状況</h4>
     <button class="btn btn-default btn-xs" id="refresh-btn">更新</button>
+    <button class="btn btn-warning btn-xs" id="goto-playing-btn">&#9654; 再生中へ</button>
   </div>
   <div class="toolbar-right">
     <a href="simplelistexport_utf8.php" class="btn btn-default btn-xs">リクエストリストCSV</a>
@@ -865,8 +874,54 @@ document.getElementById('request-list').addEventListener('click', function (e) {
     if (e.target.closest('.song-start-btn')) { songStart(); return; }
 });
 
+// ---- 再生中カードを探すセレクタ ----
+var PLAYING_SEL = [
+    '[data-nowplaying="再生中"]',
+    '[data-nowplaying="2"]',
+    '[data-nowplaying="再生開始待ち"]',
+    '[data-nowplaying="6"]'
+].join(',');
+
+function scrollToPlayingCard() {
+    var card = document.querySelector(PLAYING_SEL);
+    if (!card) return false;
+    card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    card.classList.remove('highlight-playing');
+    // リフロー強制してアニメーションをリセット
+    void card.offsetWidth;
+    card.classList.add('highlight-playing');
+    card.addEventListener('animationend', function () {
+        card.classList.remove('highlight-playing');
+    }, { once: true });
+    return true;
+}
+
+function goToPlaying() {
+    if (scrollToPlayingCard()) return;
+    // 表示されていない場合は全件ロードして探す
+    var prevLimit = currentLimit;
+    currentLimit = 0;
+    var countSel = document.getElementById('count-select');
+    if (countSel) countSel.value = '0';
+    fetch(buildUrl(0, 0))
+        .then(function (res) { return res.ok ? res.json() : Promise.reject(res.status); })
+        .then(function (data) {
+            renderList(data.items, data.total, data.has_more);
+            if (!scrollToPlayingCard()) {
+                // 再生中なし：元の件数に戻す
+                currentLimit = prevLimit;
+                if (countSel) countSel.value = String(prevLimit);
+                loadList(true);
+            }
+        })
+        .catch(function (e) { console.error('goToPlaying error:', e); });
+}
+
 // ---- 更新ボタン ----
 document.getElementById('refresh-btn').addEventListener('click', function () { loadList(true); });
+
+// ---- 再生中へボタン ----
+document.getElementById('goto-playing-btn').addEventListener('click', goToPlaying);
 
 // ---- もっと見るボタン ----
 document.getElementById('load-more-btn').addEventListener('click', function () { loadList(false); });

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -218,19 +218,24 @@ function esc(str) {
 }
 
 var STATUS_CLASS = {
-    '未再生':       'default',
-    '再生中':       'success',
-    '停止中':       'warning',
-    '再生済':       'info',
-    '再生済？':     'info',
-    '再生開始待ち': 'warning',
-    '変更中':       'danger'
+    // 数値コード
+    '1': 'default',  '2': 'success', '3': 'warning',
+    '4': 'info',     '5': 'info',    '6': 'warning',  '7': 'danger',
+    // 日本語テキスト（既存DBとの互換）
+    '未再生': 'default', '再生中': 'success',    '停止中': 'warning',
+    '再生済': 'info',    '再生済？': 'info',     '再生開始待ち': 'warning',
+    '変更中': 'danger'
+};
+var STATUS_LABEL = {
+    '1': '未再生', '2': '再生中',    '3': '停止中',
+    '4': '再生済', '5': '再生済？',  '6': '再生開始待ち', '7': '変更中'
 };
 
 function statusBadge(nowplaying) {
     if (!nowplaying) return '';
-    var cls = STATUS_CLASS[nowplaying] || 'default';
-    return '<span class="label label-' + cls + '">' + esc(nowplaying) + '</span>';
+    var cls   = STATUS_CLASS[String(nowplaying)] || 'default';
+    var label = STATUS_LABEL[String(nowplaying)] || nowplaying; // 数値なら日本語に変換、テキストはそのまま
+    return '<span class="label label-' + cls + '">' + esc(label) + '</span>';
 }
 
 // ---- カード HTML 生成 ----

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -210,7 +210,13 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
   gap: 6px;
   flex-wrap: wrap;
 }
-#count-select { width: auto; display: inline-block; }
+#count-select {
+  width: auto;
+  display: inline-block;
+  margin-left: 10px;
+  padding-left: 10px;
+  border-left: 1px solid #ccc;
+}
 
 #empty-msg {
   text-align: center;
@@ -254,6 +260,8 @@ if (!empty($config_ini['noticeof_listpage'])) {
     <button class="btn btn-default btn-xs" id="refresh-btn">更新</button>
   </div>
   <div class="toolbar-right">
+    <a href="simplelistexport_utf8.php" class="btn btn-default btn-xs">リクエストリストCSV</a>
+    <a href="simplelist.php" class="btn btn-default btn-xs">シンプルリスト</a>
 <?php if ($requestlist_num > 0): ?>
     <select id="count-select" class="form-control input-sm">
       <option value="<?php echo $requestlist_num; ?>"><?php echo $requestlist_num; ?>件</option>
@@ -261,8 +269,6 @@ if (!empty($config_ini['noticeof_listpage'])) {
       <option value="0">ALL</option>
     </select>
 <?php endif; ?>
-    <a href="simplelistexport_utf8.php" class="btn btn-default btn-xs">リクエストリストCSV</a>
-    <a href="simplelist.php" class="btn btn-default btn-xs">シンプルリスト</a>
   </div>
 </div>
 

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -123,17 +123,17 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
 .card-title {
   font-size: 15px;
   font-weight: bold;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  word-break: break-all;
+  line-height: 1.4;
 }
 .card-meta {
   font-size: 12px;
   color: #888;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin-top: 2px;
+  margin-top: 3px;
+}
+.card-label {
+  color: #bbb;
+  font-size: 11px;
 }
 
 /* 右カラム（バッジ＋曲終了ボタン） */
@@ -282,12 +282,7 @@ if (!empty($config_ini['noticeof_listpage'])) {
       <div class="modal-body">
         <select class="form-control" id="status-select">
           <option value="未再生">未再生</option>
-          <option value="再生中">再生中</option>
-          <option value="停止中">停止中</option>
           <option value="再生済">再生済</option>
-          <option value="再生済？">再生済？</option>
-          <option value="再生開始待ち">再生開始待ち</option>
-          <option value="変更中">変更中</option>
         </select>
       </div>
       <div class="modal-footer">
@@ -422,7 +417,7 @@ function createCardHTML(item) {
         '    <span class="drag-handle">&#8942;</span>',
         '    <div class="card-info">',
         '      <div class="card-title">' + esc(item.display_name) + '</div>',
-        '      <div class="card-meta">'  + esc(item.singer)       + '</div>',
+        '      <div class="card-meta"><span class="card-label">登録者：</span>' + esc(item.singer) + '　<span class="card-label">再生方法：</span>' + esc(item.kind) + '</div>',
         '      ' + commentHtml,
         '      ' + tweetHtml,
         '    </div>',

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -22,6 +22,7 @@ $connectinternet = isset($config_ini['connectinternet']) ? (int)$config_ini['con
 $useposttwitter  = configbool('useposttwitter', true);
 $playmode        = isset($config_ini['playmode']) ? (int)$config_ini['playmode'] : 3;
 $usebgv          = isset($config_ini['usebgv']) ? (int)$config_ini['usebgv'] : 2;
+$isAdmin         = ($user === 'admin');
 ?>
 <!DOCTYPE html>
 <html lang="ja">
@@ -231,6 +232,13 @@ if (!empty($config_ini['noticeof_listpage'])) {
 <div id="request-list"></div>
 <div id="empty-msg" style="display:none">リクエストはありません</div>
 
+<hr>
+<form method="get" action="simplelistexport_utf8.php">
+  <input type="submit" class="btn btn-primary" value="リクエストリスト(CSV)のダウンロード">
+  &nbsp;
+  <a href="simplelist.php" class="btn btn-primary">シンプルリクエストリスト表示(コピペ・公開用)</a>
+</form>
+
 </div><!-- /.container -->
 
 <!-- コメント編集モーダル -->
@@ -303,6 +311,7 @@ var CONNECT_INTERNET   = <?php echo $connectinternet; ?>;
 var USE_POST_TWITTER   = <?php echo $useposttwitter ? 'true' : 'false'; ?>;
 var PLAYMODE           = <?php echo $playmode; ?>;
 var USE_BGV            = <?php echo ($usebgv == 1) ? 'true' : 'false'; ?>;
+var IS_ADMIN           = <?php echo $isAdmin ? 'true' : 'false'; ?>;
 
 // ---- 状態 ----
 var openCard   = null;
@@ -369,6 +378,16 @@ function createCardHTML(item) {
     }
     commentHtml += '</div>';
 
+    // 管理者用「変更」ボタン
+    var changeBtn = '';
+    if (IS_ADMIN) {
+        changeBtn = '<form method="post" action="change.php" style="margin:0">'
+            + '<input type="hidden" name="id" value="' + item.id + '">'
+            + '<input type="hidden" name="songfile" value="' + esc(item.songfile) + '">'
+            + '<button type="submit" class="btn btn-default btn-xs card-ctrl-btn">変更</button>'
+            + '</form>';
+    }
+
     // 曲終了 / 曲開始ボタン
     var ctrlBtn = '';
     if (isPlaying(item.nowplaying)) {
@@ -430,6 +449,7 @@ function createCardHTML(item) {
         '        ' + statusBadge(item.nowplaying),
         '      </span>',
         '      ' + ctrlBtn,
+        '      ' + changeBtn,
         '    </div>',
         '  </div>',
         '</div>'

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -190,20 +190,15 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
 
 /* ヘッダ行 */
 .list-toolbar {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 6px;
   margin-bottom: 4px;
 }
 .toolbar-left {
   display: flex;
   align-items: center;
   gap: 6px;
-  flex: 1;
-  min-width: 0;
+  margin-bottom: 6px;
 }
-.toolbar-left h4 { margin: 0; white-space: nowrap; }
+.toolbar-left h4 { margin: 0; flex: 1; }
 .toolbar-right {
   display: flex;
   align-items: center;

--- a/requestlist_swipe_json.php
+++ b/requestlist_swipe_json.php
@@ -35,7 +35,7 @@ foreach ($rows as $row) {
         'singer'       => $row['singer'] ?? '',
         'comment'      => $row['comment'] ?? '',
         'kind'         => $row['kind'] ?? '',
-        'nowplaying'   => $row['nowplaying'] ?? '1',
+        'nowplaying'   => !empty($row['nowplaying']) ? $row['nowplaying'] : '1',
     ];
 }
 

--- a/requestlist_swipe_json.php
+++ b/requestlist_swipe_json.php
@@ -1,0 +1,42 @@
+<?php
+require_once 'commonfunc.php';
+require_once 'easyauth_class.php';
+$easyauth = new EasyAuth();
+$easyauth->do_eashauthcheck();
+
+header('Content-Type: application/json; charset=utf-8');
+
+try {
+    $stmt = $db->prepare(
+        "SELECT id, songfile, singer, comment, kind, reqorder, nowplaying, secret " .
+        "FROM requesttable ORDER BY reqorder DESC"
+    );
+    $stmt->execute();
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->closeCursor();
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'DB error']);
+    exit;
+}
+
+$items = [];
+foreach ($rows as $row) {
+    $songfile = $row['songfile'];
+    $display_name = $songfile;
+    if (!empty($row['secret']) && $row['secret'] == 1) {
+        $display_name = mb_substr($songfile, 0, 1) . '***';
+    }
+    $items[] = [
+        'id'           => (int)$row['id'],
+        'reqorder'     => (int)$row['reqorder'],
+        'songfile'     => $songfile,
+        'display_name' => $display_name,
+        'singer'       => $row['singer'] ?? '',
+        'comment'      => $row['comment'] ?? '',
+        'kind'         => $row['kind'] ?? '',
+        'nowplaying'   => $row['nowplaying'] ?? '1',
+    ];
+}
+
+echo json_encode($items, JSON_UNESCAPED_UNICODE);

--- a/requestlist_swipe_json.php
+++ b/requestlist_swipe_json.php
@@ -6,11 +6,20 @@ $easyauth->do_eashauthcheck();
 
 header('Content-Type: application/json; charset=utf-8');
 
+$limit  = isset($_GET['limit'])  && ctype_digit($_GET['limit'])  ? (int)$_GET['limit']  : 0;
+$offset = isset($_GET['offset']) && ctype_digit($_GET['offset']) ? (int)$_GET['offset'] : 0;
+
 try {
-    $stmt = $db->prepare(
-        "SELECT id, songfile, singer, comment, kind, reqorder, nowplaying, secret " .
-        "FROM requesttable ORDER BY reqorder DESC"
-    );
+    $total = (int)$db->query("SELECT COUNT(*) FROM requesttable")->fetchColumn();
+
+    $sql = "SELECT id, songfile, singer, comment, kind, reqorder, nowplaying, secret FROM requesttable ORDER BY reqorder DESC";
+    if ($limit > 0) {
+        $stmt = $db->prepare($sql . " LIMIT :limit OFFSET :offset");
+        $stmt->bindValue(':limit',  $limit,  PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+    } else {
+        $stmt = $db->prepare($sql);
+    }
     $stmt->execute();
     $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
     $stmt->closeCursor();
@@ -22,7 +31,7 @@ try {
 
 $items = [];
 foreach ($rows as $row) {
-    $songfile = $row['songfile'];
+    $songfile     = $row['songfile'];
     $display_name = $songfile;
     if (!empty($row['secret']) && $row['secret'] == 1) {
         $display_name = mb_substr($songfile, 0, 1) . '***';
@@ -39,4 +48,10 @@ foreach ($rows as $row) {
     ];
 }
 
-echo json_encode($items, JSON_UNESCAPED_UNICODE);
+$has_more = ($limit > 0) && (($offset + count($items)) < $total);
+
+echo json_encode([
+    'items'    => $items,
+    'total'    => $total,
+    'has_more' => $has_more,
+], JSON_UNESCAPED_UNICODE);

--- a/requestlist_top.php
+++ b/requestlist_top.php
@@ -10,6 +10,9 @@ if (array_key_exists('easypass', $_REQUEST)) {
 if (array_key_exists('showid', $_REQUEST) && ctype_digit($_REQUEST['showid'])) {
     $params[] = 'showid=' . $_REQUEST['showid'];
 }
+if (array_key_exists('username', $_REQUEST)) {
+    $params[] = 'username=' . urlencode($_REQUEST['username']);
+}
 if (!empty($params)) {
     $target .= '?' . implode('&', $params);
 }

--- a/requestlist_top.php
+++ b/requestlist_top.php
@@ -7,6 +7,9 @@ $params = [];
 if (array_key_exists('easypass', $_REQUEST)) {
     $params[] = 'easypass=' . urlencode($_REQUEST['easypass']);
 }
+if (array_key_exists('showid', $_REQUEST) && ctype_digit($_REQUEST['showid'])) {
+    $params[] = 'showid=' . $_REQUEST['showid'];
+}
 if (!empty($params)) {
     $target .= '?' . implode('&', $params);
 }

--- a/requestlist_top.php
+++ b/requestlist_top.php
@@ -1,0 +1,15 @@
+<?php
+$config = file_exists('config.ini') ? parse_ini_file('config.ini') : [];
+$useNew = isset($config['usenewrequestlist']) && $config['usenewrequestlist'] == '1';
+$target = $useNew ? 'requestlist_swipe.php' : 'requestlist_only.php';
+
+$params = [];
+if (array_key_exists('easypass', $_REQUEST)) {
+    $params[] = 'easypass=' . urlencode($_REQUEST['easypass']);
+}
+if (!empty($params)) {
+    $target .= '?' . implode('&', $params);
+}
+
+header('Location: ' . $target);
+exit();

--- a/search.php
+++ b/search.php
@@ -214,7 +214,7 @@ EOM;
 print '<hr />';
 if($connectinternet != 1){
 print <<<EOM
-<a href="requestlist_only.php" >トップに戻る </a>
+<a href="requestlist_top.php" >トップに戻る </a>
 
 </body>
 </html>

--- a/search_anisoninfo.php
+++ b/search_anisoninfo.php
@@ -146,7 +146,7 @@ if(!isset($l_url)  ) {
 通常検索に戻る
 </button> 
 
-<button type="button" onclick="location.href='requestlist_only.php' " class="btn btn-default " >
+<button type="button" onclick="location.href='requestlist_top.php' " class="btn btn-default " >
 トップに戻る
 </button> 
 </body>

--- a/search_bgv.php
+++ b/search_bgv.php
@@ -100,7 +100,7 @@ shownavigatioinbar('searchreserve.php');
 <?php
 if($connectinternet != 1){
 print <<<EOM
-<a href="requestlist_only.php" >トップに戻る </a>
+<a href="requestlist_top.php" >トップに戻る </a>
 </body>
 </html>
 EOM;

--- a/searchbandit.php
+++ b/searchbandit.php
@@ -30,7 +30,7 @@
 通常検索に戻る
 </button> 
 
-<button type="button" onclick="location.href='requestlist_only.php' " class="btn btn-default " >
+<button type="button" onclick="location.href='requestlist_top.php' " class="btn btn-default " >
 トップに戻る
 </button> 
 <br />
@@ -188,7 +188,7 @@ $songnum = 0;
 通常検索に戻る
 </button> 
 
-<button type="button" onclick="location.href='requestlist_only.php' " class="btn btn-default " >
+<button type="button" onclick="location.href='requestlist_top.php' " class="btn btn-default " >
 トップに戻る
 </button> 
 </body>

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -252,7 +252,7 @@ print urlencode($localipurl).'&qrsize='.$l_qrsize;
 	  <a href="?qrsize=16" class="btn btn-default" role="button">大</a>
     </div>
 </div>
-<a href="requestlist_only.php" > リクエストTOPに戻る </a>
+<a href="requestlist_top.php" > リクエストTOPに戻る </a>
 </div>
 </body>
 </html>

--- a/update.php
+++ b/update.php
@@ -159,5 +159,5 @@ if(strlen($updatestring) > 0){
 
 $db = null;
 
-header('Location: requestlist_only.php');
+header('Location: requestlist_top.php');
 exit;


### PR DESCRIPTION
## 概要

`requestlist_only.php`（DataTables）に代わる新しいリクエスト一覧UI `requestlist_swipe.php` を追加します。設定画面（init.php）のスイッチで切り替え可能です。

## 主な新機能

### requestlist_swipe.php（新規）
- **ドラッグハンドル並べ替え**：SortableJS によるドラッグ&ドロップ（`requestlist_reorder.php` に POST）
- **左スワイプアクションメニュー**：曲差し替え・次に再生・削除ボタン、管理者のみ変更ボタン（4番目）
- **コメント表示・編集**：コメント欄タップでモーダル表示
- **再生状況変更**：ステータスバッジタップでモーダル（未再生/再生済のみ選択可）
- **曲終了/曲開始ボタン**：再生中・再生開始待ちに応じて常時表示
- **Tweetリンク**：設定に応じて表示
- **SSE 自動リロード**：requestlist_event.php 対応

### サーバー側ページング
- `requestlist_swipe_json.php`：`limit/offset` パラメータ対応、`{items, total, has_more}` 形式
- 件数選択ドロップダウン（N件 / N*2件 / ALL）を上部ツールバーに配置
- 選択値は Cookie（`swipe_count_limit`）で永続化
- **もっと見る（残りN件）** ボタン

### ナビゲーション改善
- **「再生中へ」ボタン**：未再生が溜まっていても再生中カードへ即スクロール＋オレンジパルスハイライト
- **新規リクエスト後のハイライト**：`exec.php` → `requestlist_top.php?showid=<ID>` 経由でグリーンパルスハイライト
- 上部ツールバー常時2行レイアウト（狭い画面でのボタン重なりを解消）

## リダイレクトシム

- **`requestlist_top.php`（新規）**：設定値に応じて `requestlist_swipe.php` または `requestlist_only.php` へ振り分け
- サイト内の `requestlist_only.php` リンク（26ファイル）をすべて `requestlist_top.php` に置換
- `js/requsetlist_confirm.js`：AJAX成功時のリダイレクト先を `requestlist_top.php` に修正

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `requestlist_swipe.php` | 新規作成（メインUI） |
| `requestlist_swipe_json.php` | 新規作成（JSONエンドポイント） |
| `requestlist_reorder.php` | 新規作成（並べ替えAPI） |
| `requestlist_top.php` | 新規作成（リダイレクトシム） |
| `kara_config.php` | `usenewrequestlist` デフォルト値追加 |
| `init.php` | スワイプUI切り替えラジオボタン追加 |
| `commonfunc.php` | ナビバーのリンクを `requestlist_top.php` に統一 |
| `index.php` | `requestlist_top.php` へシンプルリダイレクト |
| `exec.php` | META refresh に `showid` 付与 |
| `js/requsetlist_confirm.js` | AJAX成功時のリダイレクト先修正 |
| その他22ファイル | `requestlist_only.php` リンクを `requestlist_top.php` に置換 |

https://claude.ai/code/session_01UgBPTmJRxQcv31734Ru2pv