### PR TITLE
再生開始時の音ズレ補正機能を実装

### DIFF
--- a/edit_creator_audiodelay.php
+++ b/edit_creator_audiodelay.php
@@ -34,6 +34,29 @@ function is_local_access_cd() {
     return in_array($remote, ['127.0.0.1', '::1', $server], true);
 }
 
+// りすたーDBから制作者一覧を取得
+$creator_list = [];
+$lister_dbpath = '';
+if (array_key_exists('listerDBPATH', $config_ini)) {
+    $lister_dbpath = urldecode($config_ini['listerDBPATH']);
+}
+if (!empty($lister_dbpath)) {
+    require_once('function_search_listerdb.php');
+    $lister_tmp = new ListerDB();
+    $lister_tmp->listerdbfile = $lister_dbpath;
+    $listerdb_tmp = $lister_tmp->initdb();
+    if ($listerdb_tmp) {
+        $rows = $lister_tmp->select("SELECT DISTINCT found_worker FROM t_found WHERE found_worker != '' ORDER BY found_worker");
+        if (is_array($rows)) {
+            foreach ($rows as $row) {
+                if (!empty($row['found_worker'])) {
+                    $creator_list[] = $row['found_worker'];
+                }
+            }
+        }
+    }
+}
+
 $auth_data     = load_delay_auth($auth_file);
 $password_set  = !empty($auth_data['password_hash']);
 $authenticated = false;
@@ -98,11 +121,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $rules  = load_creator_delays($delay_file);
 
     if ($action === 'add') {
-        $keyword = isset($_POST['keyword']) ? trim($_POST['keyword']) : '';
-        $delay   = isset($_POST['delay'])   ? intval($_POST['delay']) : 0;
-        $fps     = isset($_POST['fps'])     ? trim($_POST['fps'])     : '';
+        $keyword  = isset($_POST['keyword'])   ? trim($_POST['keyword'])   : '';
+        $delay    = isset($_POST['delay'])     ? intval($_POST['delay'])   : 0;
+        $fps      = isset($_POST['fps'])       ? trim($_POST['fps'])       : '';
+        $fps_cond = isset($_POST['fps_cond'])  ? trim($_POST['fps_cond'])  : '以下';
+        if (!in_array($fps_cond, ['以上', '以下'], true)) $fps_cond = '以下';
+
         if ($keyword === '') {
-            $message      = 'キーワード（制作者名）を入力してください';
+            $message      = '制作者名を入力してください';
             $message_type = 'danger';
         } elseif ($delay % 100 !== 0) {
             $message      = '音ズレは100ms単位で指定してください';
@@ -112,8 +138,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $message_type = 'danger';
         } else {
             $rule = ['keyword' => $keyword, 'delay' => $delay];
-            if ($fps !== '' && is_numeric($fps)) {
-                $rule['fps'] = floatval($fps);
+            if ($fps !== '' && is_numeric($fps) && floatval($fps) > 0) {
+                $rule['fps']      = floatval($fps);
+                $rule['fps_cond'] = $fps_cond;
             }
             $rules[] = $rule;
             save_creator_delays($delay_file, $rules);
@@ -177,6 +204,7 @@ $rules = load_creator_delays($delay_file);
 <?php shownavigatioinbar(); ?>
 <div class="container">
   <h1>制作者別音ズレ初期値設定</h1>
+  <p class="text-muted">※ りすたーDB使用時のみ有効です。</p>
 
   <?php if (!empty($message)): ?>
   <div class="alert alert-<?php echo htmlspecialchars($message_type, ENT_QUOTES, 'UTF-8'); ?>">
@@ -188,8 +216,8 @@ $rules = load_creator_delays($delay_file);
   <table class="table table-striped table-bordered">
     <thead>
       <tr>
-        <th class="col-xs-5">制作者名（found_worker）</th>
-        <th class="col-xs-2">FPS条件</th>
+        <th class="col-xs-4">制作者名</th>
+        <th class="col-xs-3">FPS条件</th>
         <th class="col-xs-3">音ズレ初期値</th>
         <th class="col-xs-2">操作</th>
       </tr>
@@ -198,7 +226,14 @@ $rules = load_creator_delays($delay_file);
       <?php foreach ($rules as $i => $rule): ?>
       <tr>
         <td><?php echo htmlspecialchars($rule['keyword'], ENT_QUOTES, 'UTF-8'); ?></td>
-        <td><?php echo isset($rule['fps']) ? htmlspecialchars($rule['fps'], ENT_QUOTES, 'UTF-8').' fps' : '<span class="text-muted">指定なし</span>'; ?></td>
+        <td>
+          <?php if (isset($rule['fps'])): ?>
+            <?php $cond = isset($rule['fps_cond']) ? $rule['fps_cond'] : '以下'; ?>
+            <?php echo htmlspecialchars($rule['fps'], ENT_QUOTES, 'UTF-8'); ?> fps <?php echo htmlspecialchars($cond, ENT_QUOTES, 'UTF-8'); ?>
+          <?php else: ?>
+            <span class="text-muted">指定なし</span>
+          <?php endif; ?>
+        </td>
         <td><?php echo htmlspecialchars($rule['delay'], ENT_QUOTES, 'UTF-8'); ?> ms</td>
         <td>
           <form method="post" action="edit_creator_audiodelay.php" style="margin:0;">
@@ -220,11 +255,25 @@ $rules = load_creator_delays($delay_file);
   <h3>ルール追加</h3>
   <form method="post" action="edit_creator_audiodelay.php">
     <input type="hidden" name="action" value="add">
+
     <div class="form-group">
-      <label>制作者名（found_worker）</label>
-      <input type="text" name="keyword" class="form-control" placeholder="ListerDB の found_worker の値" style="max-width:400px;">
-      <p class="help-block">りすたーDB（ListerDB）の <code>found_worker</code> フィールドと<strong>完全一致</strong>で判定されます。検索画面の制作者名リンクに表示される名前を入力してください。</p>
+      <label>制作者名</label>
+      <?php if (!empty($creator_list)): ?>
+      <select id="creator_select" class="form-control" style="max-width:400px; margin-bottom:6px;"
+              onchange="if(this.value !== '') { document.getElementById('keyword').value = this.value; }">
+        <option value="">-- プルダウンから選択 --</option>
+        <?php foreach ($creator_list as $c): ?>
+        <option value="<?php echo htmlspecialchars($c, ENT_QUOTES, 'UTF-8'); ?>">
+          <?php echo htmlspecialchars($c, ENT_QUOTES, 'UTF-8'); ?>
+        </option>
+        <?php endforeach; ?>
+      </select>
+      <?php endif; ?>
+      <input type="text" name="keyword" id="keyword" class="form-control"
+             placeholder="制作者名を直接入力することもできます" style="max-width:400px;">
+      <p class="help-block">検索画面の制作者名と完全一致で判定されます。</p>
     </div>
+
     <div class="form-group">
       <label>音ズレ初期値 (ms)</label>
       <div class="input-group" style="max-width:200px;">
@@ -233,14 +282,21 @@ $rules = load_creator_delays($delay_file);
       </div>
       <p class="help-block">100ms単位で指定。正の値で映像を遅らせる（音が早い場合）、負の値で音を遅らせる（映像が早い場合）。</p>
     </div>
+
     <div class="form-group">
       <label>FPS条件 <small class="text-muted">（任意）</small></label>
-      <div class="input-group" style="max-width:200px;">
-        <input type="number" name="fps" class="form-control" placeholder="例: 29.97" step="0.01" min="0">
-        <span class="input-group-addon">fps</span>
+      <div style="display:flex; align-items:center; gap:6px; max-width:320px;">
+        <input type="number" name="fps" class="form-control" placeholder="例: 30" step="0.01" min="0" style="max-width:120px;">
+        <span>fps</span>
+        <select name="fps_cond" class="form-control" style="max-width:80px;">
+          <option value="以下">以下</option>
+          <option value="以上">以上</option>
+        </select>
+        <span>の動画に適用</span>
       </div>
-      <p class="help-block">入力した場合、動画のFPSが一致する場合のみ適用されます。空欄にするとFPSに関わらず適用。</p>
+      <p class="help-block">入力した場合、動画のFPSが条件を満たす場合のみ適用されます。空欄にするとFPSに関わらず適用。</p>
     </div>
+
     <button type="submit" class="btn btn-primary">追加</button>
   </form>
 
@@ -250,10 +306,11 @@ $rules = load_creator_delays($delay_file);
     <div class="panel-heading"><strong>この画面の使い方</strong></div>
     <div class="panel-body">
       <ol>
-        <li>制作者名はりすたーDB（ListerDB）の <code>found_worker</code> フィールドと<strong>完全一致</strong>で判定されます。検索画面の制作者名リンクに表示される名前を入力してください。</li>
-        <li>ListerDB を使用していない環境ではこの機能は動作しません（初期値は 0ms になります）。</li>
+        <li>制作者名は検索画面に表示される制作者名と<strong>完全一致</strong>で判定されます。<br>
+            <small class="text-muted">りすたーDBを使用している場合のみ動作します。りすたーDB未使用時は初期値は 0ms になります。</small></li>
         <li>複数のルールが一致する場合、リストの上から順に最初に一致したルールが使用されます。</li>
-        <li>FPS条件を指定すると、動画のフレームレートが一致する場合のみ適用されます（±0.5fps 以内で一致判定）。</li>
+        <li>FPS条件を指定すると、動画のフレームレートが条件を満たす場合のみ適用されます。<br>
+            例：「30fps 以下」と指定すると 30fps 以下の動画にのみ適用されます。</li>
         <li>設定した音ズレ値は予約確認画面の初期値として表示されます。ユーザーが変更することもできます。</li>
         <li>音ズレ値は 100ms 単位で、-9900ms ～ +9900ms の範囲で設定できます。</li>
       </ol>

--- a/edit_creator_audiodelay.php
+++ b/edit_creator_audiodelay.php
@@ -1,0 +1,313 @@
+<?php
+require_once 'commonfunc.php';
+
+$delay_file = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'creator_audiodelay.json';
+$auth_file  = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'creator_audiodelay_auth.json';
+
+function load_creator_delays($file) {
+    if (file_exists($file)) {
+        $data = json_decode(file_get_contents($file), true);
+        if (is_array($data)) return $data;
+    }
+    return [];
+}
+
+function save_creator_delays($file, $rules) {
+    file_put_contents($file, json_encode($rules, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+}
+
+function load_delay_auth($file) {
+    if (file_exists($file)) {
+        $data = json_decode(file_get_contents($file), true);
+        if (is_array($data)) return $data;
+    }
+    return [];
+}
+
+function save_delay_auth($file, $auth_data) {
+    file_put_contents($file, json_encode($auth_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+}
+
+function is_local_access_cd() {
+    $remote = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '';
+    $server = isset($_SERVER['SERVER_ADDR']) ? $_SERVER['SERVER_ADDR'] : '';
+    return in_array($remote, ['127.0.0.1', '::1', $server], true);
+}
+
+$auth_data     = load_delay_auth($auth_file);
+$password_set  = !empty($auth_data['password_hash']);
+$authenticated = false;
+$auth_error    = false;
+
+if (is_local_access_cd() || !$password_set) {
+    $authenticated = true;
+} else {
+    $input_pass = '';
+    if (!empty($_POST['delay_auth_pass'])) {
+        $input_pass = $_POST['delay_auth_pass'];
+    } elseif (isset($_COOKIE['CreatorDelayPass'])) {
+        $input_pass = base64_decode($_COOKIE['CreatorDelayPass']);
+    }
+    if ($input_pass !== '' && password_verify($input_pass, $auth_data['password_hash'])) {
+        setcookie('CreatorDelayPass', base64_encode($input_pass), 0);
+        $authenticated = true;
+    } elseif (!empty($_POST['delay_auth_pass'])) {
+        $auth_error = true;
+    }
+}
+
+if (!$authenticated) {
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>制作者別音ズレ初期値設定 - 認証</title>
+  <link href="css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container" style="max-width:400px; margin-top:80px;">
+  <h2>制作者別音ズレ初期値設定</h2>
+  <p>このページにアクセスするにはパスワードが必要です。</p>
+  <?php if ($auth_error): ?>
+  <div class="alert alert-danger">パスワードが違います。</div>
+  <?php endif; ?>
+  <form method="post" action="edit_creator_audiodelay.php">
+    <div class="form-group">
+      <label for="delay_auth_pass">パスワード</label>
+      <input type="password" name="delay_auth_pass" id="delay_auth_pass" class="form-control" autofocus>
+    </div>
+    <button type="submit" class="btn btn-primary">ログイン</button>
+    <a href="init.php" class="btn btn-default">設定画面に戻る</a>
+  </form>
+</div>
+<script src="js/jquery.js"></script>
+<script src="js/bootstrap.min.js"></script>
+</body>
+</html>
+<?php
+    die();
+}
+
+$message      = '';
+$message_type = 'success';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = isset($_POST['action']) ? $_POST['action'] : '';
+    $rules  = load_creator_delays($delay_file);
+
+    if ($action === 'add') {
+        $keyword = isset($_POST['keyword']) ? trim($_POST['keyword']) : '';
+        $delay   = isset($_POST['delay'])   ? intval($_POST['delay']) : 0;
+        $fps     = isset($_POST['fps'])     ? trim($_POST['fps'])     : '';
+        if ($keyword === '') {
+            $message      = 'キーワード（制作者名）を入力してください';
+            $message_type = 'danger';
+        } elseif ($delay % 100 !== 0) {
+            $message      = '音ズレは100ms単位で指定してください';
+            $message_type = 'danger';
+        } elseif ($delay < -9900 || $delay > 9900) {
+            $message      = '音ズレは -9900ms ～ +9900ms の範囲で指定してください';
+            $message_type = 'danger';
+        } else {
+            $rule = ['keyword' => $keyword, 'delay' => $delay];
+            if ($fps !== '' && is_numeric($fps)) {
+                $rule['fps'] = floatval($fps);
+            }
+            $rules[] = $rule;
+            save_creator_delays($delay_file, $rules);
+            $message = '追加しました';
+        }
+
+    } elseif ($action === 'delete') {
+        $index = isset($_POST['index']) ? intval($_POST['index']) : -1;
+        if ($index >= 0 && $index < count($rules)) {
+            array_splice($rules, $index, 1);
+            save_creator_delays($delay_file, $rules);
+            $message = '削除しました';
+        }
+
+    } elseif ($action === 'clear') {
+        save_creator_delays($delay_file, []);
+        $message = '全ルールを削除しました';
+
+    } elseif ($action === 'set_password') {
+        $new_pass  = isset($_POST['new_password'])  ? $_POST['new_password']  : '';
+        $new_pass2 = isset($_POST['new_password2']) ? $_POST['new_password2'] : '';
+        if ($new_pass === '') {
+            $message = 'パスワードを入力してください';
+            $message_type = 'danger';
+        } elseif ($new_pass !== $new_pass2) {
+            $message = 'パスワードが一致しません';
+            $message_type = 'danger';
+        } else {
+            $auth_data['password_hash'] = password_hash($new_pass, PASSWORD_DEFAULT);
+            save_delay_auth($auth_file, $auth_data);
+            setcookie('CreatorDelayPass', base64_encode($new_pass), 0);
+            $password_set = true;
+            $message = 'パスワードを設定しました';
+        }
+
+    } elseif ($action === 'remove_password') {
+        $auth_data = [];
+        save_delay_auth($auth_file, $auth_data);
+        setcookie('CreatorDelayPass', '', time() - 3600);
+        $password_set = false;
+        $message = 'パスワードを削除しました';
+    }
+}
+
+$rules = load_creator_delays($delay_file);
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<?php print_meta_header(); ?>
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="cache-control" content="no-cache">
+<meta http-equiv="expires" content="0">
+<title>制作者別音ズレ初期値設定</title>
+<link href="css/bootstrap.min.css" rel="stylesheet">
+<link type="text/css" rel="stylesheet" href="css/style.css" />
+<script type="text/javascript" charset="utf8" src="js/jquery.js"></script>
+<script src="js/bootstrap.min.js"></script>
+</head>
+<body>
+<?php shownavigatioinbar(); ?>
+<div class="container">
+  <h1>制作者別音ズレ初期値設定</h1>
+
+  <?php if (!empty($message)): ?>
+  <div class="alert alert-<?php echo htmlspecialchars($message_type, ENT_QUOTES, 'UTF-8'); ?>">
+    <?php echo htmlspecialchars($message, ENT_QUOTES, 'UTF-8'); ?>
+  </div>
+  <?php endif; ?>
+
+  <h3>現在の設定ルール</h3>
+  <table class="table table-striped table-bordered">
+    <thead>
+      <tr>
+        <th class="col-xs-5">制作者名キーワード</th>
+        <th class="col-xs-2">FPS条件</th>
+        <th class="col-xs-3">音ズレ初期値</th>
+        <th class="col-xs-2">操作</th>
+      </tr>
+    </thead>
+    <tbody>
+      <?php foreach ($rules as $i => $rule): ?>
+      <tr>
+        <td><?php echo htmlspecialchars($rule['keyword'], ENT_QUOTES, 'UTF-8'); ?></td>
+        <td><?php echo isset($rule['fps']) ? htmlspecialchars($rule['fps'], ENT_QUOTES, 'UTF-8').' fps' : '<span class="text-muted">指定なし</span>'; ?></td>
+        <td><?php echo htmlspecialchars($rule['delay'], ENT_QUOTES, 'UTF-8'); ?> ms</td>
+        <td>
+          <form method="post" action="edit_creator_audiodelay.php" style="margin:0;">
+            <input type="hidden" name="action" value="delete">
+            <input type="hidden" name="index" value="<?php echo $i; ?>">
+            <button type="submit" class="btn btn-danger btn-xs">削除</button>
+          </form>
+        </td>
+      </tr>
+      <?php endforeach; ?>
+      <?php if (empty($rules)): ?>
+      <tr>
+        <td colspan="4" class="text-center text-muted">ルールが設定されていません</td>
+      </tr>
+      <?php endif; ?>
+    </tbody>
+  </table>
+
+  <h3>ルール追加</h3>
+  <form method="post" action="edit_creator_audiodelay.php">
+    <input type="hidden" name="action" value="add">
+    <div class="form-group">
+      <label>制作者名キーワード</label>
+      <input type="text" name="keyword" class="form-control" placeholder="ファイルパスに含まれる制作者名" style="max-width:400px;">
+      <p class="help-block">動画ファイルのフルパスにこのキーワードが含まれる場合に適用されます。</p>
+    </div>
+    <div class="form-group">
+      <label>音ズレ初期値 (ms)</label>
+      <div class="input-group" style="max-width:200px;">
+        <input type="number" name="delay" class="form-control" value="0" step="100" min="-9900" max="9900">
+        <span class="input-group-addon">ms</span>
+      </div>
+      <p class="help-block">100ms単位で指定。正の値で映像を遅らせる（音が早い場合）、負の値で音を遅らせる（映像が早い場合）。</p>
+    </div>
+    <div class="form-group">
+      <label>FPS条件 <small class="text-muted">（任意）</small></label>
+      <div class="input-group" style="max-width:200px;">
+        <input type="number" name="fps" class="form-control" placeholder="例: 29.97" step="0.01" min="0">
+        <span class="input-group-addon">fps</span>
+      </div>
+      <p class="help-block">入力した場合、動画のFPSが一致する場合のみ適用されます。空欄にするとFPSに関わらず適用。</p>
+    </div>
+    <button type="submit" class="btn btn-primary">追加</button>
+  </form>
+
+  <hr>
+
+  <div class="panel panel-default">
+    <div class="panel-heading"><strong>この画面の使い方</strong></div>
+    <div class="panel-body">
+      <ol>
+        <li>制作者名キーワードは動画ファイルの<strong>フルパスに含まれる文字列</strong>で判定されます（部分一致）。</li>
+        <li>複数のルールが一致する場合、リストの上から順に最初に一致したルールが使用されます。</li>
+        <li>FPS条件を指定すると、動画のフレームレートが一致する場合のみ適用されます（±0.5fps 以内で一致判定）。</li>
+        <li>設定した音ズレ値は予約確認画面の初期値として表示されます。ユーザーが変更することもできます。</li>
+        <li>音ズレ値は 100ms 単位で、-9900ms ～ +9900ms の範囲で設定できます。</li>
+      </ol>
+    </div>
+  </div>
+
+  <form method="post" action="edit_creator_audiodelay.php"
+        onsubmit="return confirm('全ルールを削除しますか？');">
+    <input type="hidden" name="action" value="clear">
+    <button type="submit" class="btn btn-warning">全ルールを削除</button>
+  </form>
+
+  <hr>
+
+  <div class="panel panel-default">
+    <div class="panel-heading"><strong>このページのパスワード設定</strong></div>
+    <div class="panel-body">
+      <p>
+        現在の状態：
+        <?php if ($password_set): ?>
+          <span class="label label-warning">パスワードあり</span>
+          <small class="text-muted">（サーバーと同じ機器からのアクセスはスキップされます）</small>
+        <?php else: ?>
+          <span class="label label-default">パスワードなし（誰でもアクセス可）</span>
+        <?php endif; ?>
+      </p>
+      <form method="post" action="edit_creator_audiodelay.php">
+        <input type="hidden" name="action" value="set_password">
+        <div class="form-group">
+          <label>新しいパスワード</label>
+          <input type="password" name="new_password" class="form-control" style="max-width:300px;">
+        </div>
+        <div class="form-group">
+          <label>確認（もう一度入力）</label>
+          <input type="password" name="new_password2" class="form-control" style="max-width:300px;">
+        </div>
+        <button type="submit" class="btn btn-primary">パスワードを設定する</button>
+      </form>
+      <?php if ($password_set): ?>
+      <hr>
+      <form method="post" action="edit_creator_audiodelay.php"
+            onsubmit="return confirm('パスワードを削除すると誰でもアクセスできるようになります。よろしいですか？');">
+        <input type="hidden" name="action" value="remove_password">
+        <button type="submit" class="btn btn-danger">パスワードを削除する</button>
+      </form>
+      <?php endif; ?>
+    </div>
+  </div>
+
+  <hr>
+  <p>
+    <a href="init.php" class="btn btn-default">設定画面に戻る</a>
+    &nbsp;
+    <a href="requestlist_top.php" class="btn btn-default">トップに戻る</a>
+  </p>
+</div>
+</body>
+</html>

--- a/edit_creator_audiodelay.php
+++ b/edit_creator_audiodelay.php
@@ -188,7 +188,7 @@ $rules = load_creator_delays($delay_file);
   <table class="table table-striped table-bordered">
     <thead>
       <tr>
-        <th class="col-xs-5">制作者名キーワード</th>
+        <th class="col-xs-5">制作者名（found_worker）</th>
         <th class="col-xs-2">FPS条件</th>
         <th class="col-xs-3">音ズレ初期値</th>
         <th class="col-xs-2">操作</th>
@@ -221,9 +221,9 @@ $rules = load_creator_delays($delay_file);
   <form method="post" action="edit_creator_audiodelay.php">
     <input type="hidden" name="action" value="add">
     <div class="form-group">
-      <label>制作者名キーワード</label>
-      <input type="text" name="keyword" class="form-control" placeholder="ファイルパスに含まれる制作者名" style="max-width:400px;">
-      <p class="help-block">動画ファイルのフルパスにこのキーワードが含まれる場合に適用されます。</p>
+      <label>制作者名（found_worker）</label>
+      <input type="text" name="keyword" class="form-control" placeholder="ListerDB の found_worker の値" style="max-width:400px;">
+      <p class="help-block">りすたーDB（ListerDB）の <code>found_worker</code> フィールドと<strong>完全一致</strong>で判定されます。検索画面の制作者名リンクに表示される名前を入力してください。</p>
     </div>
     <div class="form-group">
       <label>音ズレ初期値 (ms)</label>
@@ -250,7 +250,8 @@ $rules = load_creator_delays($delay_file);
     <div class="panel-heading"><strong>この画面の使い方</strong></div>
     <div class="panel-body">
       <ol>
-        <li>制作者名キーワードは動画ファイルの<strong>フルパスに含まれる文字列</strong>で判定されます（部分一致）。</li>
+        <li>制作者名はりすたーDB（ListerDB）の <code>found_worker</code> フィールドと<strong>完全一致</strong>で判定されます。検索画面の制作者名リンクに表示される名前を入力してください。</li>
+        <li>ListerDB を使用していない環境ではこの機能は動作しません（初期値は 0ms になります）。</li>
         <li>複数のルールが一致する場合、リストの上から順に最初に一致したルールが使用されます。</li>
         <li>FPS条件を指定すると、動画のフレームレートが一致する場合のみ適用されます（±0.5fps 以内で一致判定）。</li>
         <li>設定した音ズレ値は予約確認画面の初期値として表示されます。ユーザーが変更することもできます。</li>

--- a/exec.php
+++ b/exec.php
@@ -80,6 +80,14 @@ if(array_key_exists("pause", $_REQUEST)) {
     }
 }
 
+$l_audiodelay = 0;
+if(array_key_exists("audiodelay", $_REQUEST)) {
+    $l_audiodelay = intval($_REQUEST["audiodelay"]);
+    if($l_audiodelay < -9900 || $l_audiodelay > 9900){
+        $l_audiodelay = 0;
+    }
+}
+
 
 if(!empty($l_freesinger)){
 $l_singer=$l_freesinger;
@@ -145,7 +153,7 @@ if($request[0]['nowplaying'] === '再生中' || $request[0]['nowplaying'] === '�
 }
 
 try {
-    $sql = "UPDATE requesttable set songfile=:fn, singer=:sing, comment=:comment, kind=:kind, fullpath=:fp, secret=:secret, loop=:loop, nowplaying=:nowplaying, keychange=:keychange, track=:track, pause=:pause where id = :selectid";
+    $sql = "UPDATE requesttable set songfile=:fn, singer=:sing, comment=:comment, kind=:kind, fullpath=:fp, secret=:secret, loop=:loop, nowplaying=:nowplaying, keychange=:keychange, track=:track, pause=:pause, audiodelay=:audiodelay where id = :selectid";
     $stmt = $db->prepare($sql);
 } catch (PDOException $e) {
 	echo 'Connection failed: ' . $e->getMessage();
@@ -166,11 +174,12 @@ $arg = array(
 	':keychange' => $l_keychange,
 	':track' => $l_track,
 	':pause' => $l_pause,
+	':audiodelay' => $l_audiodelay,
 	':selectid' => (int)$selectid
 	);
 }else {
   try {
-    $sql = "INSERT INTO requesttable (songfile, singer, comment, kind, fullpath, nowplaying, status, clientip, clientua, playtimes, secret, loop, keychange, track, pause) VALUES (:fn, :sing, :comment, :kind, :fp, :np, :status, :ip, :ua, 0 ,:secret,:loop, :keychange, :track, :pause)";
+    $sql = "INSERT INTO requesttable (songfile, singer, comment, kind, fullpath, nowplaying, status, clientip, clientua, playtimes, secret, loop, keychange, track, pause, audiodelay) VALUES (:fn, :sing, :comment, :kind, :fp, :np, :status, :ip, :ua, 0 ,:secret,:loop, :keychange, :track, :pause, :audiodelay)";
     $stmt = $db->prepare($sql);
   } catch (PDOException $e) {
 	echo 'Connection failed: ' . $e->getMessage();
@@ -193,7 +202,8 @@ $arg = array(
 	':loop' => $l_loop,
 	':keychange' => $l_keychange,
 	':track' => $l_track,
-	':pause' => $l_pause
+	':pause' => $l_pause,
+	':audiodelay' => $l_audiodelay
 	);
 }
 $ret = $stmt->execute($arg);

--- a/init.php
+++ b/init.php
@@ -299,8 +299,10 @@ print '</pre>';
     <a href="edit_csv_columns.php" class="btn btn-default" > CSV出力列設定 </a>
   </p>
   <p>
-  <h3>製作者優先表示設定 <small>（りすたーDB検索のみ有効）</small></h3>
+  <h3>製作者別設定 <small>（りすたーDB検索のみ有効）</small></h3>
     <a href="edit_search_sort_priority.php" class="btn btn-default" > 製作者優先表示設定 </a>
+    &nbsp;
+    <a href="edit_creator_audiodelay.php" class="btn btn-default" > 制作者別音ズレ初期値設定 </a>
   </p>
   <p>
   <h3>表示優先度設定 <small>（Everything検索のみ有効）</small></h3>

--- a/kara_config.php
+++ b/kara_config.php
@@ -231,7 +231,8 @@ function updatedb($db){
                   array ( "name" => "loop" , "type" =>  "text") ,
                   array ( "name" => "keychange" , "type" =>  "INTEGER default 0") ,
                   array ( "name" => "track" , "type" =>  "INTEGER default 0") ,
-                  array ( "name" => "pause" , "type" =>  "INTEGER default 0") 
+                  array ( "name" => "pause" , "type" =>  "INTEGER default 0") ,
+                  array ( "name" => "audiodelay" , "type" =>  "INTEGER default 0")
                   );
     /* 現在の項目一覧取得 */
     try {
@@ -294,7 +295,8 @@ $sql = "create table IF NOT EXISTS requesttable (
  loop INTEGER,
  keychange INTEGER default 0,
  track INTEGER default 0,
- pause INTEGER default 0
+ pause INTEGER default 0,
+ audiodelay INTEGER default 0
 )";
 $stmt = $db->query($sql);
 if ($stmt === false ){

--- a/manage-mpc.php
+++ b/manage-mpc.php
@@ -1019,7 +1019,14 @@ function start_song($db,$id,$addplaytimes = 0){
             if(array_key_exists("keychange" , $row)){
                 mpc_keychange($row["keychange"]);
             }
-echo "\n".date("H時i分s秒" )."sleep ".__LINE__;
+            if(array_key_exists("audiodelay" , $row) && intval($row["audiodelay"]) !== 0){
+                $delay_steps = intval($row["audiodelay"]) / 100;
+                if($delay_steps > 0){
+                    for($di = 0; $di < $delay_steps; $di++) delay_plus100_mpc();
+                } else {
+                    for($di = 0; $di < abs($delay_steps); $di++) delay_minus100_mpc();
+                }
+            }
 
             /* track change */
             // BGVモードではmuteにする。
@@ -1170,7 +1177,6 @@ function runningcheck_mpc($db,$id,$playerchecktimes,$commenturl){
        $totaltime = $totaltime_a[0]*60*60 + $totaltime_a[1]*60 + $totaltime_a[2];
        //★ 終了時間を丁度に変更
        if($startonce && ( $playtime == $totaltime ) ){  //★
-echo "\n".date("H時i分s秒" )."sleep ".__LINE__;
            sleep(2);
            commentpost_v4("rqlst", "1", $commenturl);  //★
            break;  //★
@@ -1181,7 +1187,6 @@ echo "\n".date("H時i分s秒" )."sleep ".__LINE__;
        workcheck_pfwd();
        workcheck_andrestartxampp();
 
-echo "\n".date("H時i分s秒" )."sleep ".__LINE__;
        sleep(1.0);
    }
 }

--- a/request_confirm.php
+++ b/request_confirm.php
@@ -557,23 +557,42 @@ if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8)) {
 }
 
 <?php
-// 制作者別音ズレデフォルト値を取得
+// 制作者別音ズレデフォルト値を取得（ListerDB の found_worker と完全一致で判定）
 $audiodelay_init = 0;
 if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8)) {
     $delay_file = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'creator_audiodelay.json';
     if (file_exists($delay_file)) {
         $delay_rules = json_decode(file_get_contents($delay_file), true);
-        if (is_array($delay_rules)) {
-            $vd_fps = isset($videodetails['frame_rate']) ? floatval($videodetails['frame_rate']) : null;
-            foreach ($delay_rules as $drule) {
-                $dk = isset($drule['keyword']) ? $drule['keyword'] : '';
-                if ($dk === '') continue;
-                if (mb_strpos($fullpath_utf8, $dk) === false) continue;
-                if (!empty($drule['fps']) && $vd_fps !== null) {
-                    if (abs(floatval($drule['fps']) - $vd_fps) > 0.5) continue;
+        if (is_array($delay_rules) && !empty($delay_rules)) {
+            // ListerDB から found_worker を取得
+            $found_worker = '';
+            if (!empty($lister_dbpath)) {
+                require_once('function_search_listerdb.php');
+                $lister = new ListerDB();
+                $lister->listerdbfile = $lister_dbpath;
+                $listerdb = $lister->initdb();
+                if ($listerdb) {
+                    $songbasename = basename($fullpath_utf8);
+                    $sql = 'SELECT found_worker FROM t_found WHERE found_path LIKE '
+                         . $listerdb->quote('%' . $songbasename . '%') . ' LIMIT 1';
+                    $rows = $lister->select($sql);
+                    if (!empty($rows) && isset($rows[0]['found_worker'])) {
+                        $found_worker = $rows[0]['found_worker'];
+                    }
                 }
-                $audiodelay_init = isset($drule['delay']) ? intval($drule['delay']) : 0;
-                break;
+            }
+            if ($found_worker !== '') {
+                $vd_fps = isset($videodetails['frame_rate']) ? floatval($videodetails['frame_rate']) : null;
+                foreach ($delay_rules as $drule) {
+                    $dk = isset($drule['keyword']) ? $drule['keyword'] : '';
+                    if ($dk === '') continue;
+                    if ($found_worker !== $dk) continue;
+                    if (!empty($drule['fps']) && $vd_fps !== null) {
+                        if (abs(floatval($drule['fps']) - $vd_fps) > 0.5) continue;
+                    }
+                    $audiodelay_init = isset($drule['delay']) ? intval($drule['delay']) : 0;
+                    break;
+                }
             }
         }
     }

--- a/request_confirm.php
+++ b/request_confirm.php
@@ -527,6 +527,7 @@ EOT;
 EOT;
 }
 
+$videodetails = array();
 if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8)) {
     $videodetails = getvideodetails($fullpath_utf8);
     if (!empty($videodetails)) {
@@ -555,8 +556,50 @@ if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8)) {
     }
 }
 
+<?php
+// 制作者別音ズレデフォルト値を取得
+$audiodelay_init = 0;
+if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8)) {
+    $delay_file = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'creator_audiodelay.json';
+    if (file_exists($delay_file)) {
+        $delay_rules = json_decode(file_get_contents($delay_file), true);
+        if (is_array($delay_rules)) {
+            $vd_fps = isset($videodetails['frame_rate']) ? floatval($videodetails['frame_rate']) : null;
+            foreach ($delay_rules as $drule) {
+                $dk = isset($drule['keyword']) ? $drule['keyword'] : '';
+                if ($dk === '') continue;
+                if (mb_strpos($fullpath_utf8, $dk) === false) continue;
+                if (!empty($drule['fps']) && $vd_fps !== null) {
+                    if (abs(floatval($drule['fps']) - $vd_fps) > 0.5) continue;
+                }
+                $audiodelay_init = isset($drule['delay']) ? intval($drule['delay']) : 0;
+                break;
+            }
+        }
+    }
+}
 ?>
-
+<?php if ($shop_karaoke != 1 && $filetype == 1): ?>
+<div style="margin-top:8px; margin-bottom:4px; color:#888;">
+  <small>音ズレ補正：
+  <button type="button" class="btn btn-default btn-xs" onclick="changeAudioDelay(-100)">-100ms</button>
+  <span id="audiodelay_disp" style="display:inline-block; min-width:65px; text-align:center;"><?php echo intval($audiodelay_init); ?> ms</span>
+  <button type="button" class="btn btn-default btn-xs" onclick="changeAudioDelay(100)">+100ms</button>
+  <input type="hidden" name="audiodelay" id="audiodelay_val" value="<?php echo intval($audiodelay_init); ?>" />
+  </small>
+</div>
+<script>
+function changeAudioDelay(delta){
+  var inp = document.getElementById('audiodelay_val');
+  var disp = document.getElementById('audiodelay_disp');
+  var v = parseInt(inp.value, 10) + delta;
+  if(v < -9900) v = -9900;
+  if(v > 9900) v = 9900;
+  inp.value = v;
+  disp.textContent = v + ' ms';
+}
+</script>
+<?php endif; ?>
 
 <!-----
 <select name="kind">

--- a/request_confirm.php
+++ b/request_confirm.php
@@ -556,7 +556,6 @@ if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8)) {
     }
 }
 
-<?php
 // 制作者別音ズレデフォルト値を取得（ListerDB の found_worker と完全一致で判定）
 $audiodelay_init = 0;
 if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8)) {

--- a/request_confirm.php
+++ b/request_confirm.php
@@ -588,7 +588,13 @@ if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8)) {
                     if ($dk === '') continue;
                     if ($found_worker !== $dk) continue;
                     if (!empty($drule['fps']) && $vd_fps !== null) {
-                        if (abs(floatval($drule['fps']) - $vd_fps) > 0.5) continue;
+                        $rule_fps  = floatval($drule['fps']);
+                        $fps_cond  = isset($drule['fps_cond']) ? $drule['fps_cond'] : '以下';
+                        if ($fps_cond === '以上') {
+                            if ($vd_fps < $rule_fps) continue;
+                        } else {
+                            if ($vd_fps > $rule_fps) continue;
+                        }
                     }
                     $audiodelay_init = isset($drule['delay']) ? intval($drule['delay']) : 0;
                     break;

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -487,6 +487,24 @@ function createCardHTML(item) {
         '    </button>'
     ].join('\n') : '';
 
+    // トラック・キー・音ズレ（デフォルト値と異なる場合のみ表示）
+    var extras = [];
+    var track = parseInt(item.track, 10);
+    var keychange = parseInt(item.keychange, 10);
+    var audiodelay = parseInt(item.audiodelay, 10);
+    if (track > 0) {
+        extras.push('<span class="card-label">トラック：</span>' + (track + 1));
+    }
+    if (keychange !== 0) {
+        extras.push('<span class="card-label">キー：</span>' + (keychange > 0 ? '+' : '') + keychange);
+    }
+    if (audiodelay !== 0) {
+        extras.push('<span class="card-label">音ズレ：</span>' + (audiodelay > 0 ? '+' : '') + audiodelay + 'ms');
+    }
+    var extraMetaHtml = extras.length > 0
+        ? '<div class="card-meta" style="font-size:12px;">' + extras.join('　') + '</div>'
+        : '';
+
     return [
         '<div class="request-card' + (IS_ADMIN ? ' admin-card' : '') + '"',
         '     data-id="'       + item.id              + '"',
@@ -516,6 +534,7 @@ function createCardHTML(item) {
         '    <div class="card-info">',
         '      <div class="card-title">' + esc(item.display_name) + '</div>',
         '      <div class="card-meta"><span class="card-label">登録者：</span>' + esc(item.singer) + '　<span class="card-label">再生方法：</span>' + esc(item.kind) + '</div>',
+        '      ' + extraMetaHtml,
         '      ' + commentHtml,
         '      ' + tweetHtml,
         '    </div>',

--- a/requestlist_swipe_json.php
+++ b/requestlist_swipe_json.php
@@ -12,7 +12,7 @@ $offset = isset($_GET['offset']) && ctype_digit($_GET['offset']) ? (int)$_GET['o
 try {
     $total = (int)$db->query("SELECT COUNT(*) FROM requesttable")->fetchColumn();
 
-    $sql = "SELECT id, songfile, singer, comment, kind, reqorder, nowplaying, secret FROM requesttable ORDER BY reqorder DESC";
+    $sql = "SELECT id, songfile, singer, comment, kind, reqorder, nowplaying, secret, track, keychange, audiodelay FROM requesttable ORDER BY reqorder DESC";
     if ($limit > 0) {
         $stmt = $db->prepare($sql . " LIMIT :limit OFFSET :offset");
         $stmt->bindValue(':limit',  $limit,  PDO::PARAM_INT);
@@ -45,6 +45,9 @@ foreach ($rows as $row) {
         'comment'      => $row['comment'] ?? '',
         'kind'         => $row['kind'] ?? '',
         'nowplaying'   => !empty($row['nowplaying']) ? $row['nowplaying'] : '1',
+        'track'        => (int)($row['track']      ?? 0),
+        'keychange'    => (int)($row['keychange']   ?? 0),
+        'audiodelay'   => (int)($row['audiodelay']  ?? 0),
     ];
 }
 


### PR DESCRIPTION
## Summary

- **DBスキーマ拡張**: `requesttable` に `audiodelay INTEGER default 0` を追加（既存DBへの自動マイグレーション対応）
- **予約確認画面** (`request_confirm.php`): 音ズレ補正UIを追加（-100ms / +100ms ボタン、動画ファイル時のみ表示、目立たない小さめ配置）。りすたーDB使用時は制作者別デフォルト初期値を自動適用
- **制作者別音ズレ初期値設定** (`edit_creator_audiodelay.php` 新規作成): 制作者名（りすたーDBから一覧取得してプルダウン選択も可）・FPS条件（以上/以下）・遅延値を設定。パスワード保護付き
- **設定画面** (`init.php`): 「製作者別設定」セクションに「制作者別音ズレ初期値設定」ボタンを追加
- **再生制御** (`manage-mpc.php`): 再生前のトラック・キー変更処理の直後に `audiodelay` 値を適用（`delay_plus100_mpc` / `delay_minus100_mpc` を必要回数呼び出し）
- **デバッグ出力削除** (`manage-mpc.php`): 再生中に表示されていたタイムスタンプ＋行番号の `echo` 3か所を削除
- **予約一覧スワイプ画面** (`requestlist_swipe.php` / `requestlist_swipe_json.php`): カードにトラック・キー・音ズレをデフォルト値と異なる場合のみ小さい文字で表示

## Test plan

- [ ] 予約確認画面でファイル再生時に「音ズレ補正」UIが表示されること
- [ ] -100ms / +100ms ボタンで値が変化し、予約時にDBに保存されること
- [ ] 再生時に `audiodelay` の値に応じて音ズレ補正が適用されること
- [ ] 制作者別音ズレ初期値設定ページにアクセスできること（りすたーDB使用時は制作者プルダウンが表示される）
- [ ] 設定画面から制作者別音ズレ初期値設定ページへのリンクが機能すること
- [ ] 再生中に「05時57分52秒sleep 1184」のようなデバッグメッセージが表示されないこと
- [ ] スワイプ一覧でトラック・キー・音ズレが非デフォルト値の場合のみ表示されること

https://claude.ai/code/session_016HL2kH3K8rwdghChDCQ3KV