### PR TITLE
検索画面に表示する項目にドラッグハンドルUI・検索画面表示メッセージ追加＋アコーディオン不具合修正

### DIFF
--- a/init.php
+++ b/init.php
@@ -889,11 +889,12 @@ print 'value="'.urldecode($config_ini["max_filesize"]).'"';
 <?php
 
 if(!array_key_exists('searchitem', $config_ini )){
-    $config_ini['searchitem'] = array("filesearch_e", "anisoninfo_e", "bandit_e");
+    $config_ini['searchitem'] = array("searchmessage", "listerDB_file", "listerDB", "filesearch_e");
 }
 
 if(!array_key_exists('searchitem_o', $config_ini )){
-    $config_ini['searchitem_o'] = array("1", "2", "3", "4", "5", "6");
+    // 表示順: searchmessage=1位, listerDB_file=2位, listerDB=3位, filesearch_e=4位, anisoninfo_e=5位, bandit_e=6位
+    $config_ini['searchitem_o'] = array("2", "3", "4", "5", "6", "1");
 }
 
 $searchitem_defs = array(

--- a/init.php
+++ b/init.php
@@ -64,7 +64,7 @@ $(function () {
 })
 
 $(function(){
-	$('a[href^=#]').click(function() {
+	$('a[href^=#]').not('[data-toggle]').click(function() {
 		var speed = 400;
 		var href= $(this).attr("href");
 		var target = $(href == "#" || href == "" ? 'html' : href);
@@ -895,6 +895,14 @@ if(!array_key_exists('searchitem', $config_ini )){
 if(!array_key_exists('searchitem_o', $config_ini )){
     // 表示順: searchmessage=1位, listerDB_file=2位, listerDB=3位, filesearch_e=4位, anisoninfo_e=5位, bandit_e=6位
     $config_ini['searchitem_o'] = array("2", "3", "4", "5", "6", "1");
+}
+
+// 既存設定へのマイグレーション: searchmessageが未追加の場合、先頭に有効状態で追加
+if(!isset($config_ini['searchitem_o'][5])) {
+    $config_ini['searchitem_o'][5] = 0;
+    if(!in_array('searchmessage', $config_ini['searchitem'])) {
+        $config_ini['searchitem'][] = 'searchmessage';
+    }
 }
 
 $searchitem_defs = array(

--- a/init.php
+++ b/init.php
@@ -57,6 +57,7 @@ if(array_key_exists("clearauth", $_REQUEST)) {
     
 <script type="text/javascript" charset="utf8" src="js/jquery.js"></script>
 <script src="js/bootstrap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.3/Sortable.min.js"></script>
 <script type="text/javascript" >
 $(function () {
   $('[data-toggle="tooltip"]').tooltip()
@@ -892,49 +893,44 @@ if(!array_key_exists('searchitem', $config_ini )){
 }
 
 if(!array_key_exists('searchitem_o', $config_ini )){
-    $config_ini['searchitem_o'] = array("1", "2", "3", "4");
+    $config_ini['searchitem_o'] = array("1", "2", "3", "4", "5", "6");
 }
+
+$searchitem_defs = array(
+    array('id' => 'listerDB_file',  'label' => 'キーワード検索（りすたー）'),
+    array('id' => 'listerDB',       'label' => 'りすたーDB検索'),
+    array('id' => 'filesearch_e',   'label' => 'ファイル名検索（Everything）'),
+    array('id' => 'anisoninfo_e',   'label' => '外部検索（anison.info）（Everything）'),
+    array('id' => 'bandit_e',       'label' => '外部検索（banditの隠れ家）（Everything）'),
+    array('id' => 'searchmessage',  'label' => '検索画面表示メッセージ'),
+);
+
+$si_order_map = array();
+foreach ($searchitem_defs as $idx => $def) {
+    $si_order_map[$idx] = isset($config_ini['searchitem_o'][$idx]) ? (int)$config_ini['searchitem_o'][$idx] : ($idx + 1);
+}
+asort($si_order_map);
+$si_sorted_indices = array_keys($si_order_map);
 
 ?>
 
-
   <div class="form-group">
      <h4 class=""> 検索画面に表示する項目 </h4>
+     <small>ドラッグで表示順を変更できます</small>
 
-  <table class="table table-striped table-bordered table-condensed">
-  <thead>
-    <tr>
-      <th class="col-xs-6" >項目</th>
-      <th class="col-xs-1" >表示</th>
-      <th class="col-xs-5" >表示順</th>
-    </tr>
-  </thead>
-    <tr>
-      <td>キーワード検索（りすたー） </td>
-      <td><input type="checkbox" name="searchitem[]" value="listerDB_file" <?php print checkbox_check($config_ini['searchitem'],"listerDB_file" )?'checked':' ' ?> > </td>
-      <td><input type="text" name="searchitem_o[]" size="100" class="form-control"  value="<?php print $config_ini['searchitem_o'][0]; ?>" placeholder="表示順" /> </td>
-    </tr>
-    <tr>
-      <td>りすたーDB検索 </td>
-      <td><input type="checkbox" name="searchitem[]" value="listerDB" <?php print checkbox_check($config_ini['searchitem'],"listerDB" )?'checked':' ' ?> > </td>
-      <td><input type="text" name="searchitem_o[]" size="100" class="form-control"  value="<?php print $config_ini['searchitem_o'][1]; ?>" placeholder="表示順" /> </td>
-    </tr>
-    <tr>
-      <td>ファイル名検索（Everything） </td>
-      <td><input type="checkbox" name="searchitem[]" value="filesearch_e" <?php print checkbox_check($config_ini['searchitem'],"filesearch_e" )?'checked':' ' ?> > </td>
-      <td><input type="text" name="searchitem_o[]" size="100" class="form-control"  value="<?php print $config_ini['searchitem_o'][2]; ?>" placeholder="表示順" /> </td>
-    </tr>
-    <tr>
-      <td>外部検索（anison.info）（Everything） </td>
-      <td><input type="checkbox" name="searchitem[]" value="anisoninfo_e" <?php print checkbox_check($config_ini['searchitem'],"anisoninfo_e" )?'checked':' ' ?> > </td>
-      <td><input type="text" name="searchitem_o[]" size="100" class="form-control"  value="<?php print $config_ini['searchitem_o'][3]; ?>" placeholder="表示順" /> </td>
-    </tr>
-    <tr>
-      <td>外部検索（banditの隠れ家）（Everything） </td>
-      <td> <input type="checkbox" name="searchitem[]" value="bandit_e" <?php print checkbox_check($config_ini['searchitem'],"bandit_e" )?'checked':' ' ?> >  </td>
-      <td> <input type="text" name="searchitem_o[]" size="100" class="form-control"  value="<?php print $config_ini['searchitem_o'][4]; ?>" placeholder="表示順" /> </td>
-    </tr>
-  </table>
+  <div id="searchitem-sortable" style="max-width:600px; margin-top:8px;">
+<?php foreach ($si_sorted_indices as $si_sorted_pos => $idx) {
+    $def = $searchitem_defs[$idx];
+    $checked = checkbox_check($config_ini['searchitem'], $def['id']) ? 'checked' : '';
+?>
+    <div class="searchitem-row" data-index="<?php echo $idx; ?>" style="display:flex; align-items:center; padding:6px 10px; margin-bottom:4px; border:1px solid #ddd; background:#f9f9f9; border-radius:3px;">
+      <span class="searchitem-drag-handle" style="cursor:grab; color:#aaa; font-size:20px; padding:0 10px 0 0; line-height:1; user-select:none; touch-action:none;">&#8942;</span>
+      <input type="checkbox" name="searchitem[]" value="<?php echo $def['id']; ?>" <?php echo $checked; ?> style="margin-right:8px;">
+      <span><?php echo $def['label']; ?></span>
+      <input type="hidden" name="searchitem_o[<?php echo $idx; ?>]" value="<?php echo $si_sorted_pos + 1; ?>" class="searchitem-order-input">
+    </div>
+<?php } ?>
+  </div>
 
   <div class="form-group">
     <h4  > りすたーDBファイルパス  </h4>
@@ -1661,7 +1657,24 @@ var xmlhttp = createXMLHttpRequest();
 
 </div>
 
-<hr />  
+<hr />
+
+<script>
+(function() {
+    var container = document.getElementById('searchitem-sortable');
+    if (!container) return;
+    Sortable.create(container, {
+        handle: '.searchitem-drag-handle',
+        animation: 150,
+        onEnd: function() {
+            var rows = container.querySelectorAll('.searchitem-row');
+            for (var i = 0; i < rows.length; i++) {
+                rows[i].querySelector('.searchitem-order-input').value = i + 1;
+            }
+        }
+    });
+})();
+</script>
 
 </body>
 </html>

--- a/search.php
+++ b/search.php
@@ -124,14 +124,16 @@ print '<div class="container">';
 
 
  if(empty($word) || $result_count === 0 ) {
-// トップページメッセージ表示
-if(array_key_exists("noticeof_searchpage",$config_ini)) {
-    if(!empty($config_ini["noticeof_searchpage"])){
-      print '<div class="well">';
-      print str_replace('#yukarihost#',$_SERVER["HTTP_HOST"],urldecode($config_ini["noticeof_searchpage"]));
-      print '</div>';
+// トップページメッセージ表示 (searchitem_o未設定時の後方互換)
+if(!array_key_exists("searchitem_o", $config_ini)) {
+    if(array_key_exists("noticeof_searchpage",$config_ini)) {
+        if(!empty($config_ini["noticeof_searchpage"])){
+          print '<div class="well">';
+          print str_replace('#yukarihost#',$_SERVER["HTTP_HOST"],urldecode($config_ini["noticeof_searchpage"]));
+          print '</div>';
+        }
     }
- }
+}
 }else {
     print_everything_filenamesearch();
     die();
@@ -418,6 +420,15 @@ foreach ($disp_search_order  as $v){
         case 4:
             if(checkbox_check($config_ini['searchitem'], "bandit_e" )) {
                 print_everything_banditsearch();
+            }
+            break;
+        case 5:
+            if(checkbox_check($config_ini['searchitem'], "searchmessage" )) {
+                if(array_key_exists("noticeof_searchpage", $config_ini) && !empty($config_ini["noticeof_searchpage"])) {
+                    print '<div class="well">';
+                    print str_replace('#yukarihost#', $_SERVER["HTTP_HOST"], urldecode($config_ini["noticeof_searchpage"]));
+                    print '</div>';
+                }
             }
             break;
     }

--- a/search.php
+++ b/search.php
@@ -378,8 +378,17 @@ if(!array_key_exists("searchitem_o", $config_ini) || !array_key_exists("searchit
     print_everything_filenamesearch();
     print_everything_anisoninfosearch();
     print_everything_banditsearch();
-    
+
 } else {
+
+// 既存設定へのマイグレーション: searchmessageが未追加の場合、先頭に有効状態で追加
+if(!isset($config_ini['searchitem_o'][5])) {
+    $config_ini['searchitem_o'][5] = 0;
+    if(!in_array('searchmessage', $config_ini['searchitem'])) {
+        $config_ini['searchitem'][] = 'searchmessage';
+    }
+}
+
 $disp_search_order = array();
 $o_srt=$config_ini['searchitem_o'];
 asort($o_srt);


### PR DESCRIPTION
## 変更内容

### 1. 検索画面に表示する項目のUI変更（init.php）
- テーブル＋数値テキスト入力による表示順設定を **SortableJS** を使ったドラッグ＆ドロップUIに変更
- 各項目に有効/無効チェックボックスとドラッグハンドル（⋮）を配置
- 「**検索画面表示メッセージ**」（`searchmessage`）を新規項目として追加

### 2. 初期値の変更
| 順位 | 項目 | 初期チェック |
|---|---|---|
| 1 | 検索画面表示メッセージ | ✓ |
| 2 | キーワード検索（りすたー） | ✓ |
| 3 | りすたーDB検索 | ✓ |
| 4 | ファイル名検索（Everything） | ✓ |
| 5 | 外部検索（anison.info） | — |
| 6 | 外部検索（banditの隠れ家） | — |

### 3. 既存設定へのマイグレーション（init.php・search.php）
- `searchitem_o[5]` が未設定の既存設定に対し、`searchmessage` を先頭・有効状態で自動追加

### 4. search.phpの対応
- `searchmessage` を case 5 としてソータブルループに追加し、`noticeof_searchpage` の表示位置を他の検索項目と並べて制御可能に
- `searchitem_o` 未設定の旧設定に対しては従来通り先頭表示（後方互換）

### 5. アコーディオン（ドロップダウン）不具合修正（init.php）
- **原因**: 平滑スクロール用の `$('a[href^=#]').click(...)` が `href="#"` を持つナビバードロップダウンリンク（いろいろ予約・Help等）のクリックを横取りし、`return false` でBootstrapのイベント処理をキャンセルしていた
- **修正**: セレクタに `.not('[data-toggle]')` を追加し、ドロップダウントグルをスクロール対象から除外

https://claude.ai/code/session_016YjmuyTndG7zQBmBSPmRxr