### PR TITLE
Add song duration tracking and statistics display

### DIFF
--- a/exec.php
+++ b/exec.php
@@ -236,7 +236,7 @@ if(!empty($DEBUG))
 } catch (PDOException $e) {
 	echo 'Connection failed: ' . $e->getMessage();
 }
-  if($config_ini["request_automove"] == 1){
+  if($config_ini["request_automove"] == 1 && !is_numeric($selectid)){
     require_once('function_moveitem.php');
     $db->exec("BEGIN DEFERRED;");
     $list = new MoveItem;

--- a/exec.php
+++ b/exec.php
@@ -88,6 +88,12 @@ if(array_key_exists("audiodelay", $_REQUEST)) {
     }
 }
 
+$l_duration = 0;
+if(array_key_exists("duration", $_REQUEST)) {
+    $l_duration = intval($_REQUEST["duration"]);
+    if($l_duration < 0) $l_duration = 0;
+}
+
 
 if(!empty($l_freesinger)){
 $l_singer=$l_freesinger;
@@ -153,7 +159,7 @@ if($request[0]['nowplaying'] === '再生中' || $request[0]['nowplaying'] === '�
 }
 
 try {
-    $sql = "UPDATE requesttable set songfile=:fn, singer=:sing, comment=:comment, kind=:kind, fullpath=:fp, secret=:secret, loop=:loop, nowplaying=:nowplaying, keychange=:keychange, track=:track, pause=:pause, audiodelay=:audiodelay where id = :selectid";
+    $sql = "UPDATE requesttable set songfile=:fn, singer=:sing, comment=:comment, kind=:kind, fullpath=:fp, secret=:secret, loop=:loop, nowplaying=:nowplaying, keychange=:keychange, track=:track, pause=:pause, audiodelay=:audiodelay, duration=:duration where id = :selectid";
     $stmt = $db->prepare($sql);
 } catch (PDOException $e) {
 	echo 'Connection failed: ' . $e->getMessage();
@@ -175,11 +181,12 @@ $arg = array(
 	':track' => $l_track,
 	':pause' => $l_pause,
 	':audiodelay' => $l_audiodelay,
+	':duration' => $l_duration,
 	':selectid' => (int)$selectid
 	);
 }else {
   try {
-    $sql = "INSERT INTO requesttable (songfile, singer, comment, kind, fullpath, nowplaying, status, clientip, clientua, playtimes, secret, loop, keychange, track, pause, audiodelay) VALUES (:fn, :sing, :comment, :kind, :fp, :np, :status, :ip, :ua, 0 ,:secret,:loop, :keychange, :track, :pause, :audiodelay)";
+    $sql = "INSERT INTO requesttable (songfile, singer, comment, kind, fullpath, nowplaying, status, clientip, clientua, playtimes, secret, loop, keychange, track, pause, audiodelay, duration) VALUES (:fn, :sing, :comment, :kind, :fp, :np, :status, :ip, :ua, 0 ,:secret,:loop, :keychange, :track, :pause, :audiodelay, :duration)";
     $stmt = $db->prepare($sql);
   } catch (PDOException $e) {
 	echo 'Connection failed: ' . $e->getMessage();
@@ -203,7 +210,8 @@ $arg = array(
 	':keychange' => $l_keychange,
 	':track' => $l_track,
 	':pause' => $l_pause,
-	':audiodelay' => $l_audiodelay
+	':audiodelay' => $l_audiodelay,
+	':duration' => $l_duration
 	);
 }
 $ret = $stmt->execute($arg);

--- a/func_audiotracklist.php
+++ b/func_audiotracklist.php
@@ -126,6 +126,7 @@ function getvideodetails($filename) {
 
     if (!empty($info['playtime_seconds'])) {
         $total_seconds = (int)round($info['playtime_seconds']);
+        $details['duration_seconds'] = $total_seconds;
         $minutes = (int)($total_seconds / 60);
         $secs = $total_seconds % 60;
         $details['duration'] = sprintf('%d:%02d', $minutes, $secs);

--- a/init.php
+++ b/init.php
@@ -278,6 +278,11 @@ print '</pre>';
     <input type="submit" name="resetstatus" value="全て未再生化" class="btn btn-default" />
   </form>
 
+  <h3> 曲の長さ一括更新 </h3>
+  <a href="update_duration_all.php" class="btn btn-default" onclick="return confirm('リクエストリスト内の全曲の長さを取得し直します。曲数が多い場合は時間がかかります。実行しますか？')">
+    曲の長さを全件登録し直す
+  </a>
+
   <h3> BGMモード用再生回数操作 </h3>
   <li>
     <a href ="listtimesclear.php?times=0" class="btn btn-default" > 再生回数0クリア </a>【BGMモード(ジュークボックスモード)にて次から全て順番に再生】

--- a/kara_config.php
+++ b/kara_config.php
@@ -232,7 +232,8 @@ function updatedb($db){
                   array ( "name" => "keychange" , "type" =>  "INTEGER default 0") ,
                   array ( "name" => "track" , "type" =>  "INTEGER default 0") ,
                   array ( "name" => "pause" , "type" =>  "INTEGER default 0") ,
-                  array ( "name" => "audiodelay" , "type" =>  "INTEGER default 0")
+                  array ( "name" => "audiodelay" , "type" =>  "INTEGER default 0") ,
+                  array ( "name" => "duration"   , "type" =>  "INTEGER default 0")
                   );
     /* 現在の項目一覧取得 */
     try {
@@ -296,7 +297,8 @@ $sql = "create table IF NOT EXISTS requesttable (
  keychange INTEGER default 0,
  track INTEGER default 0,
  pause INTEGER default 0,
- audiodelay INTEGER default 0
+ audiodelay INTEGER default 0,
+ duration INTEGER default 0
 )";
 $stmt = $db->query($sql);
 if ($stmt === false ){

--- a/request_confirm.php
+++ b/request_confirm.php
@@ -607,6 +607,10 @@ if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8)) {
         }
     }
 }
+// 差し替えモードの場合は元のリクエストの音ズレ値を優先
+if (is_numeric($selectid) && !empty($selectrequest)) {
+    $audiodelay_init = intval($selectrequest[0]['audiodelay']);
+}
 ?>
 <?php if ($shop_karaoke != 1 && $filetype == 1): ?>
 <div style="margin-top:8px; margin-bottom:4px; color:#888;">

--- a/request_confirm.php
+++ b/request_confirm.php
@@ -528,9 +528,14 @@ EOT;
 }
 
 $videodetails = array();
-if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8)) {
+$duration_seconds = 0;
+if ($shop_karaoke != 1 && !empty($fullpath_utf8) && ($filetype == 1 || $filetype == 2)) {
     $videodetails = getvideodetails($fullpath_utf8);
-    if (!empty($videodetails)) {
+    if (isset($videodetails['duration_seconds'])) {
+        $duration_seconds = $videodetails['duration_seconds'];
+    }
+}
+if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8) && !empty($videodetails)) {
         print '<div class="panel panel-default" style="margin-top:8px;">'."\n";
         print '<div class="panel-heading" role="tab" id="videoDetailsHeading">'."\n";
         print '<h4 class="panel-title">'."\n";
@@ -553,8 +558,8 @@ if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8)) {
         print '</div>'."\n";
         print '</div>'."\n";
         print '</div>'."\n";
-    }
 }
+echo '<input type="hidden" name="duration" value="' . (int)$duration_seconds . '" />' . "\n";
 
 // 制作者別音ズレデフォルト値を取得（ListerDB の found_worker と完全一致で判定）
 $audiodelay_init = 0;

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -236,6 +236,42 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
   text-align: center;
   padding: 12px 0 4px;
 }
+
+/* 統計バー */
+#stats-bar {
+  font-size: 13px;
+  color: #555;
+  background: #fff;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.08);
+  padding: 6px 10px;
+  margin-bottom: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+}
+.stats-item { white-space: nowrap; }
+.stats-val   { font-weight: bold; color: #333; }
+
+/* カード左側（番号＋ドラッグハンドル） */
+.card-left {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  min-width: 28px;
+}
+.card-num {
+  font-size: 10px;
+  color: #ccc;
+  line-height: 1;
+  font-weight: bold;
+}
+.card-duration {
+  color: #888;
+  font-size: 13px;
+}
 </style>
 </head>
 <body>
@@ -279,6 +315,12 @@ if (!empty($config_ini['noticeof_listpage'])) {
     </select>
 <?php endif; ?>
   </div>
+</div>
+
+<div id="stats-bar">
+  <span class="stats-item">総件数：<span class="stats-val" id="stat-total">-</span>件</span>
+  <span class="stats-item">残り：<span class="stats-val" id="stat-remaining">-</span>件</span>
+  <span class="stats-item">残り時間：<span class="stats-val" id="stat-remaining-time">-</span></span>
 </div>
 
 <div id="request-list"></div>
@@ -444,7 +486,7 @@ function isUnplayed(nowplaying) {
     return nowplaying === '未再生' || nowplaying === '1';
 }
 
-function createCardHTML(item) {
+function createCardHTML(item, idx) {
     var replaceLabel = (item.kind === 'カラオケ配信' && USE_BGV) ? 'BGV選択' : '曲差し替え';
 
     // コメント欄
@@ -486,6 +528,18 @@ function createCardHTML(item) {
         '      <span class="action-icon">&#9998;</span>変更',
         '    </button>'
     ].join('\n') : '';
+
+    // 曲の長さ（データがある場合のみ）
+    var durationHtml = '';
+    if (item.duration && item.duration > 0) {
+        var dm = Math.floor(item.duration / 60);
+        var ds = item.duration % 60;
+        durationHtml = '<span class="card-duration">　' + dm + ':' + ('0' + ds).slice(-2) + '</span>';
+    }
+
+    // 番号（先頭からの件数）
+    var position = item.position != null ? item.position : (totalCount - idx);
+    var numHtml = '<span class="card-num">' + position + '</span>';
 
     // トラック・キー・音ズレ（デフォルト値と異なる場合のみ表示）
     var extras = [];
@@ -530,10 +584,13 @@ function createCardHTML(item) {
         adminChangeBtnHtml,
         '  </div>',
         '  <div class="card-main">',
-        '    <span class="drag-handle">&#8942;</span>',
+        '    <div class="card-left">',
+        '      ' + numHtml,
+        '      <span class="drag-handle">&#8942;</span>',
+        '    </div>',
         '    <div class="card-info">',
         '      <div class="card-title">' + esc(item.display_name) + '</div>',
-        '      <div class="card-meta"><span class="card-label">登録者：</span>' + esc(item.singer) + '　<span class="card-label">再生方法：</span>' + esc(item.kind) + '</div>',
+        '      <div class="card-meta"><span class="card-label">登録者：</span>' + esc(item.singer) + '　<span class="card-label">再生方法：</span>' + esc(item.kind) + durationHtml + '</div>',
         '      ' + extraMetaHtml,
         '      ' + commentHtml,
         '      ' + tweetHtml,
@@ -564,24 +621,43 @@ function loadList(reset) {
         var offset = 0;
         fetch(buildUrl(limit, offset))
             .then(function (res) { return res.ok ? res.json() : Promise.reject(res.status); })
-            .then(function (data) { renderList(data.items, data.total, data.has_more); })
+            .then(function (data) { renderList(data.items, data.total, data.has_more, data); })
             .catch(function (e)   { console.error('loadList error:', e); });
     } else {
         // もっと見る: 現在表示分をまとめて再取得して全置き換え
         var newLimit = (currentLimit > 0) ? shownCount + currentLimit : 0;
         fetch(buildUrl(newLimit, 0))
             .then(function (res) { return res.ok ? res.json() : Promise.reject(res.status); })
-            .then(function (data) { renderList(data.items, data.total, data.has_more); })
+            .then(function (data) { renderList(data.items, data.total, data.has_more, data); })
             .catch(function (e)   { console.error('loadMore error:', e); });
     }
 }
 
-function renderList(items, total, hasMore) {
+function formatRemainingTime(secs) {
+    if (!secs || secs <= 0) return '-';
+    var h = Math.floor(secs / 3600);
+    var m = Math.floor((secs % 3600) / 60);
+    if (h > 0) return h + '時間' + m + '分';
+    return m + '分';
+}
+
+function updateStats(data) {
+    var el;
+    el = document.getElementById('stat-total');
+    if (el) el.textContent = data.total || 0;
+    el = document.getElementById('stat-remaining');
+    if (el) el.textContent = data.remaining_count != null ? data.remaining_count : '-';
+    el = document.getElementById('stat-remaining-time');
+    if (el) el.textContent = formatRemainingTime(data.remaining_seconds);
+}
+
+function renderList(items, total, hasMore, data) {
     var container   = document.getElementById('request-list');
     var emptyMsg    = document.getElementById('empty-msg');
     var loadMoreWrap = document.getElementById('load-more-wrap');
 
     totalCount = total || 0;
+    if (data) updateStats(data);
 
     if (items.length === 0 && totalCount === 0) {
         container.innerHTML = '';
@@ -593,7 +669,9 @@ function renderList(items, total, hasMore) {
 
     emptyMsg.style.display = 'none';
     shownCount = items.length;
-    container.innerHTML = items.map(createCardHTML).join('');
+    container.innerHTML = items.map(function (item, idx) {
+        return createCardHTML(item, idx);
+    }).join('');
 
     var remaining = totalCount - shownCount;
     if (hasMore && remaining > 0) {
@@ -971,7 +1049,7 @@ function scrollToShowId() {
     fetch(buildUrl(0, 0))
         .then(function (res) { return res.ok ? res.json() : Promise.reject(res.status); })
         .then(function (data) {
-            renderList(data.items, data.total, data.has_more);
+            renderList(data.items, data.total, data.has_more, data);
             var c = document.querySelector('.request-card[data-id="' + SHOW_ID + '"]');
             if (c) highlightCard(c, 'highlight-new');
         })
@@ -988,7 +1066,7 @@ function goToPlaying() {
     fetch(buildUrl(0, 0))
         .then(function (res) { return res.ok ? res.json() : Promise.reject(res.status); })
         .then(function (data) {
-            renderList(data.items, data.total, data.has_more);
+            renderList(data.items, data.total, data.has_more, data);
             if (!scrollToPlayingCard()) {
                 // 再生中なし：元の件数に戻す
                 currentLimit = prevLimit;
@@ -1060,7 +1138,7 @@ function reloadCurrent() {
     var limit = (currentLimit > 0 && shownCount > 0) ? shownCount : currentLimit;
     fetch(buildUrl(limit, 0))
         .then(function (res) { return res.ok ? res.json() : Promise.reject(res.status); })
-        .then(function (data) { renderList(data.items, data.total, data.has_more); })
+        .then(function (data) { renderList(data.items, data.total, data.has_more, data); })
         .catch(function (e)   { console.error('reload error:', e); });
 }
 

--- a/requestlist_swipe_json.php
+++ b/requestlist_swipe_json.php
@@ -12,7 +12,15 @@ $offset = isset($_GET['offset']) && ctype_digit($_GET['offset']) ? (int)$_GET['o
 try {
     $total = (int)$db->query("SELECT COUNT(*) FROM requesttable")->fetchColumn();
 
-    $sql = "SELECT id, songfile, singer, comment, kind, reqorder, nowplaying, secret, track, keychange, audiodelay FROM requesttable ORDER BY reqorder DESC";
+    $remaining_count = (int)$db->query(
+        "SELECT COUNT(*) FROM requesttable WHERE nowplaying IN ('未再生', '1')"
+    )->fetchColumn();
+
+    $remaining_seconds = (int)$db->query(
+        "SELECT COALESCE(SUM(duration), 0) FROM requesttable WHERE nowplaying IN ('未再生', '1') AND duration > 0"
+    )->fetchColumn();
+
+    $sql = "SELECT id, songfile, singer, comment, kind, reqorder, nowplaying, secret, track, keychange, audiodelay, duration FROM requesttable ORDER BY reqorder DESC";
     if ($limit > 0) {
         $stmt = $db->prepare($sql . " LIMIT :limit OFFSET :offset");
         $stmt->bindValue(':limit',  $limit,  PDO::PARAM_INT);
@@ -30,7 +38,7 @@ try {
 }
 
 $items = [];
-foreach ($rows as $row) {
+foreach ($rows as $idx => $row) {
     $songfile     = $row['songfile'];
     $display_name = $songfile;
     if (!empty($row['secret']) && $row['secret'] == 1) {
@@ -48,13 +56,17 @@ foreach ($rows as $row) {
         'track'        => (int)($row['track']      ?? 0),
         'keychange'    => (int)($row['keychange']   ?? 0),
         'audiodelay'   => (int)($row['audiodelay']  ?? 0),
+        'duration'     => (int)($row['duration']    ?? 0),
+        'position'     => $total - $offset - $idx,
     ];
 }
 
 $has_more = ($limit > 0) && (($offset + count($items)) < $total);
 
 echo json_encode([
-    'items'    => $items,
-    'total'    => $total,
-    'has_more' => $has_more,
+    'items'             => $items,
+    'total'             => $total,
+    'has_more'          => $has_more,
+    'remaining_count'   => $remaining_count,
+    'remaining_seconds' => $remaining_seconds,
 ], JSON_UNESCAPED_UNICODE);

--- a/update_duration_all.php
+++ b/update_duration_all.php
@@ -1,0 +1,84 @@
+<?php
+require_once 'commonfunc.php';
+require_once 'configauth_class.php';
+$configauth = new ConfigAuth();
+
+if (!isset($_SERVER['PHP_AUTH_USER'])) {
+    header('WWW-Authenticate: Basic realm="Please use username admin."');
+    die('設定画面の表示にはログインが必要です');
+}
+if ($_SERVER['PHP_AUTH_USER'] !== 'admin') {
+    header('WWW-Authenticate: Basic realm="Configuration page authorization."');
+    die('設定画面の表示にはログインが必要です');
+}
+if (!$configauth->check_auth($_SERVER['PHP_AUTH_PW'])) {
+    header('WWW-Authenticate: Basic realm="Configuration page authorization."');
+    die('設定画面の表示にはログインが必要です');
+}
+
+require_once 'easyauth_class.php';
+$easyauth = new EasyAuth();
+$easyauth->do_eashauthcheck();
+
+require_once 'func_audiotracklist.php';
+
+$lister_dbpath = '';
+if (array_key_exists('listerDBPATH', $config_ini)) {
+    $lister_dbpath = urldecode($config_ini['listerDBPATH']);
+}
+
+$stmt = $db->query("SELECT id, songfile, fullpath, kind FROM requesttable ORDER BY id");
+$rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$stmt->closeCursor();
+
+$updated = 0;
+$skipped = 0;
+$update_stmt = $db->prepare("UPDATE requesttable SET duration = :duration WHERE id = :id");
+
+foreach ($rows as $row) {
+    if (empty($row['fullpath'])) {
+        $skipped++;
+        continue;
+    }
+
+    $fullpath_utf8 = '';
+    get_fullfilename($row['fullpath'], $row['songfile'], $fullpath_utf8, $lister_dbpath);
+
+    if (empty($fullpath_utf8)) {
+        $skipped++;
+        continue;
+    }
+
+    $details = getvideodetails($fullpath_utf8);
+    if (!isset($details['duration_seconds']) || $details['duration_seconds'] <= 0) {
+        $skipped++;
+        continue;
+    }
+
+    $update_stmt->execute([
+        ':duration' => $details['duration_seconds'],
+        ':id'       => (int)$row['id'],
+    ]);
+    $updated++;
+}
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="3; url=init.php">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>曲の長さ一括更新</title>
+<link href="css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<?php shownavigatioinbar(); ?>
+<div class="container" style="margin-top:20px;">
+  <h3>曲の長さを一括更新しました</h3>
+  <p>更新：<strong><?php echo $updated; ?></strong> 件 ／ スキップ：<strong><?php echo $skipped; ?></strong> 件</p>
+  <p class="text-muted">（ファイルが見つからない・長さが取得できない場合はスキップされます）</p>
+  <p>3秒後に設定画面に戻ります。</p>
+  <a href="init.php" class="btn btn-default">すぐに戻る</a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 概要

スワイプリストにキュー情報の統計表示と曲の長さ表示機能を追加し、差し替え時の動作を改善しました。

## 実装内容

### 1. スワイプリストの表示機能強化
- **統計バー**: リスト上部に総件数・残り件数（未再生）・残り時間を表示
- **曲の長さ**: 各カードの「再生方法」の右側に曲の長さ（分:秒）を表示（データなしは非表示）
- **番号表示**: 各カード左上に先頭からの通し番号を表示

### 2. データベース・データフロー
- `requesttable` に `duration` 列を追加（秒数、INTEGER）
- `request_confirm.php` で動画・音声ファイルの長さを取得してDB保存
- `getvideodetails()` に `duration_seconds` フィールドを追加
- `requestlist_swipe_json.php` で統計情報と位置番号を返す

### 3. 曲の長さ一括更新機能
- 新規ファイル `update_duration_all.php`: リクエストリスト全件の曲の長さを取得し直す
- 設定画面（init.php）の「リクエストリスト操作」セクションに「曲の長さを全件登録し直す」ボタンを追加

### 4. 差し替え時の動作改善
- 曲差し替え時（selectid指定）はピッタリ移動（request_automove）を実行しない
- 差し替え時は制作者別音ズレ初期値の設定を無視し、元のリクエストの音ズレ値を初期値として表示

## 主な変更ファイル
- `kara_config.php`: スキーマと自動マイグレーション
- `func_audiotracklist.php`: duration_seconds の追加
- `request_confirm.php`: 長さ取得とhiddenフィールド追加
- `exec.php`: duration 保存・差し替え時の動作改善
- `requestlist_swipe_json.php`: 統計情報・位置番号の返却
- `requestlist_swipe.php`: UI・統計表示の実装
- `init.php`: 一括更新ボタン追加
- `update_duration_all.php`: 新規ファイル

## テスト済み項目
- 動画・音声ファイルの長さ取得と表示
- スマートフォン・PC両デバイスでの表示確認
- 統計情報（総件数・残り件数・残り時間）の計算
- 曲差し替え時のピッタリ移動スキップ
- 曲差し替え時の音ズレ値保持