### PR TITLE
exec.php: reqorder重複バグを修正

### DIFF
--- a/exec.php
+++ b/exec.php
@@ -196,38 +196,38 @@ $arg = array(
 	':pause' => $l_pause
 	);
 }
-$ret = $stmt->execute($arg);
-if (! $ret ) {
-	print(htmlspecialchars((string)$l_filename, ENT_QUOTES, 'UTF-8') . " を追加にしっぱいしました。");
-	die();
-}
-
-$sql = "SELECT * FROM requesttable where status = 'new' ORDER BY id DESC";
-try {
-if(!empty($DEBUG))
-    print $sql.'<br />';
-    $select = $db->query($sql);
-    while($row = $select->fetch(PDO::FETCH_ASSOC)){
-    $newid=$row['id'];
-    $sql_u = 'UPDATE requesttable set reqorder = '. $newid . ', status = \'OK\' WHERE id = '. $newid;
-if(!empty($DEBUG))
-    print $sql_u.'<br />';
-    $ret = $db->query($sql_u);
+if (is_numeric($selectid)) {
+    // 差し替え: UPDATEのみ実行、reqorderは変更しない
+    $newid = (int)$selectid;
+    $ret = $stmt->execute($arg);
+    if (!$ret) {
+        print(htmlspecialchars((string)$l_filename, ENT_QUOTES, 'UTF-8') . " を追加にしっぱいしました。");
+        die();
     }
-
-} catch (PDOException $e) {
-	echo 'Connection failed: ' . $e->getMessage();
-}
-  if($config_ini["request_automove"] == 1){
-    require_once('function_moveitem.php');
-    $db->exec("BEGIN DEFERRED;");
-    $list = new MoveItem;
-    $turnlist = $list->getturnlist($db);
-    $newreq = $list->get_new_reqorder($newid);
-    $list->insertreqorder($newid,$newreq);
-    $list->save_allrequest($db);
+} else {
+    // 新規追加: BEGIN IMMEDIATEで同時アクセス競合を防ぎ、INSERT〜reqorder割り当て〜自動整列を一括処理
+    $db->exec("BEGIN IMMEDIATE;");
+    $ret = $stmt->execute($arg);
+    if (!$ret) {
+        $db->exec("ROLLBACK;");
+        print(htmlspecialchars((string)$l_filename, ENT_QUOTES, 'UTF-8') . " を追加にしっぱいしました。");
+        die();
+    }
+    $newid = (int)$db->lastInsertId();
+    $sql_u = 'UPDATE requesttable SET reqorder = ' . $newid . ', status = \'OK\' WHERE id = ' . $newid;
+    if (!empty($DEBUG))
+        print $sql_u . '<br />';
+    $db->exec($sql_u);
+    if ($config_ini["request_automove"] == 1) {
+        require_once('function_moveitem.php');
+        $list = new MoveItem;
+        $list->getturnlist($db);
+        $newreq = $list->get_new_reqorder($newid);
+        $list->insertreqorder($newid, $newreq);
+        $list->save_allrequest($db);
+    }
     $db->exec("COMMIT;");
-  }
+}
 file_get_contents("http://localhost/updaterequestlist.php");
 
 if(!empty($DEBUG)){

--- a/function_moveitem.php
+++ b/function_moveitem.php
@@ -240,19 +240,26 @@ class MoveItem {
     }
 
     public function insertreqorder($id, $reqorder) {
-        $currentreqorder = 1;
+        // allrequest_newはreqorder昇順ソート済みの前提
+        // target_reqorderより小さいreqorderを持つアイテム数 = 新アイテムの前に来るアイテム数
+        $items_before = 0;
+        foreach ($this->allrequest_new as $r) {
+            if ($r['id'] == $id) continue;
+            if ($r['reqorder'] < $reqorder) $items_before++;
+        }
+        $new_position = $items_before + 1;
+
+        // 全アイテムを連番で振り直す（隙間も吸収）
+        // 新アイテムはnew_positionに配置し、それ以外は前後に詰める
+        $pos = 1;
         for ($i = 0; $i < count($this->allrequest_new); $i++) {
             if ($this->allrequest_new[$i]['id'] == $id) {
-                $this->allrequest_new[$i]['reqorder'] = $reqorder;
+                $this->allrequest_new[$i]['reqorder'] = $new_position;
                 continue;
             }
-            if ($currentreqorder == $reqorder) {
-                $currentreqorder++;
-            } elseif ($this->allrequest_new[$i]['reqorder'] == $reqorder) {
-                $currentreqorder++;
-            }
-            $this->allrequest_new[$i]['reqorder'] = $currentreqorder;
-            $currentreqorder++;
+            if ($pos == $new_position) $pos++;
+            $this->allrequest_new[$i]['reqorder'] = $pos;
+            $pos++;
         }
     }
 


### PR DESCRIPTION
## 概要
差し替え時と新規追加時の reqorder（リクエスト順序値）の処理を修正し、重複バグを完全に解決しました。

## 変更内容

### 1. 差し替え（selectid指定）時のMoveItemスキップ
- UPDATE側の処理を分離し、reqorderを変更しないように修正
- `$newid = (int)$selectid` を設定して後続の表示処理に使用

### 2. 同時アクセス競合の防止
- 新規追加時に `BEGIN IMMEDIATE` でトランザクションを開始
- INSERT → reqorder割り当て → MoveItem整列 → COMMIT を一括処理
- 2プロセスが同時にINSERTしても、後発のプロセスは前発のCOMMIT完了後にトランザクション取得するため、staleなデータでMoveItemが動くことがなくなる
- `lastInsertId()` を使って直接IDを取得し、`status='new'` の SELECT ループも廃止（よりシンプルかつ確実）

### 3. function_moveitem.phpの既知バグ修正
- `insertreqorder` のelseifバグ（reqorderに隙間がある場合に重複が発生）も修正済み