### PR TITLE
fix: リクエスト確認画面で歌う人が最後のリクエスト者になるバグを修正

### DIFF
--- a/exec.php
+++ b/exec.php
@@ -248,6 +248,12 @@ if (is_numeric($selectid)) {
 }
 file_get_contents("http://localhost/updaterequestlist.php");
 
+// 歌う人名をクッキーに保存（次回 request_confirm.php でIP+UAマッチングの代わりに使われる）
+$nonameusername = urldecode($config_ini['nonameusername']);
+if (!empty($l_singer) && $l_singer !== $nonameusername && $l_kind !== '小休止') {
+    setcookie("YkariUsername", $l_singer, time() + 5184000, '/');
+}
+
 // マイページ: 新規追加時のみ選曲履歴に記録 (差し替えは記録しない)
 if (!is_numeric($selectid) && configbool("usemypage", true)) {
     require_once 'mypage_class.php';

--- a/request_confirm.php
+++ b/request_confirm.php
@@ -103,8 +103,6 @@ function pickupsinger($rt, $moreuser = "")
 }
 
 function selectedcheck_rc($rt,$singer,$beforesinger = 'none' ){
-    $rt_i = array_reverse($rt);
-
     if($beforesinger == 'none'){
       foreach($rt as $row){
       


### PR DESCRIPTION
## 概要

`request_confirm.php` で、リクエスト者が「リストの最後の曲の歌う人」になってしまい、一度その状態になるとずっと続くバグを修正しました。

## バグの原因

### IP + User-Agent による識別の限界

`YkariUsername` クッキーが未設定のユーザーに対して、`selectedcheck_rc` 関数が **IPアドレス + User-Agent** でユーザーを識別していました。

以下の条件が重なると誤動作します：

- 同じWiFi/NATを使う複数人が **同じ公開IPアドレス** を持つ
- 同じブラウザを使うと **User-Agent も一致** する（同機種のスマホや同じPCの複数ユーザーなど）

### バグの流れ

1. Aさんが「Alice」でリクエスト（IP: 共有、UA: Chrome）
2. Bさんが同じWiFiで同じブラウザから `request_confirm.php` を開く
3. `selectedcheck_rc` がAさんの行をIP+UAで一致させてしまい、「Alice」が自動選択される
4. Bさんがそのまま送信すると、DBに「Alice」名義でBさんのリクエストが入る
5. 以降も同じIP+UAで一致し続けるため「ずっと」同じ状態が続く

### デッドコード

`selectedcheck_rc`（`request_confirm.php` 旧107行目）に `$rt_i = array_reverse($rt)` という行があり、変数が作成されるものの **その後一切使われていない** 未使用変数でした。

## 修正内容

### `exec.php`（主要修正）

リクエスト登録成功後に `YkariUsername` クッキーを設定するよう追加しました。

`YkariUsername` クッキーはIP+UAマッチングより優先されるため、**一度リクエストを送信すれば次回以降は正しい自分の名前が選ばれる**ようになります。

```php
// 歌う人名をクッキーに保存（次回 request_confirm.php でIP+UAマッチングの代わりに使われる）
$nonameusername = urldecode($config_ini['nonameusername']);
if (!empty($l_singer) && $l_singer !== $nonameusername && $l_kind !== '小休止') {
    setcookie("YkariUsername", $l_singer, time() + 5184000, '/');
}
```

### `request_confirm.php`（デッドコード削除）

`selectedcheck_rc` 内の未使用変数 `$rt_i = array_reverse($rt)` を削除しました。

## 注意事項

- 初回リクエスト前（クッキー未設定）は従来通りIP+UAマッチングが使われます
- `$blank_username = true`（共有端末モード）の場合はクッキー選択がスキップされるため影響なし
- `小休止` リクエスト時はクッキーを更新しません

https://claude.ai/code/session_01JLUZzyQaP8aLjhs9Xbp38H

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLUZzyQaP8aLjhs9Xbp38H)_