### PR TITLE
キーワード検索（りすたー）のシンプル化・詳細検索分離

### DIFF
--- a/init.php
+++ b/init.php
@@ -935,14 +935,19 @@ if(!isset($config_ini['searchitem_o'][5])) {
         $config_ini['searchitem'][] = 'searchmessage';
     }
 }
+if(!isset($config_ini['searchitem_o'][6])) {
+    // 詳細検索フォームは既存ユーザーではデフォルト非表示（順序0）
+    $config_ini['searchitem_o'][6] = 0;
+}
 
 $searchitem_defs = array(
-    array('id' => 'listerDB_file',  'label' => 'キーワード検索（りすたー）'),
-    array('id' => 'listerDB',       'label' => 'りすたーDB検索'),
-    array('id' => 'filesearch_e',   'label' => 'ファイル名検索（Everything）'),
-    array('id' => 'anisoninfo_e',   'label' => '外部検索（anison.info）（Everything）'),
-    array('id' => 'bandit_e',       'label' => '外部検索（banditの隠れ家）（Everything）'),
-    array('id' => 'searchmessage',  'label' => '検索画面表示メッセージ'),
+    array('id' => 'listerDB_file',   'label' => 'キーワード検索（りすたー）'),
+    array('id' => 'listerDB',        'label' => 'りすたーDB検索'),
+    array('id' => 'filesearch_e',    'label' => 'ファイル名検索（Everything）'),
+    array('id' => 'anisoninfo_e',    'label' => '外部検索（anison.info）（Everything）'),
+    array('id' => 'bandit_e',        'label' => '外部検索（banditの隠れ家）（Everything）'),
+    array('id' => 'searchmessage',   'label' => '検索画面表示メッセージ'),
+    array('id' => 'listerDB_detail', 'label' => 'キーワード詳細検索（りすたー）'),
 );
 
 $si_order_map = array();

--- a/search_bs5.php
+++ b/search_bs5.php
@@ -67,13 +67,81 @@ function print_listerdb_search() {
 }
 
 function print_listerdb_fileonly() {
-    global $config_ini;
-    $includepage = 1;
+    global $config_ini, $selectid;
+    $lister_dbpath = '';
     if (array_key_exists("listerDBPATH", $config_ini)) {
-        $lister_dbpath = $config_ini['listerDBPATH'];
+        $lister_dbpath = urldecode($config_ini['listerDBPATH']);
     }
-    $filesearch = 1;
-    require 'search_listerdb_anysearch_index_bs5.php';
+    $sid_field = !empty($selectid)
+        ? '<input type="hidden" name="selectid" value="' . htmlspecialchars($selectid, ENT_QUOTES, 'UTF-8') . '" />'
+        : '';
+    $db_field = !empty($lister_dbpath)
+        ? '<input type="hidden" name="lister_dbpath" value="' . htmlspecialchars($lister_dbpath, ENT_QUOTES, 'UTF-8') . '" />'
+        : '';
+
+    print '<p class="form-label-sm mb-2">検索ワード <small>（ふりがな・作品名・曲名・歌手名・ファイル名の一部）</small></p>';
+    print '<form action="search_listerdb_filelist.php" method="GET">';
+    print '  <div class="search-input-wrap">';
+    print '    <input type="text" name="anyword" id="anyword" class="form-control-themed"';
+    print '           placeholder="作品名、曲名、歌手名、ファイル名の一部" autocomplete="off" />';
+    print '    <button type="submit" class="btn-search-submit">検索</button>';
+    print '  </div>';
+    print  $db_field . $sid_field;
+    print '</form>';
+}
+
+function print_listerdb_detailsearch() {
+    global $config_ini, $selectid;
+    $lister_dbpath = '';
+    if (array_key_exists("listerDBPATH", $config_ini)) {
+        $lister_dbpath = urldecode($config_ini['listerDBPATH']);
+    }
+    $sid_field = !empty($selectid)
+        ? '<input type="hidden" name="selectid" value="' . htmlspecialchars($selectid, ENT_QUOTES, 'UTF-8') . '" />'
+        : '';
+    $db_field = !empty($lister_dbpath)
+        ? '<input type="hidden" name="lister_dbpath" value="' . htmlspecialchars($lister_dbpath, ENT_QUOTES, 'UTF-8') . '" />'
+        : '';
+
+    $fields = [
+        ['name' => 'song_name',         'label' => '曲名'],
+        ['name' => 'program_name',      'label' => '作品名'],
+        ['name' => 'artist',            'label' => '歌手名'],
+        ['name' => 'maker_name',        'label' => '制作会社'],
+        ['name' => 'tie_up_group_name', 'label' => 'シリーズ名'],
+        ['name' => 'worker',            'label' => '動画製作者'],
+    ];
+
+    print '<form action="search_listerdb_songlist.php" method="GET">';
+    print  $db_field . $sid_field;
+    print '<div class="row g-3 mb-3">';
+    foreach ($fields as $f) {
+        print '<div class="col-md-4">';
+        print '  <label class="form-label-sm" for="' . $f['name'] . '">' . $f['label'] . '</label>';
+        print '  <input type="text" name="' . $f['name'] . '" id="' . $f['name'] . '" class="form-control-themed" value="">';
+        print '</div>';
+    }
+    print '</div>';
+    print '<div class="row g-3 mb-3">';
+    print '  <div class="col-md-4">';
+    print '    <label class="form-label-sm" for="datestart">更新日（開始）</label>';
+    print '    <input type="date" name="datestart" id="datestart" class="form-control-themed">';
+    print '  </div>';
+    print '  <div class="col-md-4">';
+    print '    <label class="form-label-sm" for="dateend">更新日（終了）</label>';
+    print '    <input type="date" name="dateend" id="dateend" class="form-control-themed">';
+    print '  </div>';
+    print '</div>';
+    print '<div class="d-flex gap-3 mb-3">';
+    print '  <label class="d-flex align-items-center gap-1" style="cursor:pointer;">';
+    print '    <input type="radio" name="match" value="part" checked> 部分一致';
+    print '  </label>';
+    print '  <label class="d-flex align-items-center gap-1" style="cursor:pointer;">';
+    print '    <input type="radio" name="match" value="full"> 完全一致';
+    print '  </label>';
+    print '</div>';
+    print '<button type="submit" class="btn-secondary-themed">検索</button>';
+    print '</form>';
 }
 
 function print_everything_filenamesearch($first = false) {
@@ -293,8 +361,7 @@ else:
             switch ($v) {
                 case 0:
                     if (checkbox_check($config_ini['searchitem'], "listerDB_file")) {
-                        // キーワード検索 (listerDB) はそのまま include
-                        _section_open('sec-listerdb-file', 'キーワード検索', $first);
+                        _section_open('sec-listerdb-file', 'キーワード検索（りすたー）', $first);
                         print_listerdb_fileonly();
                         _section_close();
                         $first = false;
@@ -334,6 +401,14 @@ else:
                             print str_replace('#yukarihost#', $_SERVER["HTTP_HOST"], urldecode($config_ini["noticeof_searchpage"]));
                             print '</div>';
                         }
+                    }
+                    break;
+                case 6:
+                    if (checkbox_check($config_ini['searchitem'], "listerDB_detail")) {
+                        _section_open('sec-listerdb-detail', 'キーワード詳細検索', $first);
+                        print_listerdb_detailsearch();
+                        _section_close();
+                        $first = false;
                     }
                     break;
             }

--- a/search_bs5.php
+++ b/search_bs5.php
@@ -79,15 +79,17 @@ function print_listerdb_fileonly() {
         ? '<input type="hidden" name="lister_dbpath" value="' . htmlspecialchars($lister_dbpath, ENT_QUOTES, 'UTF-8') . '" />'
         : '';
 
-    print '<p class="form-label-sm mb-2">検索ワード <small>（ふりがな・作品名・曲名・歌手名・ファイル名の一部）</small></p>';
-    print '<form action="search_listerdb_filelist.php" method="GET">';
-    print '  <div class="search-input-wrap">';
-    print '    <input type="text" name="anyword" id="anyword" class="form-control-themed"';
-    print '           placeholder="作品名、曲名、歌手名、ファイル名の一部" autocomplete="off" />';
-    print '    <button type="submit" class="btn-search-submit">検索</button>';
-    print '  </div>';
-    print  $db_field . $sid_field;
-    print '</form>';
+    print '<div class="search-hero">';
+    print '  <p class="form-label-sm mb-2">検索ワード <small>（ふりがな・作品名・曲名・歌手名・ファイル名の一部）</small></p>';
+    print '  <form action="search_listerdb_filelist.php" method="GET">';
+    print '    <div class="search-input-wrap">';
+    print '      <input type="text" name="anyword" id="anyword" class="form-control-themed"';
+    print '             placeholder="作品名、曲名、歌手名、ファイル名の一部" autocomplete="off" />';
+    print '      <button type="submit" class="btn-search-submit">検索</button>';
+    print '    </div>';
+    print      $db_field . $sid_field;
+    print '  </form>';
+    print '</div>';
 }
 
 function print_listerdb_detailsearch() {
@@ -361,10 +363,8 @@ else:
             switch ($v) {
                 case 0:
                     if (checkbox_check($config_ini['searchitem'], "listerDB_file")) {
-                        _section_open('sec-listerdb-file', 'キーワード検索（りすたー）', $first);
+                        // アコーディオンなしで常時表示
                         print_listerdb_fileonly();
-                        _section_close();
-                        $first = false;
                     }
                     break;
                 case 1:


### PR DESCRIPTION
## 変更概要

キーワード検索（りすたー）を「シンプル版」と「詳細検索」の2つに分離し、シンプル版のデザインをほかの検索フォームと統一しました。

---

## 主な変更内容

### キーワード検索の分離

- **キーワード検索（りすたー）**（既存項目を変更）
  - アコーディオンを撤去し、常時表示のシンプルなフォームに変更
  - テキストボックスと検索ボタンのみのミニマルな構成
  - デザインをほかの検索フォームと統一（`.search-input-wrap` を使用）
  - 横幅が広いときはボタンを右に、狭いときはボタンを下段に配置（flex レイアウト）

- **キーワード詳細検索（りすたー）**（新規追加項目）
  - 曲名・作品名・歌手名・制作会社・シリーズ名・動画製作者・更新日範囲で絞り込み可能な詳細フォーム
  - アコーディオン形式（管理者が「検索画面に表示する項目」から有効化）
  - 既存ユーザーへの後方互換性として、デフォルトは非表示

### 管理画面（設定）
- `searchitem` の選択肢に `listerDB_detail`（キーワード詳細検索）を追加
- 既存ユーザーは移行時に詳細検索が自動的に非表示（index 6 のデフォルト値 `0`）

---

## 技術的メモ

- `search_bs5.php` の `case 0` でアコーディオンを使わずシンプルフォームを直接描画
- `init.php` の `$searchitem_defs` に `listerDB_detail`（index 6）を追加
- CDN 不使用（完全オフライン対応）

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUXNWENJeScNvnSakFZdRy)_