### PR TITLE
キーワード検索に検索履歴ドロップダウンを追加

### DIFF
--- a/css/themes/search.css
+++ b/css/themes/search.css
@@ -654,3 +654,90 @@ table.searchresult tbody td {
 .file-item:hover {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
 }
+
+/* --- 検索履歴ドロップダウン --- */
+.search-history-wrap {
+  position: relative;
+}
+
+#search-history-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: var(--bg-card);
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card-hover);
+  z-index: 1000;
+  overflow: hidden;
+}
+
+.search-history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.search-history-item {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.search-history-item:last-child {
+  border-bottom: none;
+}
+
+.search-history-word {
+  flex: 1;
+  background: none;
+  border: none;
+  padding: 10px var(--space-3);
+  text-align: left;
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.search-history-word:hover {
+  background: var(--bg-card-hover);
+  color: var(--color-accent);
+}
+
+.search-history-del {
+  background: none;
+  border: none;
+  padding: 8px 12px;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.search-history-del:hover {
+  color: var(--color-accent);
+}
+
+.search-history-footer {
+  padding: 5px var(--space-3);
+  background: var(--bg-card-alt);
+  text-align: right;
+  border-top: 1px solid var(--color-border);
+}
+
+.search-history-footer button {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: 0.78rem;
+  cursor: pointer;
+  padding: 2px 4px;
+}
+
+.search-history-footer button:hover {
+  color: var(--color-accent);
+  text-decoration: underline;
+}

--- a/search_bs5.php
+++ b/search_bs5.php
@@ -81,11 +81,14 @@ function print_listerdb_fileonly() {
 
     print '<div class="search-hero">';
     print '  <p class="form-label-sm mb-2">検索ワード <small>（ふりがな・作品名・曲名・歌手名・ファイル名の一部）</small></p>';
-    print '  <form action="search_listerdb_filelist.php" method="GET">';
-    print '    <div class="search-input-wrap">';
-    print '      <input type="text" name="anyword" id="anyword" class="form-control-themed"';
-    print '             placeholder="作品名、曲名、歌手名、ファイル名の一部" autocomplete="off" />';
-    print '      <button type="submit" class="btn-search-submit">検索</button>';
+    print '  <form action="search_listerdb_filelist.php" method="GET" id="anyword-form">';
+    print '    <div class="search-history-wrap">';
+    print '      <div class="search-input-wrap">';
+    print '        <input type="text" name="anyword" id="anyword" class="form-control-themed"';
+    print '               placeholder="作品名、曲名、歌手名、ファイル名の一部" autocomplete="off" />';
+    print '        <button type="submit" class="btn-search-submit">検索</button>';
+    print '      </div>';
+    print '      <div id="search-history-dropdown" hidden></div>';
     print '    </div>';
     print      $db_field . $sid_field;
     print '  </form>';
@@ -418,6 +421,99 @@ endif;
 ?>
 
 </div><!-- /container -->
+
+<script>
+(function () {
+  var STORAGE_KEY = "krw_search_history";
+  var MAX_HISTORY = 10;
+
+  function getHistory() {
+    try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]"); }
+    catch (e) { return []; }
+  }
+  function saveHistory(hist) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(hist));
+  }
+  function addToHistory(word) {
+    word = word.trim();
+    if (!word) return;
+    var hist = getHistory().filter(function (h) { return h !== word; });
+    hist.unshift(word);
+    saveHistory(hist.slice(0, MAX_HISTORY));
+  }
+  function removeFromHistory(word) {
+    saveHistory(getHistory().filter(function (h) { return h !== word; }));
+  }
+  function escHtml(s) {
+    return s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
+  }
+
+  function renderDropdown() {
+    var dropdown = document.getElementById("search-history-dropdown");
+    if (!dropdown) return;
+    var hist = getHistory();
+    if (hist.length === 0) { dropdown.hidden = true; dropdown.innerHTML = ""; return; }
+
+    var html = "<ul class=\"search-history-list\">";
+    hist.forEach(function (word) {
+      var e = escHtml(word);
+      html += "<li class=\"search-history-item\">"
+            + "<button type=\"button\" class=\"search-history-word\" data-word=\"" + e + "\">" + e + "</button>"
+            + "<button type=\"button\" class=\"search-history-del\" data-word=\"" + e + "\" aria-label=\"削除\">×</button>"
+            + "</li>";
+    });
+    html += "</ul>";
+    html += "<div class=\"search-history-footer\"><button type=\"button\" id=\"search-history-clear\">履歴をクリア</button></div>";
+    dropdown.innerHTML = html;
+    dropdown.hidden = false;
+
+    dropdown.querySelectorAll(".search-history-word").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var input = document.getElementById("anyword");
+        input.value = btn.dataset.word;
+        dropdown.hidden = true;
+        addToHistory(btn.dataset.word);
+        input.form.submit();
+      });
+    });
+    dropdown.querySelectorAll(".search-history-del").forEach(function (btn) {
+      btn.addEventListener("mousedown", function (e) { e.preventDefault(); });
+      btn.addEventListener("click", function () {
+        removeFromHistory(btn.dataset.word);
+        renderDropdown();
+      });
+    });
+    var clearBtn = document.getElementById("search-history-clear");
+    if (clearBtn) {
+      clearBtn.addEventListener("mousedown", function (e) { e.preventDefault(); });
+      clearBtn.addEventListener("click", function () {
+        saveHistory([]);
+        renderDropdown();
+      });
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var input = document.getElementById("anyword");
+    var form  = document.getElementById("anyword-form");
+    if (!input || !form) return;
+
+    form.addEventListener("submit", function () {
+      if (input.value.trim()) addToHistory(input.value.trim());
+    });
+
+    input.addEventListener("focus", function () {
+      if (getHistory().length > 0) renderDropdown();
+    });
+    input.addEventListener("blur", function () {
+      setTimeout(function () {
+        var dropdown = document.getElementById("search-history-dropdown");
+        if (dropdown) dropdown.hidden = true;
+      }, 180);
+    });
+  });
+})();
+</script>
 
 </body>
 </html>

--- a/search_listerdb_anysearch_index_bs5.php
+++ b/search_listerdb_anysearch_index_bs5.php
@@ -54,11 +54,14 @@ function printfilenamesearch()
     print '<div class="container py-3">';
     print '<div class="search-hero">';
     print '  <p class="form-label-sm mb-2">検索ワード <small>（ふりがな・作品名・曲名・歌手名・ファイル名の一部）</small></p>';
-    print '  <form action="search_listerdb_filelist.php" method="GET">';
-    print '    <div class="search-input-wrap">';
-    print '      <input type="text" name="anyword" id="anyword" class="form-control-themed"';
-    print '             placeholder="作品名、曲名、歌手名、ファイル名の一部" autocomplete="off" />';
-    print '      <button type="submit" class="btn-search-submit">検索</button>';
+    print '  <form action="search_listerdb_filelist.php" method="GET" id="anyword-form">';
+    print '    <div class="search-history-wrap">';
+    print '      <div class="search-input-wrap">';
+    print '        <input type="text" name="anyword" id="anyword" class="form-control-themed"';
+    print '               placeholder="作品名、曲名、歌手名、ファイル名の一部" autocomplete="off" />';
+    print '        <button type="submit" class="btn-search-submit">検索</button>';
+    print '      </div>';
+    print '      <div id="search-history-dropdown" hidden></div>';
     print '    </div>';
     print    $db_field . $sid_field;
     print '  </form>';
@@ -137,6 +140,98 @@ $db_field = !empty($lister_dbpath)
 
 <?php
 if (empty($includepage)) {
+    print '<script>
+(function () {
+  var STORAGE_KEY = "krw_search_history";
+  var MAX_HISTORY = 10;
+
+  function getHistory() {
+    try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]"); }
+    catch (e) { return []; }
+  }
+  function saveHistory(hist) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(hist));
+  }
+  function addToHistory(word) {
+    word = word.trim();
+    if (!word) return;
+    var hist = getHistory().filter(function (h) { return h !== word; });
+    hist.unshift(word);
+    saveHistory(hist.slice(0, MAX_HISTORY));
+  }
+  function removeFromHistory(word) {
+    saveHistory(getHistory().filter(function (h) { return h !== word; }));
+  }
+  function escHtml(s) {
+    return s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
+  }
+
+  function renderDropdown() {
+    var dropdown = document.getElementById("search-history-dropdown");
+    if (!dropdown) return;
+    var hist = getHistory();
+    if (hist.length === 0) { dropdown.hidden = true; dropdown.innerHTML = ""; return; }
+
+    var html = "<ul class=\"search-history-list\">";
+    hist.forEach(function (word) {
+      var e = escHtml(word);
+      html += "<li class=\"search-history-item\">"
+            + "<button type=\"button\" class=\"search-history-word\" data-word=\"" + e + "\">" + e + "</button>"
+            + "<button type=\"button\" class=\"search-history-del\" data-word=\"" + e + "\" aria-label=\"削除\">×</button>"
+            + "</li>";
+    });
+    html += "</ul>";
+    html += "<div class=\"search-history-footer\"><button type=\"button\" id=\"search-history-clear\">履歴をクリア</button></div>";
+    dropdown.innerHTML = html;
+    dropdown.hidden = false;
+
+    dropdown.querySelectorAll(".search-history-word").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var input = document.getElementById("anyword");
+        input.value = btn.dataset.word;
+        dropdown.hidden = true;
+        addToHistory(btn.dataset.word);
+        input.form.submit();
+      });
+    });
+    dropdown.querySelectorAll(".search-history-del").forEach(function (btn) {
+      btn.addEventListener("mousedown", function (e) { e.preventDefault(); });
+      btn.addEventListener("click", function () {
+        removeFromHistory(btn.dataset.word);
+        renderDropdown();
+      });
+    });
+    var clearBtn = document.getElementById("search-history-clear");
+    if (clearBtn) {
+      clearBtn.addEventListener("mousedown", function (e) { e.preventDefault(); });
+      clearBtn.addEventListener("click", function () {
+        saveHistory([]);
+        renderDropdown();
+      });
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var input = document.getElementById("anyword");
+    var form  = document.getElementById("anyword-form");
+    if (!input || !form) return;
+
+    form.addEventListener("submit", function () {
+      if (input.value.trim()) addToHistory(input.value.trim());
+    });
+
+    input.addEventListener("focus", function () {
+      if (getHistory().length > 0) renderDropdown();
+    });
+    input.addEventListener("blur", function () {
+      setTimeout(function () {
+        var dropdown = document.getElementById("search-history-dropdown");
+        if (dropdown) dropdown.hidden = true;
+      }, 180);
+    });
+  });
+})();
+</script>';
     print '</body></html>';
 }
 ?>


### PR DESCRIPTION
## Summary

キーワード検索フォーム（りすたーDB）に検索履歴ドロップダウン機能を追加しました。

- **保存場所**: ブラウザの localStorage（サーバー不要）
- **保存件数**: 最大10件（新しい順）
- **対応ページ**: `search_listerdb_anysearch_index_bs5.php` と `search_bs5.php`
- **共有**: 両ページで同じ localStorage キーを使用するため履歴が共有される

## 実装内容

### 動作
- 入力欄フォーカス時に、過去の検索ワードがあれば自動的にドロップダウン表示
- 履歴項目をクリック → 入力欄にセット → 自動検索
- 各項目右の「×」ボタンで個別削除、「履歴をクリア」で全削除
- フォームの外見は初期状態では変わらない（シンプルさを維持）

### 変更ファイル
- `search_listerdb_anysearch_index_bs5.php`
  - `printfilenamesearch()` に `.search-history-wrap` ラッパーと `#search-history-dropdown` div を追加
  - フォームに `id="anyword-form"` を付与
  - 検索履歴管理用の JS を `</body>` 直前に挿入

- `search_bs5.php`
  - `print_listerdb_fileonly()` に同じ HTML 構造を追加
  - 同じ JS を `</body>` 直前に挿入

- `css/themes/search.css`
  - ドロップダウンの表示・スタイル定義を追加（`.search-history-wrap`, `#search-history-dropdown`, 関連クラス）

## Test plan
- [ ] `search_listerdb_anysearch_index_bs5.php` で検索してから入力欄をフォーカスして履歴が表示される
- [ ] 履歴項目をクリックすると検索が実行される
- [ ] 「×」ボタンで個別削除ができる
- [ ] 「履歴をクリア」で全削除できる
- [ ] `search_bs5.php` でも同様に動作することを確認
- [ ] ブラウザのデベロッパーツール → Application → localStorage で `krw_search_history` キーが作成されていることを確認
- [ ] 両ページで履歴が共有されることを確認（一方で検索 → 他方で入力欄フォーカス → 履歴表示）

---
_Generated by [Claude Code](https://claude.ai/code/session_015tmpVVNp7rptVTceYBTUgv)_