### PR TITLE
コメント機能をBootstrap 5に移行・デザイン統一

### DIFF
--- a/comment.php
+++ b/comment.php
@@ -17,12 +17,6 @@ require_once 'commonfunc.php';
     <link href="css/bootstrap.min.css" rel="stylesheet">
 
 
-    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
 
 <title>コメントポスト</title>
 <link type="text/css" rel="stylesheet" href="css/style.css" />
@@ -65,40 +59,40 @@ print '<div align="center" class="commentpost" >';
 <form name=forms action="commentpost.php" class="sendcomment" method="post">
 
 <div class="row" >
-<div class="col-xs-12 col-sm-12" ><b>文字色</b> </div>
-<div class="col-xs-2 col-sm-push-11 col-sm-1" >その他 <input type="radio" name="col" value="CUSTOM" > <input type="color" name="c_col" value="#808080" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:white;"><input type="radio" name="col" value="FFFFFF" checked="checked" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:gray;"><input type="radio" name="col" value="808080" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:pink"><input type="radio" name="col" value="FFC0CB" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:red;"><input type="radio" name="col" value="FF0000" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:orange;"><input type="radio" name="col" value="FFA500" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:yellow;"><input type="radio" name="col" value="FFFF00" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:lime;"><input type="radio" name="col" value="00FF00" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:aqua;"><input type="radio" name="col" value="00FFFF" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:blue;"><input type="radio" name="col" value="0000FF" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:purple;"><input type="radio" name="col" value="800080" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:black;"><input type="radio" name="col" value="111111" ></div>
+<div class="col-12" ><b>文字色</b> </div>
+<div class="col-2 col-sm-1 order-sm-last" >その他 <input type="radio" name="col" value="CUSTOM" > <input type="color" name="c_col" value="#808080" ></div>
+<div class="col-2 col-sm-1" style="background-color:white;"><input type="radio" name="col" value="FFFFFF" checked="checked" ></div>
+<div class="col-2 col-sm-1" style="background-color:gray;"><input type="radio" name="col" value="808080" ></div>
+<div class="col-2 col-sm-1" style="background-color:pink"><input type="radio" name="col" value="FFC0CB" ></div>
+<div class="col-2 col-sm-1" style="background-color:red;"><input type="radio" name="col" value="FF0000" ></div>
+<div class="col-2 col-sm-1" style="background-color:orange;"><input type="radio" name="col" value="FFA500" ></div>
+<div class="col-2 col-sm-1" style="background-color:yellow;"><input type="radio" name="col" value="FFFF00" ></div>
+<div class="col-2 col-sm-1" style="background-color:lime;"><input type="radio" name="col" value="00FF00" ></div>
+<div class="col-2 col-sm-1" style="background-color:aqua;"><input type="radio" name="col" value="00FFFF" ></div>
+<div class="col-2 col-sm-1" style="background-color:blue;"><input type="radio" name="col" value="0000FF" ></div>
+<div class="col-2 col-sm-1" style="background-color:purple;"><input type="radio" name="col" value="800080" ></div>
+<div class="col-2 col-sm-1" style="background-color:black;"><input type="radio" name="col" value="111111" ></div>
 </div>
 <div class="row" >
-<div class="col-xs-12 col-sm-2"><b>文字サイズ</b></div>
-<div class="col-xs-3 col-sm-2">小<input type="radio" name="sz" value="0"></div>
-<div class="col-xs-3 col-sm-2">中<input type="radio" name="sz" value="3" checked="checked"></div>
-<div class="col-xs-3 col-sm-2">大<input type="radio" name="sz" value="6"></div>
-<div class="col-xs-3 col-sm-2">特大<input type="radio" name="sz" value="9"></div>
+<div class="col-12 col-sm-2"><b>文字サイズ</b></div>
+<div class="col-3 col-sm-2">小<input type="radio" name="sz" value="0"></div>
+<div class="col-3 col-sm-2">中<input type="radio" name="sz" value="3" checked="checked"></div>
+<div class="col-3 col-sm-2">大<input type="radio" name="sz" value="6"></div>
+<div class="col-3 col-sm-2">特大<input type="radio" name="sz" value="9"></div>
 </div>
-<div class="col-xs-12 col-sm-1" ><b>名前</b></div>
-<div class="col-xs-12 col-sm-2" >
+<div class="col-12 col-sm-1" ><b>名前</b></div>
+<div class="col-12 col-sm-2" >
 <input type=text name="nm" style="font-size:1em;WIDTH:100%;" fontsize=9 MAXLENGTH="32" title="匿名にしたいときは名前を空欄" value="
 EOD;
 print returnusername_self();
     print <<<EOD
 " > 
 </div>
-<div class="col-xs-12 col-sm-2" ><b>コメント</b></div>
-<div class="col-xs-12 col-sm-7" >
+<div class="col-12 col-sm-2" ><b>コメント</b></div>
+<div class="col-12 col-sm-7" >
 <input type="text" style="font-size:1em;WIDTH:100%;" name="msg" fontsize=8 MAXLENGTH="256" tabindex="1">
 </div>
-<br><font size=-1><input type="submit" name="SUBMIT" style="WIDTH:100%; HEIGHT:30;" align="right" value="コメント送信" class="btn btn-default ">
+<br><input type="submit" name="SUBMIT" style="WIDTH:100%; HEIGHT:30;" align="right" value="コメント送信" class="btn btn-secondary">
 </form>
 EOD;
 print '</div>';

--- a/comment.php
+++ b/comment.php
@@ -6,103 +6,98 @@ require_once 'commonfunc.php';
 <!doctype html>
 <html lang="ja">
 <head>
-<?php print_meta_header();?>
+<?php print_meta_header(); ?>
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta http-equiv="Pragma" content="no-cache">
 <meta http-equiv="cache-control" content="no-cache">
 <meta http-equiv="expires" content="0">
-
-
-    <!-- Bootstrap -->
-    <link href="css/bootstrap.min.css" rel="stylesheet">
-
-
-
 <title>コメントポスト</title>
-<link type="text/css" rel="stylesheet" href="css/style.css" />
-<!-- <script type='text/javascript' src='jwplayer/jwplayer.js'></script> -->
-<link rel="stylesheet" type="text/css" href="css/jquery.dataTables.css">
-<script type="text/javascript" charset="utf8" src="js/jquery.js"></script>
-<script type="text/javascript" charset="utf8" src="js/jquery.dataTables.js"></script>
-<script src="js/bootstrap.min.js"></script>
-<script type="text/javascript" charset="utf8" src="js/requsetlist_ctrl.js"></script>
+<?php print_bs5_search_head(); ?>
 </head>
 <body>
-<?php
-shownavigatioinbar();
-?>
+<?php shownavigatioinbar_bs5('comment.php'); ?>
 
-<div align="center" >
-<h4> 現在の動作モード </h4>
-<?php
-     if($playmode == 1){
-     print ("自動再生開始モード: 自動で次の曲の再生を開始します。");
-     }elseif ($playmode == 2){
-     print ("手動再生開始モード: 再生開始を押すと、次の曲が始まります。(歌う人が押してね)");
-     }elseif ($playmode == 4){
-     print ("BGMモード: 自動で次の曲の再生を開始します。すべての再生が終わると再生済みの曲をランダムに流します。");
-     }elseif ($playmode == 5){
-     print ("BGMモード(ランダムモード): 順番は関係なくリストの中からランダムで再生します。");
-     }else{
-     print ("手動プレイリスト登録モード: 機材係が手動でプレイリストに登録しています。");
-     }
-?>
-</div>
+<div class="container py-3">
 
+  <div class="card mb-3">
+    <div class="card-header">
+      <h5 class="card-title mb-0">現在の動作モード</h5>
+    </div>
+    <div class="card-body">
+      <?php
+      if ($playmode == 1) {
+          echo '自動再生開始モード: 自動で次の曲の再生を開始します。';
+      } elseif ($playmode == 2) {
+          echo '手動再生開始モード: 再生開始を押すと、次の曲が始まります。(歌う人が押してね)';
+      } elseif ($playmode == 4) {
+          echo 'BGMモード: 自動で次の曲の再生を開始します。すべての再生が終わると再生済みの曲をランダムに流します。';
+      } elseif ($playmode == 5) {
+          echo 'BGMモード(ランダムモード): 順番は関係なくリストの中からランダムで再生します。';
+      } else {
+          echo '手動プレイリスト登録モード: 機材係が手動でプレイリストに登録しています。';
+      }
+      ?>
+    </div>
+  </div>
 
-<?php
-if(commentenabledcheck()) {
-print '<div align="center" class="commentpost" >';
-//    print '<input type="button" onclick="location.href=\''.$commenturl.'\'" value="こちらから画面にコメントを出せます(ニコ生風に)" class="topbtn"/>';
-    print "<h4>こちらから画面にコメントを出せます(ニコ生風に)</h4>";
-    print <<<EOD
-<form name=forms action="commentpost.php" class="sendcomment" method="post">
+  <?php if (commentenabledcheck()): ?>
+  <div class="card">
+    <div class="card-header">
+      <h5 class="card-title mb-0">こちらから画面にコメントを出せます(ニコ生風に)</h5>
+    </div>
+    <div class="card-body">
+      <form name="forms" action="commentpost.php" class="sendcomment" method="post">
 
-<div class="row" >
-<div class="col-12" ><b>文字色</b> </div>
-<div class="col-2 col-sm-1 order-sm-last" >その他 <input type="radio" name="col" value="CUSTOM" > <input type="color" name="c_col" value="#808080" ></div>
-<div class="col-2 col-sm-1" style="background-color:white;"><input type="radio" name="col" value="FFFFFF" checked="checked" ></div>
-<div class="col-2 col-sm-1" style="background-color:gray;"><input type="radio" name="col" value="808080" ></div>
-<div class="col-2 col-sm-1" style="background-color:pink"><input type="radio" name="col" value="FFC0CB" ></div>
-<div class="col-2 col-sm-1" style="background-color:red;"><input type="radio" name="col" value="FF0000" ></div>
-<div class="col-2 col-sm-1" style="background-color:orange;"><input type="radio" name="col" value="FFA500" ></div>
-<div class="col-2 col-sm-1" style="background-color:yellow;"><input type="radio" name="col" value="FFFF00" ></div>
-<div class="col-2 col-sm-1" style="background-color:lime;"><input type="radio" name="col" value="00FF00" ></div>
-<div class="col-2 col-sm-1" style="background-color:aqua;"><input type="radio" name="col" value="00FFFF" ></div>
-<div class="col-2 col-sm-1" style="background-color:blue;"><input type="radio" name="col" value="0000FF" ></div>
-<div class="col-2 col-sm-1" style="background-color:purple;"><input type="radio" name="col" value="800080" ></div>
-<div class="col-2 col-sm-1" style="background-color:black;"><input type="radio" name="col" value="111111" ></div>
-</div>
-<div class="row" >
-<div class="col-12 col-sm-2"><b>文字サイズ</b></div>
-<div class="col-3 col-sm-2">小<input type="radio" name="sz" value="0"></div>
-<div class="col-3 col-sm-2">中<input type="radio" name="sz" value="3" checked="checked"></div>
-<div class="col-3 col-sm-2">大<input type="radio" name="sz" value="6"></div>
-<div class="col-3 col-sm-2">特大<input type="radio" name="sz" value="9"></div>
-</div>
-<div class="col-12 col-sm-1" ><b>名前</b></div>
-<div class="col-12 col-sm-2" >
-<input type=text name="nm" style="font-size:1em;WIDTH:100%;" fontsize=9 MAXLENGTH="32" title="匿名にしたいときは名前を空欄" value="
-EOD;
-print returnusername_self();
-    print <<<EOD
-" > 
-</div>
-<div class="col-12 col-sm-2" ><b>コメント</b></div>
-<div class="col-12 col-sm-7" >
-<input type="text" style="font-size:1em;WIDTH:100%;" name="msg" fontsize=8 MAXLENGTH="256" tabindex="1">
-</div>
-<br><input type="submit" name="SUBMIT" style="WIDTH:100%; HEIGHT:30;" align="right" value="コメント送信" class="btn btn-secondary">
-</form>
-EOD;
-print '</div>';
-}
-?>
+        <div class="mb-3">
+          <label class="form-label fw-bold">文字色</label>
+          <div class="d-flex flex-wrap gap-1 align-items-center">
+            <div style="background-color:white;width:2rem;height:2rem;border:1px solid #ccc;display:flex;align-items:center;justify-content:center;"><input type="radio" name="col" value="FFFFFF" checked></div>
+            <div style="background-color:gray;width:2rem;height:2rem;display:flex;align-items:center;justify-content:center;"><input type="radio" name="col" value="808080"></div>
+            <div style="background-color:pink;width:2rem;height:2rem;display:flex;align-items:center;justify-content:center;"><input type="radio" name="col" value="FFC0CB"></div>
+            <div style="background-color:red;width:2rem;height:2rem;display:flex;align-items:center;justify-content:center;"><input type="radio" name="col" value="FF0000"></div>
+            <div style="background-color:orange;width:2rem;height:2rem;display:flex;align-items:center;justify-content:center;"><input type="radio" name="col" value="FFA500"></div>
+            <div style="background-color:yellow;width:2rem;height:2rem;border:1px solid #ccc;display:flex;align-items:center;justify-content:center;"><input type="radio" name="col" value="FFFF00"></div>
+            <div style="background-color:lime;width:2rem;height:2rem;display:flex;align-items:center;justify-content:center;"><input type="radio" name="col" value="00FF00"></div>
+            <div style="background-color:aqua;width:2rem;height:2rem;display:flex;align-items:center;justify-content:center;"><input type="radio" name="col" value="00FFFF"></div>
+            <div style="background-color:blue;width:2rem;height:2rem;display:flex;align-items:center;justify-content:center;"><input type="radio" name="col" value="0000FF"></div>
+            <div style="background-color:purple;width:2rem;height:2rem;display:flex;align-items:center;justify-content:center;"><input type="radio" name="col" value="800080"></div>
+            <div style="background-color:black;width:2rem;height:2rem;display:flex;align-items:center;justify-content:center;"><input type="radio" name="col" value="111111"></div>
+            <div class="ms-2 d-flex align-items-center gap-1">
+              その他 <input type="radio" name="col" value="CUSTOM"> <input type="color" name="c_col" value="#808080">
+            </div>
+          </div>
+        </div>
 
-<br />
+        <div class="mb-3">
+          <label class="form-label fw-bold">文字サイズ</label>
+          <div class="d-flex gap-3">
+            <label><input type="radio" name="sz" value="0"> 小</label>
+            <label><input type="radio" name="sz" value="3" checked> 中</label>
+            <label><input type="radio" name="sz" value="6"> 大</label>
+            <label><input type="radio" name="sz" value="9"> 特大</label>
+          </div>
+        </div>
 
+        <div class="mb-3">
+          <label class="form-label fw-bold">名前</label>
+          <input type="text" name="nm" class="form-control" maxlength="32"
+                 title="匿名にしたいときは名前を空欄"
+                 value="<?php echo htmlspecialchars(returnusername_self(), ENT_QUOTES, 'UTF-8'); ?>">
+        </div>
 
+        <div class="mb-3">
+          <label class="form-label fw-bold">コメント</label>
+          <input type="text" name="msg" class="form-control" maxlength="256" tabindex="1">
+        </div>
+
+        <button type="submit" name="SUBMIT" class="btn btn-secondary w-100">コメント送信</button>
+
+      </form>
+    </div>
+  </div>
+  <?php endif; ?>
+
+</div><!-- /container -->
 
 </body>
 </html>
-

--- a/request.php
+++ b/request.php
@@ -29,12 +29,6 @@ require_once 'commonfunc.php';
     <link href="css/bootstrap.min.css" rel="stylesheet">
 
 
-    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
 
 <title>カラオケ動画リクエスト</title>
 <link type="text/css" rel="stylesheet" href="css/style.css" />
@@ -166,40 +160,40 @@ print '<div align="center" class="commentpost" >';
 <form name=forms action="commentpost.php" class="sendcomment" method="post">
 
 <div class="row" >
-<div class="col-xs-12 col-sm-12" ><b>文字色</b> </div>
-<div class="col-xs-2 col-sm-push-11 col-sm-1" >その他 <input type="radio" name="col" value="CUSTOM" > <input type="color" name="c_col" value="#FFFFFF" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:white;"><input type="radio" name="col" value="FFFFFF" checked="checked" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:gray;"><input type="radio" name="col" value="808080" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:pink"><input type="radio" name="col" value="FFC0CB" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:red;"><input type="radio" name="col" value="FF0000" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:orange;"><input type="radio" name="col" value="FFA500" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:yellow;"><input type="radio" name="col" value="FFFF00" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:lime;"><input type="radio" name="col" value="00FF00" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:aqua;"><input type="radio" name="col" value="00FFFF" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:blue;"><input type="radio" name="col" value="0000FF" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:purple;"><input type="radio" name="col" value="800080" ></div>
-<div class="col-xs-2 col-sm-pull-1 col-sm-1" style="background-color:black;"><input type="radio" name="col" value="111111" ></div>
+<div class="col-12" ><b>文字色</b> </div>
+<div class="col-2 col-sm-1 order-sm-last" >その他 <input type="radio" name="col" value="CUSTOM" > <input type="color" name="c_col" value="#FFFFFF" ></div>
+<div class="col-2 col-sm-1" style="background-color:white;"><input type="radio" name="col" value="FFFFFF" checked="checked" ></div>
+<div class="col-2 col-sm-1" style="background-color:gray;"><input type="radio" name="col" value="808080" ></div>
+<div class="col-2 col-sm-1" style="background-color:pink"><input type="radio" name="col" value="FFC0CB" ></div>
+<div class="col-2 col-sm-1" style="background-color:red;"><input type="radio" name="col" value="FF0000" ></div>
+<div class="col-2 col-sm-1" style="background-color:orange;"><input type="radio" name="col" value="FFA500" ></div>
+<div class="col-2 col-sm-1" style="background-color:yellow;"><input type="radio" name="col" value="FFFF00" ></div>
+<div class="col-2 col-sm-1" style="background-color:lime;"><input type="radio" name="col" value="00FF00" ></div>
+<div class="col-2 col-sm-1" style="background-color:aqua;"><input type="radio" name="col" value="00FFFF" ></div>
+<div class="col-2 col-sm-1" style="background-color:blue;"><input type="radio" name="col" value="0000FF" ></div>
+<div class="col-2 col-sm-1" style="background-color:purple;"><input type="radio" name="col" value="800080" ></div>
+<div class="col-2 col-sm-1" style="background-color:black;"><input type="radio" name="col" value="111111" ></div>
 </div>
 <div class="row" >
-<div class="col-xs-12 col-sm-2"><b>文字サイズ</b></div>
-<div class="col-xs-3 col-sm-2">小<input type="radio" name="sz" value="0"></div>
-<div class="col-xs-3 col-sm-2">中<input type="radio" name="sz" value="3" checked="checked"></div>
-<div class="col-xs-3 col-sm-2">大<input type="radio" name="sz" value="6"></div>
-<div class="col-xs-3 col-sm-2">特大<input type="radio" name="sz" value="9"></div>
+<div class="col-12 col-sm-2"><b>文字サイズ</b></div>
+<div class="col-3 col-sm-2">小<input type="radio" name="sz" value="0"></div>
+<div class="col-3 col-sm-2">中<input type="radio" name="sz" value="3" checked="checked"></div>
+<div class="col-3 col-sm-2">大<input type="radio" name="sz" value="6"></div>
+<div class="col-3 col-sm-2">特大<input type="radio" name="sz" value="9"></div>
 </div>
-<div class="col-xs-12 col-sm-1" ><b>名前</b></div>
-<div class="col-xs-12 col-sm-2" >
+<div class="col-12 col-sm-1" ><b>名前</b></div>
+<div class="col-12 col-sm-2" >
 <input type=text name="nm" style="font-size:1em;WIDTH:100%;" fontsize=9 MAXLENGTH="32" value="
 EOD;
 print returnusername_self();
     print <<<EOD
 " > 
 </div>
-<div class="col-xs-12 col-sm-2" ><b>コメント</b></div>
-<div class="col-xs-12 col-sm-7" >
+<div class="col-12 col-sm-2" ><b>コメント</b></div>
+<div class="col-12 col-sm-7" >
 <input type="text" style="font-size:1em;WIDTH:100%;" name="msg" fontsize=8 MAXLENGTH="256" tabindex="1">
 </div>
-<br><font size=-1><input type="submit" name="SUBMIT" style="WIDTH:100%; HEIGHT:30;" align="right" value="コメント送信" class="btn btn-default ">
+<br><input type="submit" name="SUBMIT" style="WIDTH:100%; HEIGHT:30;" align="right" value="コメント送信" class="btn btn-secondary">
 </form>
 EOD;
 print '</div>';
@@ -208,7 +202,7 @@ print '</div>';
 
 
 <table id="request_table" class="cell-border">
-<caption> <h4>現在の登録状況 <button type="submit" value="" class="topbtn btn btn-default btn-xs"  onclick=location.reload() >更新</button></h4></caption>
+<caption> <h4>現在の登録状況 <button type="submit" value="" class="topbtn btn btn-secondary btn-sm"  onclick=location.reload() >更新</button></h4></caption>
 <thead>
 <tr>
 <th>No.</th>
@@ -243,7 +237,7 @@ if($user === "admin"){
 <script type="text/javascript" charset="utf8" src="js/requsetlist_ctrl.js"></script>
 <hr>
 <form method="get" action="init.php">
-<input type="submit" value="設定" class=" btn btn-default " />
+<input type="submit" value="設定" class="btn btn-secondary" />
 </form>
 <a href="toolinfo.php" > 接続情報表示 </a>
 

--- a/requestlist_table_json.php
+++ b/requestlist_table_json.php
@@ -82,9 +82,9 @@ foreach($allrequest as $value ){
 $showcommentblock = "";
 if(strlen($value['comment']) === 0){
 //    $showcommentblock = '<a class="btn btn-default" data-toggle="modal" data-target="#comment_modal_'.$value['id'].'">修正orレス</a>';
-    $showcommentblock = '<a href="#" data-toggle="modal" class="commentmodallink" data-target="#comment_modal_'.$value['id'].'"  title="このエリアを押すことでコメントにレスを付けたり編集したりできます">'.nl2br(htmlspecialchars($value['comment']))."</a>\n";
+    $showcommentblock = '<a href="#" data-bs-toggle="modal" class="commentmodallink" data-bs-target="#comment_modal_'.$value['id'].'"  title="このエリアを押すことでコメントにレスを付けたり編集したりできます">'.nl2br(htmlspecialchars($value['comment']))."</a>\n";
 } else {
-    $showcommentblock = '<a href="#" data-toggle="modal" class="commentmodallink" data-target="#comment_modal_'.$value['id'].'"  title="このエリアを押すことでコメントにレスを付けたり編集したりできます">'.nl2br(htmlspecialchars($value['comment']))."</a>\n";
+    $showcommentblock = '<a href="#" data-bs-toggle="modal" class="commentmodallink" data-bs-target="#comment_modal_'.$value['id'].'"  title="このエリアを押すことでコメントにレスを付けたり編集したりできます">'.nl2br(htmlspecialchars($value['comment']))."</a>\n";
 }    
     $comment_pf = <<<EOD
 <div style="position: relative;width:100%%;min-height: 1em;">
@@ -94,34 +94,32 @@ if(strlen($value['comment']) === 0){
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal">
-         <span aria-hidden="true">&times;</span>
-        </button>
-        <h4 class="modal-title" id="modal-label">コメントへのレス＆編集</h4>
+        <h5 class="modal-title" id="modal-label">コメントへのレス＆編集</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
       </div>
       <form method="GET" action="update.php" class="sendnomove" >\n
-      <div class="form-group">
+      <div class="mb-3">
       <textarea class="form-control" name="comment"  >%s</textarea>
       <input type="hidden" name="id" value="%s" />\n
-      <input type="submit" class="btn btn-default pull-right" name="edit"   value="修正"  />\n
+      <input type="submit" class="btn btn-secondary float-end" name="edit"   value="修正"  />\n
       </div>
       </form>\n
       <form method="GET" action="commentedit.php" class="sendnomove" >\n
-      <label class="control-label">コメント <small>再生中にコメントするとその場で流れます</small></label>
-      <div class="form-group btn-toolbar">
-      <label  class="col-sm-2 control-label">レス</label>
+      <label class="form-label">コメント <small>再生中にコメントするとその場で流れます</small></label>
+      <div class="mb-3">
+      <label class="col-sm-2 col-form-label">レス</label>
       <div class="col-sm-10">
       <input type="text" class="form-control" name="addcomment"  value="" placeholder="レス(コメントへの)"/>\n
       </div>
-      <label  class="col-sm-2 control-label">名前</label>
+      <label class="col-sm-2 col-form-label">名前</label>
       <div class="col-sm-10">
         <input type="text" name="name" class="form-control" value="%s" placeholder="名前" />\n
       </div>
       <input type="hidden" name="id" value="%s" />\n
-      <input type="submit" name="add"  class="btn btn-primary pull-right" value="送信"/>\n
+      <input type="submit" name="add"  class="btn btn-primary float-end" value="送信"/>\n
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
       </div>
     </form>
     </div>
@@ -205,7 +203,7 @@ $action_pf = <<<EOD
 <input type="hidden" name="id" class="requestid" value="%s" />
 <input type="hidden" name="songfile" id="requestsongfile" value="%s" />
 <div class="acition" >
-<button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+<button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
 リスト操作
 <span class="caret"></span>
 </button>
@@ -214,7 +212,7 @@ $action_pf = <<<EOD
 <li> <a class="requestmove" name="down" id="requestdown"  value="down" onClick='moverequestlist(this,%s,"down","%s")' > 下へ</a> </li>
 <li> <a class="requestmove" name="warikomi" id="requesttonext" value="warikomi" onClick='moverequestlist(this,%s,"warikomi","%s")' > 次に再生</a> </li>
 %s
-<li> <a href="#" class="" data-toggle="modal" data-target="#act_modal_%s">削除</a> </li>
+<li> <a href="#" class="" data-bs-toggle="modal" data-bs-target="#act_modal_%s">削除</a> </li>
 </ul>
 </div>
 <!--
@@ -227,14 +225,12 @@ $action_pf = <<<EOD
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal">
-         <span aria-hidden="true">&times;</span>
-        </button>
-        <h4 class="modal-title" id="modal-label">%sを削除します</h4>
+        <h5 class="modal-title" id="modal-label">%sを削除します</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
       </div>
       <div class="modal-footer">
         <form method="post" class="sendnomove" action="delete.php">
-        <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
           <input type="hidden" name="id" class="requestid" value="%s" />
           <input type="hidden" name="songfile" id="requestsongfile" value="%s" />
           <button class="btn btn-primary" type="submit" name="delete" id="requestdelete" value="delete" > 削除</button>
@@ -258,12 +254,12 @@ EOD;
 //★         $stopbtnmsg = '<small>曲停止</small><br /><strong>要次曲</strong>';
             $stopbtnmsg = '<strong>曲終了</strong>';//★ 「曲終了」を目立たせる。次曲がなくても予約待機になるため「要次曲」は削除。
         }
-        $songstop ='<button type="button" class="btn btn-default" onClick=\'song_end(this,'.$value["id"].');return false;\' >'.$stopbtnmsg.'</button>';
+        $songstop ='<button type="button" class="btn btn-secondary" onClick=\'song_end(this,'.$value["id"].');return false;\' >'.$stopbtnmsg.'</button>';
     }
     // 曲開始ボタン
     if($value['nowplaying'] === '再生開始待ち'){
         if($value['kind'] === '動画'  ){ 
-        $songstop ='<button type="button" class="btn btn-default" onClick=\'song_start(this,'.$value["id"].');return false;\' >曲開始</button>';
+        $songstop ='<button type="button" class="btn btn-secondary" onClick=\'song_start(this,'.$value["id"].');return false;\' >曲開始</button>';
         }
     }
     


### PR DESCRIPTION
## Summary

コメント機能全体をBootstrap 5に移行し、検索画面（search_bs5.php）やマイページ（mypage.php）と統一されたデザインに刷新しました。

## Changes

### comment.php の完全リデザイン
- **CSS/JS**: `bootstrap.min.css` (BS3) から `print_bs5_search_head()` に変更
  - `css/bootstrap5/bootstrap.min.css`
  - `css/themes/_variables.css`
  - `css/themes/search.css`
- **ナビバー**: `shownavigatioinbar()` (BS3) → `shownavigatioinbar_bs5('comment.php')`
- **レイアウト**: `align="center"` から `container py-3` コンテナに統一
- **コンポーネント**: 従来のグリッド + div から `card` コンポーネントに統一
  - 動作モード表示を card に
  - コメントフォームを card ボディに配置
- **フォーム要素**: Flexbox ベースのレイアウト
  - 文字色: `d-flex flex-wrap gap-1` で色スウォッチを整列
  - 文字サイズ: `d-flex gap-3` でラベルグループ化
  - 名前・コメント入力: `form-control` クラスを適用
- **セキュリティ**: `returnusername_self()` の出力を `htmlspecialchars()` でエスケープ
- **クリーンアップ**: 不要なスクリプト（dataTables、requsetlist_ctrl.js）を削除

### requestlist_table_json.php のコメントモーダル BS5化
- `data-toggle/data-target/data-dismiss` → `data-bs-toggle/data-bs-target/data-bs-dismiss`
- モーダルクローズボタンを BS5 形式（`btn-close`）に
- モーダルヘッダーの構造を BS5 仕様に調整（タイトル後にクローズボタン）
- `btn-default` → `btn-secondary`
- `pull-right` → `float-end`
- `form-group` → `mb-3`
- `control-label` → `col-form-label` / `form-label`

### request.php のコメントセクション BS5化
- グリッド: `col-xs-*` / `col-sm-*` → `col-*` / `col-sm-*`
- `col-sm-push-11` / `col-sm-pull-1` → `order-sm-last`
- `btn-default` → `btn-secondary`
- `btn-xs` → `btn-sm`
- IE8 HTML5 shim 条件コメントを削除

## Visual Design

comment.php は now:
- 検索画面（search_bs5.php）と同じ BS5 + テーマシステムを使用
- 同じナビバースタイル・padding・card コンポーネント配置
- 統一された color scheme と spacing

## Test Plan

- [ ] comment.php を開き、ナビバーが表示されることを確認
- [ ] 動作モード情報がカード形式で表示されることを確認
- [ ] コメントフォームが見やすくレイアウトされていることを確認
- [ ] 文字色スウォッチが整列して表示されることを確認
- [ ] コメント送信が機能することを確認
- [ ] リクエスト一覧のコメントモーダルが表示・動作することを確認
- [ ] request.php のコメントセクションがBS5スタイルで表示されることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ya6JtnFvSNDQfbPduKNTqq)_