### PR TITLE
minor fixes: BS5デザイン改善・UI v2設定統合・シークレット表示設定・config.ini修復

### DIFF
--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1245,11 +1245,11 @@ EOD;
     print '</li>';
 
     print '     <li  ';
-    if($page == 'playerctrl_portal.php')
+    if($page == 'playerctrl_portal.php' || $page == 'playerctrl_portal_bs5.php')
     {
         print 'class="active" ';
     }
-    print '><a href="'.$prefix.'playerctrl_portal.php" >Player</a></li>';
+    print '><a href="'.$prefix.'playerctrl_portal_top.php" >Player</a></li>';
     // comment 
     if(commentenabledcheck()){
         print '     <li ';
@@ -1536,7 +1536,7 @@ function shownavigatioinbar_bs5($page = 'none', $prefix = '') {
 
     // Player
     $pl_active = ($page == 'playerctrl_portal.php' || $page == 'playerctrl_portal_bs5.php') ? ' active' : '';
-    print '<li class="nav-item"><a class="nav-link' . $pl_active . '" href="' . htmlspecialchars($prefix, ENT_QUOTES, 'UTF-8') . 'playerctrl_portal_bs5.php">Player</a></li>';
+    print '<li class="nav-item"><a class="nav-link' . $pl_active . '" href="' . htmlspecialchars($prefix, ENT_QUOTES, 'UTF-8') . 'playerctrl_portal_top.php">Player</a></li>';
 
     // コメント
     if (commentenabledcheck()) {

--- a/func_readconfig.php
+++ b/func_readconfig.php
@@ -9,7 +9,8 @@ class ReadConfig {
         $config_ini = array ();
     
         if(file_exists($this->readconfigfile)){
-            $this->read_config_ini = parse_ini_file($this->readconfigfile);
+            $parsed = parse_ini_file($this->readconfigfile);
+            $this->read_config_ini = is_array($parsed) ? $parsed : false;
         }else {
             $this->read_config_ini = false;
         }

--- a/get_playingstatus_json.php
+++ b/get_playingstatus_json.php
@@ -52,7 +52,7 @@
 
               $sf = $row_next['songfile'];
               $sn = $sn_raw !== '' ? $sn_raw : '';
-              $secret_text = $config_ini['secret_display_text'] ?? 'ヒ・ミ・ツ♪(シークレット予約)';
+              $secret_text = urldecode($config_ini['secret_display_text'] ?? urlencode('ヒ・ミ・ツ♪(シークレット予約)'));
               $ret['nextsong'] = [
                   'title'    => $is_secret_next ? $secret_text : ($sn ?: $sf),
                   'songfile' => $is_secret_next ? '' : $sf,

--- a/get_playingstatus_json.php
+++ b/get_playingstatus_json.php
@@ -52,8 +52,9 @@
 
               $sf = $row_next['songfile'];
               $sn = $sn_raw !== '' ? $sn_raw : '';
+              $secret_text = $config_ini['secret_display_text'] ?? 'ヒ・ミ・ツ♪(シークレット予約)';
               $ret['nextsong'] = [
-                  'title'    => $is_secret_next ? 'ヒ・ミ・ツ♪' : ($sn ?: $sf),
+                  'title'    => $is_secret_next ? $secret_text : ($sn ?: $sf),
                   'songfile' => $is_secret_next ? '' : $sf,
                   'show_file'=> !$is_secret_next && $sn !== '' && $sn !== $sf,
                   'singer'   => $is_secret_next ? '' : $row_next['singer'],

--- a/init.php
+++ b/init.php
@@ -571,7 +571,7 @@ print ' value="10" ';
     <h4 class="radio control-label"> シークレット予約の表示テキスト </h4>
     <label class="radio control-label"><small>未再生のシークレット予約の曲名の代わりに表示するテキストです。</small></label>
     <input type="text" name="secret_display_text" class="form-control"
-      value="<?php echo htmlspecialchars($config_ini['secret_display_text'] ?? 'ヒ・ミ・ツ♪(シークレット予約)', ENT_QUOTES, 'UTF-8'); ?>"
+      value="<?php echo htmlspecialchars(urldecode($config_ini['secret_display_text'] ?? urlencode('ヒ・ミ・ツ♪(シークレット予約)')), ENT_QUOTES, 'UTF-8'); ?>"
       placeholder="ヒ・ミ・ツ♪(シークレット予約)" />
   </div>
 

--- a/init.php
+++ b/init.php
@@ -566,6 +566,15 @@ print ' value="10" ';
     </label>
   </div>
 
+<!---- シークレット予約の表示テキスト ----->
+  <div class="form-group">
+    <h4 class="radio control-label"> シークレット予約の表示テキスト </h4>
+    <label class="radio control-label"><small>未再生のシークレット予約の曲名の代わりに表示するテキストです。</small></label>
+    <input type="text" name="secret_display_text" class="form-control"
+      value="<?php echo htmlspecialchars($config_ini['secret_display_text'] ?? 'ヒ・ミ・ツ♪(シークレット予約)', ENT_QUOTES, 'UTF-8'); ?>"
+      placeholder="ヒ・ミ・ツ♪(シークレット予約)" />
+  </div>
+
 <!---- ページ背景色設定 ----->
   <?php
       $bgcolor='#F8ECE0';

--- a/init.php
+++ b/init.php
@@ -163,6 +163,15 @@ foreach($newconfig as $key => $value){
 }
 
 if(!empty($newconfig) ) $newconfig['roomurlshow'] = $new_roomurlshow ;
+
+// usev2ui（統合設定）を個別キーに展開
+if (isset($newconfig['usev2ui'])) {
+    $v2 = ($newconfig['usev2ui'] == '1');
+    $newconfig['usenewrequestlist'] = $v2 ? '1' : '0';
+    $newconfig['usenewsearchui']    = $v2 ? '1' : '2';
+    unset($newconfig['usev2ui']);
+}
+
 // $config_ini['roomurl'] = array();
 $config_ini_new = array_merge($config_ini,$newconfig);
 
@@ -537,49 +546,23 @@ print ' value="10" ';
   </label>
   </div>
 
-<!---- リクエスト一覧UI v2 ----->
+<!---- UI v2 ----->
   <?php
-      $usenewrequestlist = false;
-      if(array_key_exists("usenewrequestlist",$config_ini)){
-          if($config_ini["usenewrequestlist"] == 1 ){
-             $usenewrequestlist = true;
-          }
-      }
+      $usev2ui = (isset($config_ini["usenewrequestlist"]) && $config_ini["usenewrequestlist"] == 1)
+              || (isset($config_ini["usenewsearchui"])    && $config_ini["usenewsearchui"]    == 1);
   ?>
   <div class="form-group">
-    <h4 class="radio control-label"> リクエスト一覧UI v2 </h4>
-    <label class="radio control-label"><small>ドラッグハンドルで並べ替え・左スワイプでアクションメニューを表示するリクエスト一覧画面を使用します。</small></label>
+    <h4 class="radio control-label"> UI v2 </h4>
+    <label class="radio control-label"><small>リクエスト一覧・検索画面をまとめてv2デザイン（モバイル対応）に切り替えます。</small></label>
     <label class="radio-inline">
-      <input type="radio" name="usenewrequestlist" value="1" <?php print ($usenewrequestlist)?'checked':' ' ?> /> 使用する
+      <input type="radio" name="usev2ui" value="1" <?php print $usev2ui ? 'checked' : '' ?> /> 使用する
     </label>
     <label class="radio-inline">
-      <input type="radio" name="usenewrequestlist" value="0" <?php print (!$usenewrequestlist)?'checked':' ' ?> /> 使用しない
+      <input type="radio" name="usev2ui" value="0" <?php print !$usev2ui ? 'checked' : '' ?> /> 使用しない
     </label>
     <label>
       <a href="requestlist_swipe.php"> リクエスト一覧UI v2 へのリンク </a>
-    </label>
-  </div>
-
-<!---- 検索画面UI v2 ----->
-  <?php
-      $usenewsearchui = false;
-      if(array_key_exists("usenewsearchui",$config_ini)){
-          if($config_ini["usenewsearchui"] == 1 ){
-             $usenewsearchui = true;
-          }
-      }
-  ?>
-  <div class="form-group">
-    <h4 class="radio control-label"> 検索画面UI v2 </h4>
-    <label class="radio control-label"><small>モバイル対応の検索画面を使用します。旧バージョンに戻すには「使用しない」を選択してください。</small></label>
-    <label class="radio-inline">
-      <input type="radio" name="usenewsearchui" value="1" <?php print ($usenewsearchui)?'checked':' ' ?> /> 使用する
-    </label>
-    <label class="radio-inline">
-      <input type="radio" name="usenewsearchui" value="2" <?php print (!$usenewsearchui)?'checked':' ' ?> /> 使用しない
-    </label>
-    <label>
-      <a href="search_bs5.php"> 検索画面UI v2 へのリンク </a>
+      　<a href="search_bs5.php"> 検索画面UI v2 へのリンク </a>
     </label>
   </div>
 

--- a/init.php
+++ b/init.php
@@ -537,7 +537,7 @@ print ' value="10" ';
   </label>
   </div>
 
-<!---- スワイプ操作対応リクエスト一覧UI ----->
+<!---- リクエスト一覧UI v2 ----->
   <?php
       $usenewrequestlist = false;
       if(array_key_exists("usenewrequestlist",$config_ini)){
@@ -547,7 +547,7 @@ print ' value="10" ';
       }
   ?>
   <div class="form-group">
-    <h4 class="radio control-label"> スワイプ操作対応リクエスト一覧UI </h4>
+    <h4 class="radio control-label"> リクエスト一覧UI v2 </h4>
     <label class="radio control-label"><small>ドラッグハンドルで並べ替え・左スワイプでアクションメニューを表示するリクエスト一覧画面を使用します。</small></label>
     <label class="radio-inline">
       <input type="radio" name="usenewrequestlist" value="1" <?php print ($usenewrequestlist)?'checked':' ' ?> /> 使用する
@@ -556,11 +556,11 @@ print ' value="10" ';
       <input type="radio" name="usenewrequestlist" value="0" <?php print (!$usenewrequestlist)?'checked':' ' ?> /> 使用しない
     </label>
     <label>
-      <a href="requestlist_swipe.php"> スワイプUIリクエスト一覧へのリンク </a>
+      <a href="requestlist_swipe.php"> リクエスト一覧UI v2 へのリンク </a>
     </label>
   </div>
 
-<!---- 新デザイン検索画面UI ----->
+<!---- 検索画面UI v2 ----->
   <?php
       $usenewsearchui = false;
       if(array_key_exists("usenewsearchui",$config_ini)){
@@ -570,8 +570,8 @@ print ' value="10" ';
       }
   ?>
   <div class="form-group">
-    <h4 class="radio control-label"> 新デザイン検索画面UI（Bootstrap 5） </h4>
-    <label class="radio control-label"><small>モバイル対応の新デザイン検索画面を使用します。旧デザインに戻すには「使用しない」を選択してください。</small></label>
+    <h4 class="radio control-label"> 検索画面UI v2 </h4>
+    <label class="radio control-label"><small>モバイル対応の検索画面を使用します。旧バージョンに戻すには「使用しない」を選択してください。</small></label>
     <label class="radio-inline">
       <input type="radio" name="usenewsearchui" value="1" <?php print ($usenewsearchui)?'checked':' ' ?> /> 使用する
     </label>
@@ -579,7 +579,7 @@ print ' value="10" ';
       <input type="radio" name="usenewsearchui" value="2" <?php print (!$usenewsearchui)?'checked':' ' ?> /> 使用しない
     </label>
     <label>
-      <a href="search_bs5.php"> 新デザイン検索画面へのリンク </a>
+      <a href="search_bs5.php"> 検索画面UI v2 へのリンク </a>
     </label>
   </div>
 

--- a/kara_config.php
+++ b/kara_config.php
@@ -10,9 +10,10 @@ function readconfig_array()
     $configinifile = $configfile."";
     
     if(file_exists($configinifile)){
-        $config_ini = parse_ini_file($configinifile);
-    }else {
-       // set initial value
+        $parsed = parse_ini_file($configinifile);
+        if (is_array($parsed)) {
+            $config_ini = $parsed;
+        }
     }
     // set initial value
     if(!array_key_exists("dbname", $config_ini)){
@@ -144,9 +145,7 @@ function readconfig_array()
         $config_ini = array_merge($config_ini,array("usenewrequestlist" => 2));
     }
     if(!array_key_exists("secret_display_text", $config_ini)){
-        $config_ini["secret_display_text"] = "ヒ・ミ・ツ♪(シークレット予約)";
-    } else {
-        $config_ini["secret_display_text"] = urldecode($config_ini["secret_display_text"]);
+        $config_ini["secret_display_text"] = urlencode("ヒ・ミ・ツ♪(シークレット予約)");
     }
     if(!array_key_exists("usemypage", $config_ini)){
         $config_ini = array_merge($config_ini,array("usemypage" => 1));

--- a/kara_config.php
+++ b/kara_config.php
@@ -143,6 +143,11 @@ function readconfig_array()
     if(!array_key_exists("usenewrequestlist", $config_ini)){
         $config_ini = array_merge($config_ini,array("usenewrequestlist" => 2));
     }
+    if(!array_key_exists("secret_display_text", $config_ini)){
+        $config_ini["secret_display_text"] = "ヒ・ミ・ツ♪(シークレット予約)";
+    } else {
+        $config_ini["secret_display_text"] = urldecode($config_ini["secret_display_text"]);
+    }
     if(!array_key_exists("usemypage", $config_ini)){
         $config_ini = array_merge($config_ini,array("usemypage" => 1));
     }

--- a/mpcctrl_bs5.php
+++ b/mpcctrl_bs5.php
@@ -203,8 +203,9 @@ try {
 
             $sf = htmlspecialchars($row_next['songfile'], ENT_QUOTES, 'UTF-8');
             $sn = $sn_raw !== '' ? htmlspecialchars($sn_raw, ENT_QUOTES, 'UTF-8') : '';
+            $secret_text = htmlspecialchars($config_ini['secret_display_text'] ?? 'ヒ・ミ・ツ♪(シークレット予約)', ENT_QUOTES, 'UTF-8');
             $next_song = [
-                'title'    => $is_secret_next ? 'ヒ・ミ・ツ♪' : ($sn ?: $sf),
+                'title'    => $is_secret_next ? $secret_text : ($sn ?: $sf),
                 'songfile' => $is_secret_next ? '' : $sf,
                 'show_file'=> !$is_secret_next && $sn !== '' && $sn !== $sf,
                 'singer'   => $is_secret_next ? '' : htmlspecialchars($row_next['singer'], ENT_QUOTES, 'UTF-8'),

--- a/mpcctrl_bs5.php
+++ b/mpcctrl_bs5.php
@@ -203,7 +203,7 @@ try {
 
             $sf = htmlspecialchars($row_next['songfile'], ENT_QUOTES, 'UTF-8');
             $sn = $sn_raw !== '' ? htmlspecialchars($sn_raw, ENT_QUOTES, 'UTF-8') : '';
-            $secret_text = htmlspecialchars($config_ini['secret_display_text'] ?? 'ヒ・ミ・ツ♪(シークレット予約)', ENT_QUOTES, 'UTF-8');
+            $secret_text = htmlspecialchars(urldecode($config_ini['secret_display_text'] ?? urlencode('ヒ・ミ・ツ♪(シークレット予約)')), ENT_QUOTES, 'UTF-8');
             $next_song = [
                 'title'    => $is_secret_next ? $secret_text : ($sn ?: $sf),
                 'songfile' => $is_secret_next ? '' : $sf,

--- a/playerctrl_portal_top.php
+++ b/playerctrl_portal_top.php
@@ -1,0 +1,25 @@
+<?php
+header('Pragma: no-cache');
+header('Cache-Control: no-cache, no-store, max-age=0, must-revalidate');
+header('Expires: Mon, 01 Jan 1990 00:00:00 GMT');
+
+$config = [];
+if (file_exists('config.ini')) {
+    $config = @parse_ini_file('config.ini');
+    if ($config === false) {
+        $config = [];
+    }
+}
+$useV2 = isset($config['usenewrequestlist']) && $config['usenewrequestlist'] == '1';
+$target = $useV2 ? 'playerctrl_portal_bs5.php' : 'playerctrl_portal.php';
+
+$params = [];
+if (array_key_exists('easypass', $_REQUEST)) {
+    $params[] = 'easypass=' . urlencode($_REQUEST['easypass']);
+}
+if (!empty($params)) {
+    $target .= '?' . implode('&', $params);
+}
+
+header('Location: ' . $target);
+exit();

--- a/repair_config.php
+++ b/repair_config.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * repair_config.php - config.ini 修復スクリプト
+ * secret_display_text の不正な値（括弧等の特殊文字）によって
+ * parse_ini_file が失敗する状態を修復します。
+ * 実行後はこのファイルを削除してください。
+ */
+
+$configfile = 'config.ini';
+
+if (!file_exists($configfile)) {
+    echo '<p>config.ini が見つかりません。設定ファイルが存在するか確認してください。</p>';
+    exit;
+}
+
+// まず現在の状態を確認
+$test = parse_ini_file($configfile);
+if (is_array($test)) {
+    echo '<p style="color:green;">✔ config.ini は正常に読み込めます。修復は不要です。</p>';
+    exit;
+}
+
+// 行ごとに読み込んで問題のある値を修正
+$lines = file($configfile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+if ($lines === false) {
+    echo '<p style="color:red;">config.ini を読み込めませんでした。</p>';
+    exit;
+}
+
+$fixed = [];
+foreach ($lines as $line) {
+    $trimmed = trim($line);
+
+    // コメント・セクションはそのまま
+    if ($trimmed === '' || $trimmed[0] === ';' || $trimmed[0] === '#' || $trimmed[0] === '[') {
+        $fixed[] = $line;
+        continue;
+    }
+
+    // key=value を分解
+    $eqpos = strpos($trimmed, '=');
+    if ($eqpos === false) {
+        $fixed[] = $line;
+        continue;
+    }
+
+    $key   = trim(substr($trimmed, 0, $eqpos));
+    $value = substr($trimmed, $eqpos + 1);
+
+    // secret_display_text が未エンコードで書き込まれていた場合、URL エンコードして修正
+    if ($key === 'secret_display_text') {
+        // すでに %xx 形式ならそのまま、そうでなければエンコード
+        $decoded = urldecode($value);
+        $fixed[] = $key . '=' . urlencode($decoded);
+        continue;
+    }
+
+    $fixed[] = $line;
+}
+
+$content = implode("\n", $fixed) . "\n";
+if (file_put_contents($configfile, $content) === false) {
+    echo '<p style="color:red;">config.ini への書き込みに失敗しました。ファイルのパーミッションを確認してください。</p>';
+    exit;
+}
+
+// 修復後に再確認
+$retest = parse_ini_file($configfile);
+if (is_array($retest)) {
+    echo '<p style="color:green; font-size:1.2em;">✔ config.ini を修復しました。</p>';
+    echo '<p>このファイル (repair_config.php) を削除してから通常のページを開いてください。</p>';
+} else {
+    echo '<p style="color:red;">修復しましたが、まだ問題があります。config.ini を手動で確認してください。</p>';
+    echo '<p>config.ini の内容を確認するか、ファイルを削除して init.php から再設定してください。</p>';
+}

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -83,10 +83,10 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
   padding: 0;
 }
 .action-btn:active { opacity: 0.8; }
-.action-replace { background: #27ae60; }
-.action-next    { background: #e67e22; }
-.action-delete  { background: #e74c3c; }
-.action-change  { background: #7f8c8d; }
+.action-replace { background: var(--bs-success); }
+.action-next    { background: var(--bs-orange, #fd7e14); }
+.action-delete  { background: var(--bs-danger); }
+.action-change  { background: var(--bs-secondary); }
 .action-icon    { font-size: 18px; }
 
 /* カード本体（スワイプで左にスライド） */
@@ -167,7 +167,7 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
   padding: 2px 0;
   min-height: 18px;
 }
-.card-comment-area:hover { color: #337ab7; text-decoration: underline; }
+.card-comment-area:hover { color: var(--bs-primary); text-decoration: underline; }
 .card-comment-placeholder { color: #bbb; font-style: italic; }
 /* Tweet リンク */
 .card-tweet-link {
@@ -182,7 +182,7 @@ body { background-color: <?php echo htmlspecialchars($bgcolor, ENT_QUOTES, 'UTF-
 /* SortableJS */
 .sortable-ghost {
   opacity: 0.4;
-  background: #d9eaf7 !important;
+  background: #cfe2ff !important;
 }
 .sortable-chosen {
   box-shadow: 0 4px 12px rgba(0,0,0,0.25);
@@ -288,11 +288,10 @@ if (!empty($config_ini['noticeof_listpage'])) {
 ?>
 
 <?php if ($reloadInterval != 0): ?>
-<div class="checkbox">
-  <label class="d-inline-flex align-items-center gap-1" data-bs-toggle="tooltip" data-bs-placement="top"
-         title="コピペとかする時はチェックを外してください">
-    <input type="checkbox" id="autoreload" checked> 自動リロード
-  </label>
+<div class="form-check" data-bs-toggle="tooltip" data-bs-placement="top"
+     title="コピペとかする時はチェックを外してください">
+  <input class="form-check-input" type="checkbox" id="autoreload" checked>
+  <label class="form-check-label" for="autoreload">自動リロード</label>
 </div>
 <?php endif; ?>
 
@@ -302,7 +301,7 @@ if (!empty($config_ini['noticeof_listpage'])) {
   <div class="toolbar-left">
     <h4>現在の登録状況</h4>
     <button class="btn btn-outline-secondary btn-sm" id="refresh-btn">更新</button>
-    <button class="btn btn-warning btn-sm" id="goto-playing-btn">&#9654; 再生中へ</button>
+    <button class="btn btn-outline-primary btn-sm" id="goto-playing-btn">&#9654; 再生中へ</button>
   </div>
   <div class="toolbar-right">
     <a href="simplelistexport_utf8.php" class="btn btn-outline-secondary btn-sm">リクエストリストCSV</a>
@@ -325,7 +324,7 @@ if (!empty($config_ini['noticeof_listpage'])) {
 
 <div id="request-list"></div>
 <div id="load-more-wrap" style="display:none">
-  <button class="btn btn-default" id="load-more-btn">もっと見る</button>
+  <button class="btn btn-outline-secondary" id="load-more-btn">もっと見る</button>
 </div>
 <div id="empty-msg" style="display:none">リクエストはありません</div>
 
@@ -506,7 +505,7 @@ function createCardHTML(item, idx) {
     // 曲終了 / 曲開始ボタン
     var ctrlBtn = '';
     if (isPlaying(item.nowplaying)) {
-        ctrlBtn = '<button class="btn btn-warning btn-sm card-ctrl-btn song-end-btn">曲終了</button>';
+        ctrlBtn = '<button class="btn btn-outline-warning btn-sm card-ctrl-btn song-end-btn">曲終了</button>';
     } else if (isWaiting(item.nowplaying) && item.kind === '動画') {
         ctrlBtn = '<button class="btn btn-success btn-sm card-ctrl-btn song-start-btn">曲開始</button>';
     }

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -300,12 +300,12 @@ if (!empty($config_ini['noticeof_listpage'])) {
 <div class="list-toolbar">
   <div class="toolbar-left">
     <h4>現在の登録状況</h4>
-    <button class="btn btn-outline-secondary btn-sm" id="refresh-btn">更新</button>
-    <button class="btn btn-outline-primary btn-sm" id="goto-playing-btn">&#9654; 再生中へ</button>
+    <button class="btn btn-secondary btn-sm" id="refresh-btn">更新</button>
+    <button class="btn btn-primary btn-sm" id="goto-playing-btn">&#9654; 再生中へ</button>
   </div>
   <div class="toolbar-right">
-    <a href="simplelistexport_utf8.php" class="btn btn-outline-secondary btn-sm">リクエストリストCSV</a>
-    <a href="simplelist.php" class="btn btn-outline-secondary btn-sm">シンプルリスト</a>
+    <a href="simplelistexport_utf8.php" class="btn btn-secondary btn-sm">リクエストリストCSV</a>
+    <a href="simplelist.php" class="btn btn-secondary btn-sm">シンプルリスト</a>
 <?php if ($requestlist_num > 0): ?>
     <select id="count-select" class="form-select form-select-sm">
       <option value="<?php echo $requestlist_num; ?>"><?php echo $requestlist_num; ?>件</option>
@@ -324,7 +324,7 @@ if (!empty($config_ini['noticeof_listpage'])) {
 
 <div id="request-list"></div>
 <div id="load-more-wrap" style="display:none">
-  <button class="btn btn-outline-secondary" id="load-more-btn">もっと見る</button>
+  <button class="btn btn-secondary" id="load-more-btn">もっと見る</button>
 </div>
 <div id="empty-msg" style="display:none">リクエストはありません</div>
 
@@ -505,7 +505,7 @@ function createCardHTML(item, idx) {
     // 曲終了 / 曲開始ボタン
     var ctrlBtn = '';
     if (isPlaying(item.nowplaying)) {
-        ctrlBtn = '<button class="btn btn-outline-warning btn-sm card-ctrl-btn song-end-btn">曲終了</button>';
+        ctrlBtn = '<button class="btn btn-warning btn-sm card-ctrl-btn song-end-btn">曲終了</button>';
     } else if (isWaiting(item.nowplaying) && item.kind === '動画') {
         ctrlBtn = '<button class="btn btn-success btn-sm card-ctrl-btn song-start-btn">曲開始</button>';
     }

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -281,7 +281,7 @@ shownavigatioinbar_bs5();
 showmode();
 
 if (!empty($config_ini['noticeof_listpage'])) {
-    echo '<div class="well">';
+    echo '<div class="p-3 mb-3 border rounded bg-light">';
     echo str_replace('#yukarihost#', $_SERVER['HTTP_HOST'], urldecode($config_ini['noticeof_listpage']));
     echo '</div>';
 }

--- a/requestlist_swipe_json.php
+++ b/requestlist_swipe_json.php
@@ -44,7 +44,7 @@ foreach ($rows as $idx => $row) {
     $nowplaying_val = !empty($row['nowplaying']) ? $row['nowplaying'] : '1';
     if (!empty($row['secret']) && $row['secret'] == 1
         && ($nowplaying_val === '未再生' || $nowplaying_val === '1')) {
-        $display_name = $config_ini['secret_display_text'] ?? 'ヒ・ミ・ツ♪(シークレット予約)';
+        $display_name = urldecode($config_ini['secret_display_text'] ?? urlencode('ヒ・ミ・ツ♪(シークレット予約)'));
     }
     $items[] = [
         'id'           => (int)$row['id'],

--- a/requestlist_swipe_json.php
+++ b/requestlist_swipe_json.php
@@ -44,7 +44,7 @@ foreach ($rows as $idx => $row) {
     $nowplaying_val = !empty($row['nowplaying']) ? $row['nowplaying'] : '1';
     if (!empty($row['secret']) && $row['secret'] == 1
         && ($nowplaying_val === '未再生' || $nowplaying_val === '1')) {
-        $display_name = mb_substr($songfile, 0, 1) . '***';
+        $display_name = $config_ini['secret_display_text'] ?? 'ヒ・ミ・ツ♪(シークレット予約)';
     }
     $items[] = [
         'id'           => (int)$row['id'],

--- a/requestlist_table_json.php
+++ b/requestlist_table_json.php
@@ -54,7 +54,8 @@ foreach($allrequest as $value ){
     $reqcount -= 1;
     $songfilename = '';
     if( ($value['secret'] == 1 ) && strcmp($value['nowplaying'],'未再生') == 0){
-        $songfilename = nl2br(htmlspecialchars(' ヒ・ミ・ツ♪(シークレット予約) '));
+        $secret_text  = $config_ini['secret_display_text'] ?? 'ヒ・ミ・ツ♪(シークレット予約)';
+        $songfilename = nl2br(htmlspecialchars(' ' . $secret_text . ' '));
     }else{
         $songfilename = nl2br(htmlspecialchars($value['songfile']));
     }

--- a/requestlist_table_json.php
+++ b/requestlist_table_json.php
@@ -54,7 +54,7 @@ foreach($allrequest as $value ){
     $reqcount -= 1;
     $songfilename = '';
     if( ($value['secret'] == 1 ) && strcmp($value['nowplaying'],'未再生') == 0){
-        $secret_text  = $config_ini['secret_display_text'] ?? 'ヒ・ミ・ツ♪(シークレット予約)';
+        $secret_text  = urldecode($config_ini['secret_display_text'] ?? urlencode('ヒ・ミ・ツ♪(シークレット予約)'));
         $songfilename = nl2br(htmlspecialchars(' ' . $secret_text . ' '));
     }else{
         $songfilename = nl2br(htmlspecialchars($value['songfile']));

--- a/update.php
+++ b/update.php
@@ -146,6 +146,15 @@ if(array_key_exists("pause", $_REQUEST)) {
     }
     $updatestring = $updatestring.' pause = '. $db->quote($l_value) . ' ';
 }
+
+foreach (['audiodelay', 'duration', 'volume', 'song_name', 'lister_artist', 'lister_work', 'lister_op_ed', 'lister_comment'] as $col) {
+    if (array_key_exists($col, $_REQUEST)) {
+        if (strlen($updatestring) > 0) {
+            $updatestring = $updatestring . ' ,';
+        }
+        $updatestring = $updatestring . ' ' . $col . ' = ' . $db->quote($_REQUEST[$col]) . ' ';
+    }
+}
 if(strlen($updatestring) > 0){
     try{
     $sql_u = 'UPDATE requesttable set '. $updatestring . ' WHERE id = '. (int)$l_id;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **requestlist_swipe.php BS5デザイン改善**: ボタンをoutline（透過）からソリッドに変更、BS3の`.well`をBS5ユーティリティクラスに置き換え
- **UI設定をv2に統合**: 「スワイプ操作対応リクエスト一覧UI」と「新デザイン検索画面UI」を「UI v2」1つのトグルに統合。Playerナビリンクもv2設定に連動
- **シークレット予約表示テキストを設定可能に**: 初期値「ヒ・ミ・ツ♪(シークレット予約)」、v1/v2両方対応。`secret_display_text`はURLエンコードで保存
- **config.ini破損修正**: `secret_display_text`の`()`がPHP ini特殊文字として解釈されparse_ini_fileがfalseを返すバグを修正。`kara_config.php`・`func_readconfig.php`両方にis_array()ガードを追加
- **repair_config.php追加**: 既存の破損したconfig.iniを修復するためのユーティリティスクリプト
- **update.phpのカラム不足修正**: `song_name`以降（audiodelay, duration, volume, song_name, lister_artist, lister_work, lister_op_ed, lister_comment）がchange.phpから編集しても反映されなかった問題を修正

## Test plan

- [ ] `requestlist_swipe.php` のボタン表示が見やすくなっていること
- [ ] 設定画面で「UI v2」を切り替えるとリクエスト一覧・検索画面・Playerリンクすべてが連動すること
- [ ] シークレット予約が未再生状態のとき、設定したテキストが表示されること
- [ ] `config.ini` が正常に読み込まれ、Apacheログに`parse_ini_file`エラーが出ないこと
- [ ] `change.php` でsong_name等の新カラムを編集して保存すると反映されること

https://claude.ai/code/session_01ViWB62yN3ZqozWktpro75L
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViWB62yN3ZqozWktpro75L)_