### PR TITLE
マイページ画面のBS5化・背景色修正・動画更新日ソート追加

### DIFF
--- a/mypage.php
+++ b/mypage.php
@@ -9,6 +9,8 @@ print_meta_header();
 <title>マイページ</title>
 <link href="css/bootstrap5/bootstrap.min.css" rel="stylesheet">
 <link href="css/style.css" rel="stylesheet">
+<link href="css/themes/_variables.css" rel="stylesheet">
+<style>body { background-color: var(--bg-page); background-image: var(--bg-page-image); background-size: cover; background-attachment: fixed; }</style>
 <script src="js/bootstrap5/bootstrap.bundle.min.js"></script>
 </head>
 <body>

--- a/mypage_class.php
+++ b/mypage_class.php
@@ -248,15 +248,30 @@ class MypageUser {
     }
 
     /**
-     * @param string $sort  'date'|'count'
+     * @param string $sort  'date'|'count'|'filedate'
      * @param string $order 'desc'|'asc'
      */
     public function getHistory($sort = 'date', $order = 'desc', $limit = 200) {
-        $order = ($order === 'asc') ? 'ASC' : 'DESC';
+        $orderDir = ($order === 'asc') ? 'ASC' : 'DESC';
+        if ($sort === 'filedate') {
+            $stmt = $this->db->prepare(
+                "SELECT fullpath, songfile, kind,
+                        COUNT(*) AS times,
+                        MAX(requested_at) AS last_requested_at,
+                        MIN(id) AS first_id
+                 FROM mypage_history
+                 WHERE userid = ?
+                 GROUP BY fullpath
+                 LIMIT ?"
+            );
+            $stmt->execute([$this->userid, $limit]);
+            $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            return self::sortByFileDate($rows, $orderDir);
+        }
         if ($sort === 'count') {
-            $orderby = "times $order, last_requested_at DESC";
+            $orderby = "times $orderDir, last_requested_at DESC";
         } else {
-            $orderby = "last_requested_at $order";
+            $orderby = "last_requested_at $orderDir";
         }
         $stmt = $this->db->prepare(
             "SELECT fullpath, songfile, kind,
@@ -297,11 +312,22 @@ class MypageUser {
         $stmt->execute([$this->userid, $fullpath]);
     }
 
-    public function getLaterList() {
+    public function getLaterList($sort = 'date', $order = 'desc') {
+        $orderDir = ($order === 'asc') ? 'ASC' : 'DESC';
+        if ($sort === 'filedate') {
+            $stmt = $this->db->prepare(
+                "SELECT fullpath, songfile, kind, added_at
+                 FROM mypage_later WHERE userid = ?
+                 ORDER BY added_at DESC"
+            );
+            $stmt->execute([$this->userid]);
+            $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            return self::sortByFileDate($rows, $orderDir);
+        }
         $stmt = $this->db->prepare(
             "SELECT fullpath, songfile, kind, added_at
              FROM mypage_later WHERE userid = ?
-             ORDER BY added_at DESC"
+             ORDER BY added_at $orderDir"
         );
         $stmt->execute([$this->userid]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -332,11 +358,22 @@ class MypageUser {
         $stmt->execute([$this->userid, $fullpath]);
     }
 
-    public function getFavoriteSongs() {
+    public function getFavoriteSongs($sort = 'date', $order = 'desc') {
+        $orderDir = ($order === 'asc') ? 'ASC' : 'DESC';
+        if ($sort === 'filedate') {
+            $stmt = $this->db->prepare(
+                "SELECT fullpath, songfile, kind, added_at
+                 FROM mypage_favorite_song WHERE userid = ?
+                 ORDER BY added_at DESC"
+            );
+            $stmt->execute([$this->userid]);
+            $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            return self::sortByFileDate($rows, $orderDir);
+        }
         $stmt = $this->db->prepare(
             "SELECT fullpath, songfile, kind, added_at
              FROM mypage_favorite_song WHERE userid = ?
-             ORDER BY added_at DESC"
+             ORDER BY added_at $orderDir"
         );
         $stmt->execute([$this->userid]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -579,6 +616,67 @@ class MypageUser {
      *   'songfile' => string,
      * ]
      */
+
+    private static function openListerDB() {
+        global $config_ini;
+        if (empty($config_ini['listerDBPATH'])) return null;
+        $decoded = urldecode($config_ini['listerDBPATH']);
+        if (function_exists('file_exist_check_japanese_cf')) {
+            $win_dbpath = mb_convert_encoding($decoded, 'SJIS-win', 'UTF-8');
+            if (@file_exist_check_japanese_cf($win_dbpath) === false) return null;
+        } elseif (!@file_exists($decoded)) {
+            return null;
+        }
+        try {
+            require_once 'function_search_listerdb.php';
+            $lister = new ListerDB();
+            $lister->listerdbfile = $decoded;
+            return $lister->initdb();
+        } catch (Exception $e) {
+            return null;
+        }
+    }
+
+    private static function lookupFileDate($fullpath, $listerdb) {
+        if (!$listerdb || empty($fullpath)) return 0;
+        try {
+            $stmt = $listerdb->prepare(
+                "SELECT found_last_write_time FROM t_found WHERE found_path = ? LIMIT 1"
+            );
+            $stmt->execute([$fullpath]);
+            $row = $stmt->fetch(PDO::FETCH_ASSOC);
+            if ($row && !empty($row['found_last_write_time'])) {
+                return (float)$row['found_last_write_time'];
+            }
+            // フォルダ違いに対応：ファイル名で検索
+            $basename = basename(str_replace('\\', '/', $fullpath));
+            if (!empty($basename)) {
+                $stmt = $listerdb->prepare(
+                    "SELECT found_last_write_time FROM t_found WHERE found_path LIKE ? LIMIT 1"
+                );
+                $stmt->execute(['%' . $basename]);
+                $row = $stmt->fetch(PDO::FETCH_ASSOC);
+                if ($row && !empty($row['found_last_write_time'])) {
+                    return (float)$row['found_last_write_time'];
+                }
+            }
+        } catch (Exception $e) {}
+        return 0;
+    }
+
+    private static function sortByFileDate(array $rows, $orderDir) {
+        $listerdb = self::openListerDB();
+        foreach ($rows as &$row) {
+            $row['_filedate'] = self::lookupFileDate($row['fullpath'], $listerdb);
+        }
+        unset($row);
+        usort($rows, function($a, $b) use ($orderDir) {
+            $cmp = $a['_filedate'] <=> $b['_filedate'];
+            return $orderDir === 'ASC' ? $cmp : -$cmp;
+        });
+        return $rows;
+    }
+
     public static function checkFileStatus($fullpath, $songfile) {
         // ListerDB接続を先に準備（song_name取得とrelocated検索に共用）
         $listerdb = null;

--- a/mypage_class.php
+++ b/mypage_class.php
@@ -646,8 +646,9 @@ class MypageUser {
             $stmt->execute([$fullpath]);
             $row = $stmt->fetch(PDO::FETCH_ASSOC);
             if ($row && !empty($row['found_last_write_time'])) {
-                // Excel時刻（days since 1900-01-00）→ Unixタイムスタンプ
-                return (int)round(((float)$row['found_last_write_time'] - 25569) * 86400);
+                // MJD (Modified Julian Date, days since 1858-11-17) → Unixタイムスタンプ
+                // Unixエポック(1970-01-01) = MJD 40587
+                return (int)round(((float)$row['found_last_write_time'] - 40587) * 86400);
             }
             // フォルダ違いに対応：ファイル名で検索
             $basename = basename(str_replace('\\', '/', $fullpath));
@@ -658,7 +659,7 @@ class MypageUser {
                 $stmt->execute(['%' . $basename]);
                 $row = $stmt->fetch(PDO::FETCH_ASSOC);
                 if ($row && !empty($row['found_last_write_time'])) {
-                    return (int)round(((float)$row['found_last_write_time'] - 25569) * 86400);
+                    return (int)round(((float)$row['found_last_write_time'] - 40587) * 86400);
                 }
             }
         } catch (Exception $e) {}

--- a/mypage_class.php
+++ b/mypage_class.php
@@ -646,7 +646,8 @@ class MypageUser {
             $stmt->execute([$fullpath]);
             $row = $stmt->fetch(PDO::FETCH_ASSOC);
             if ($row && !empty($row['found_last_write_time'])) {
-                return (float)$row['found_last_write_time'];
+                // Excel時刻（days since 1900-01-00）→ Unixタイムスタンプ
+                return (int)round(((float)$row['found_last_write_time'] - 25569) * 86400);
             }
             // フォルダ違いに対応：ファイル名で検索
             $basename = basename(str_replace('\\', '/', $fullpath));
@@ -657,7 +658,7 @@ class MypageUser {
                 $stmt->execute(['%' . $basename]);
                 $row = $stmt->fetch(PDO::FETCH_ASSOC);
                 if ($row && !empty($row['found_last_write_time'])) {
-                    return (float)$row['found_last_write_time'];
+                    return (int)round(((float)$row['found_last_write_time'] - 25569) * 86400);
                 }
             }
         } catch (Exception $e) {}
@@ -667,11 +668,12 @@ class MypageUser {
     private static function sortByFileDate(array $rows, $orderDir) {
         $listerdb = self::openListerDB();
         foreach ($rows as &$row) {
-            $row['_filedate'] = self::lookupFileDate($row['fullpath'], $listerdb);
+            // _filedate_ts にUnixタイムスタンプを格納（0＝不明）
+            $row['_filedate_ts'] = self::lookupFileDate($row['fullpath'], $listerdb);
         }
         unset($row);
         usort($rows, function($a, $b) use ($orderDir) {
-            $cmp = $a['_filedate'] <=> $b['_filedate'];
+            $cmp = $a['_filedate_ts'] <=> $b['_filedate_ts'];
             return $orderDir === 'ASC' ? $cmp : -$cmp;
         });
         return $rows;

--- a/mypage_favorite_keyword.php
+++ b/mypage_favorite_keyword.php
@@ -1,4 +1,5 @@
-<html>
+<!doctype html>
+<html lang="ja">
 <head>
 <?php
 require_once 'commonfunc.php';
@@ -6,16 +7,17 @@ require_once 'mypage_class.php';
 print_meta_header();
 ?>
 <title>お気に入り検索ワード - マイページ</title>
-<link href="css/bootstrap.min.css" rel="stylesheet">
-<script src="js/jquery.js"></script>
-<script src="js/bootstrap.min.js"></script>
+<link href="css/bootstrap5/bootstrap.min.css" rel="stylesheet">
+<link href="css/themes/_variables.css" rel="stylesheet">
+<style>body { background-color: var(--bg-page); background-image: var(--bg-page-image); background-size: cover; background-attachment: fixed; padding-top: 70px; }</style>
+<script src="js/bootstrap5/bootstrap.bundle.min.js"></script>
 </head>
 <body>
 <?php
-shownavigatioinbar('mypage_favorite_keyword.php');
+shownavigatioinbar_bs5('mypage_favorite_keyword.php');
 
 if (!configbool("usemypage", true)) {
-    print '<div class="container" style="margin-top:80px;"><p>マイページ機能は無効です。</p></div>';
+    print '<div class="container py-3"><p>マイページ機能は無効です。</p></div>';
     print '</body></html>';
     exit;
 }
@@ -80,21 +82,22 @@ function build_search_url($keyword, $search_type, $search_params) {
     }
 }
 ?>
-<div class="container" style="margin-top:80px;">
-  <h2>お気に入り検索ワード</h2>
-  <p><a href="mypage.php">&laquo; マイページへ戻る</a></p>
+<div class="container py-3">
+  <h2 class="mb-2">お気に入り検索ワード</h2>
+  <p class="mb-2"><a href="mypage.php">&laquo; マイページへ戻る</a></p>
 
   <?php if (empty($list)): ?>
   <p class="text-muted">お気に入り検索ワードが登録されていません。<br>
     検索結果の画面で「検索ワードを保存」リンクを押すと追加できます。
   </p>
   <?php else: ?>
-  <table class="table table-striped table-condensed">
-    <thead>
+  <div class="table-responsive">
+  <table class="table table-striped table-sm table-hover align-middle">
+    <thead class="table-dark">
       <tr>
         <th>検索ワード</th>
-        <th>検索種別</th>
-        <th>登録日時</th>
+        <th class="text-nowrap">検索種別</th>
+        <th class="text-nowrap">登録日時</th>
         <th>操作</th>
       </tr>
     </thead>
@@ -117,22 +120,22 @@ function build_search_url($keyword, $search_type, $search_params) {
     ?>
       <tr>
         <td><?php echo htmlspecialchars($kw, ENT_QUOTES, 'UTF-8'); ?></td>
-        <td><?php echo htmlspecialchars($type_label, ENT_QUOTES, 'UTF-8'); ?></td>
-        <td><?php echo htmlspecialchars($added_dt, ENT_QUOTES, 'UTF-8'); ?></td>
-        <td>
-          <a href="<?php echo htmlspecialchars($search_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-xs">再検索</a>
-          &nbsp;
-          <form method="POST" action="mypage_favorite_keyword.php" style="display:inline;"
+        <td class="text-nowrap"><?php echo htmlspecialchars($type_label, ENT_QUOTES, 'UTF-8'); ?></td>
+        <td class="text-nowrap"><?php echo htmlspecialchars($added_dt, ENT_QUOTES, 'UTF-8'); ?></td>
+        <td class="text-nowrap">
+          <a href="<?php echo htmlspecialchars($search_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-sm">再検索</a>
+          <form method="POST" action="mypage_favorite_keyword.php" class="d-inline"
                 onsubmit="return confirm('削除しますか？');">
             <input type="hidden" name="action" value="remove" />
             <input type="hidden" name="kw_id" value="<?php echo $kw_id; ?>" />
-            <button type="submit" class="btn btn-danger btn-xs">削除</button>
+            <button type="submit" class="btn btn-outline-danger btn-sm">削除</button>
           </form>
         </td>
       </tr>
     <?php endforeach; ?>
     </tbody>
   </table>
+  </div>
   <?php endif; ?>
 </div>
 </body>

--- a/mypage_favorite_song.php
+++ b/mypage_favorite_song.php
@@ -1,4 +1,5 @@
-<html>
+<!doctype html>
+<html lang="ja">
 <head>
 <?php
 require_once 'commonfunc.php';
@@ -6,16 +7,17 @@ require_once 'mypage_class.php';
 print_meta_header();
 ?>
 <title>お気に入り曲 - マイページ</title>
-<link href="css/bootstrap.min.css" rel="stylesheet">
-<script src="js/jquery.js"></script>
-<script src="js/bootstrap.min.js"></script>
+<link href="css/bootstrap5/bootstrap.min.css" rel="stylesheet">
+<link href="css/themes/_variables.css" rel="stylesheet">
+<style>body { background-color: var(--bg-page); background-image: var(--bg-page-image); background-size: cover; background-attachment: fixed; padding-top: 70px; }</style>
+<script src="js/bootstrap5/bootstrap.bundle.min.js"></script>
 </head>
 <body>
 <?php
-shownavigatioinbar('mypage_favorite_song.php');
+shownavigatioinbar_bs5('mypage_favorite_song.php');
 
 if (!configbool("usemypage", true)) {
-    print '<div class="container" style="margin-top:80px;"><p>マイページ機能は無効です。</p></div>';
+    print '<div class="container py-3"><p>マイページ機能は無効です。</p></div>';
     print '</body></html>';
     exit;
 }
@@ -29,22 +31,47 @@ if (isset($_POST['action']) && $_POST['action'] === 'remove' && !empty($_POST['f
     exit;
 }
 
-$list = $mypage->getFavoriteSongs();
+$valid_sorts = ['date', 'filedate'];
+$sort  = in_array($_GET['sort'] ?? '', $valid_sorts, true) ? $_GET['sort'] : 'date';
+$order = isset($_GET['order']) && $_GET['order'] === 'asc' ? 'asc' : 'desc';
+
+$list = $mypage->getFavoriteSongs($sort, $order);
+
+function sort_link_f($label, $sort_key, $cur_sort, $cur_order) {
+    $next_order = ($cur_sort === $sort_key && $cur_order === 'desc') ? 'asc' : 'desc';
+    $arrow = '';
+    $active_class = '';
+    if ($cur_sort === $sort_key) {
+        $arrow = $cur_order === 'desc' ? ' ▼' : ' ▲';
+        $active_class = ' fw-bold';
+    }
+    $url = 'mypage_favorite_song.php?sort=' . urlencode($sort_key) . '&order=' . urlencode($next_order);
+    return '<a href="' . htmlspecialchars($url, ENT_QUOTES, 'UTF-8') . '" class="link-secondary' . $active_class . '">'
+         . htmlspecialchars($label . $arrow, ENT_QUOTES, 'UTF-8') . '</a>';
+}
 ?>
-<div class="container" style="margin-top:80px;">
-  <h2>お気に入り曲</h2>
-  <p><a href="mypage.php">&laquo; マイページへ戻る</a></p>
+<div class="container py-3">
+  <h2 class="mb-2">お気に入り曲</h2>
+  <p class="mb-2"><a href="mypage.php">&laquo; マイページへ戻る</a></p>
+
+  <div class="mb-3 d-flex flex-wrap gap-2 align-items-center">
+    <span class="text-muted small">並び替え:</span>
+    <?php echo sort_link_f('登録日順', 'date', $sort, $order); ?>
+    <span class="text-muted">|</span>
+    <?php echo sort_link_f('動画更新日順', 'filedate', $sort, $order); ?>
+  </div>
 
   <?php if (empty($list)): ?>
   <p class="text-muted">お気に入りに曲が登録されていません。<br>
     検索結果の画面で「お気に入り」リンクを押すと追加できます。
   </p>
   <?php else: ?>
-  <table class="table table-striped table-condensed">
-    <thead>
+  <div class="table-responsive">
+  <table class="table table-striped table-sm table-hover align-middle">
+    <thead class="table-dark">
       <tr>
         <th>曲名</th>
-        <th>登録日時</th>
+        <th class="text-nowrap">登録日時</th>
         <th>操作</th>
       </tr>
     </thead>
@@ -68,31 +95,31 @@ $list = $mypage->getFavoriteSongs();
             <br><span class="text-muted" style="font-size:x-small;"><?php echo htmlspecialchars($basename, ENT_QUOTES, 'UTF-8'); ?></span>
           <?php endif; ?>
           <?php if ($status['status'] === 'notfound'): ?>
-            <br><span class="text-danger" style="font-size:small;">[!] ファイルが見つかりません</span>
+            <br><span class="text-danger small">[!] ファイルが見つかりません</span>
           <?php elseif ($status['status'] === 'relocated'): ?>
-            <br><span class="text-warning" style="font-size:small;">[!] 別フォルダで見つかりました</span>
+            <br><span class="text-warning small">[!] 別フォルダで見つかりました</span>
           <?php endif; ?>
         </td>
-        <td><?php echo htmlspecialchars($added_dt, ENT_QUOTES, 'UTF-8'); ?></td>
-        <td>
+        <td class="text-nowrap"><?php echo htmlspecialchars($added_dt, ENT_QUOTES, 'UTF-8'); ?></td>
+        <td class="text-nowrap">
           <?php if ($status['status'] === 'ok' || $status['status'] === 'relocated'): ?>
-            <a href="<?php echo htmlspecialchars($req_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-xs">リクエスト</a>
-            <a href="<?php echo htmlspecialchars($search_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-default btn-xs">曲名で再検索</a>
+            <a href="<?php echo htmlspecialchars($req_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-sm">リクエスト</a>
+            <a href="<?php echo htmlspecialchars($search_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-outline-secondary btn-sm">再検索</a>
           <?php else: ?>
-            <a href="<?php echo htmlspecialchars($search_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-warning btn-xs">曲名で再検索</a>
+            <a href="<?php echo htmlspecialchars($search_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-warning btn-sm">曲名で再検索</a>
           <?php endif; ?>
-          &nbsp;
-          <form method="POST" action="mypage_favorite_song.php" style="display:inline;"
+          <form method="POST" action="mypage_favorite_song.php" class="d-inline"
                 onsubmit="return confirm('お気に入りから削除しますか？');">
             <input type="hidden" name="action" value="remove" />
             <input type="hidden" name="fullpath" value="<?php echo htmlspecialchars($fullpath, ENT_QUOTES, 'UTF-8'); ?>" />
-            <button type="submit" class="btn btn-danger btn-xs">削除</button>
+            <button type="submit" class="btn btn-outline-danger btn-sm">削除</button>
           </form>
         </td>
       </tr>
     <?php endforeach; ?>
     </tbody>
   </table>
+  </div>
   <?php endif; ?>
 </div>
 </body>

--- a/mypage_favorite_song.php
+++ b/mypage_favorite_song.php
@@ -66,14 +66,11 @@ function sort_link_f($label, $sort_key, $cur_sort, $cur_order) {
     検索結果の画面で「お気に入り」リンクを押すと追加できます。
   </p>
   <?php else: ?>
-  <div class="table-responsive">
   <table class="table table-striped table-sm table-hover align-middle">
     <thead class="table-dark">
       <tr>
         <th>曲名</th>
-        <th class="text-nowrap">登録日時</th>
-        <?php if ($sort === 'filedate'): ?><th class="text-nowrap">動画更新日</th><?php endif; ?>
-        <th>操作</th>
+        <th class="text-nowrap">操作</th>
       </tr>
     </thead>
     <tbody>
@@ -95,20 +92,22 @@ function sort_link_f($label, $sort_key, $cur_sort, $cur_order) {
     ?>
       <tr>
         <td>
-          <?php echo htmlspecialchars($songname, ENT_QUOTES, 'UTF-8'); ?>
+          <div><?php echo htmlspecialchars($songname, ENT_QUOTES, 'UTF-8'); ?></div>
           <?php if ($basename !== $songname): ?>
-            <br><span class="text-muted" style="font-size:x-small;"><?php echo htmlspecialchars($basename, ENT_QUOTES, 'UTF-8'); ?></span>
+            <div class="text-muted" style="font-size:x-small;"><?php echo htmlspecialchars($basename, ENT_QUOTES, 'UTF-8'); ?></div>
           <?php endif; ?>
+          <div class="text-muted small">
+            登録: <?php echo htmlspecialchars($added_dt, ENT_QUOTES, 'UTF-8'); ?>
+            <?php if ($filedate_str !== ''): ?>
+              ｜ 動画更新日: <?php echo htmlspecialchars($filedate_str, ENT_QUOTES, 'UTF-8'); ?>
+            <?php endif; ?>
+          </div>
           <?php if ($status['status'] === 'notfound'): ?>
-            <br><span class="text-danger small">[!] ファイルが見つかりません</span>
+            <div class="text-danger small">[!] ファイルが見つかりません</div>
           <?php elseif ($status['status'] === 'relocated'): ?>
-            <br><span class="text-warning small">[!] 別フォルダで見つかりました</span>
+            <div class="text-warning small">[!] 別フォルダで見つかりました</div>
           <?php endif; ?>
         </td>
-        <td class="text-nowrap"><?php echo htmlspecialchars($added_dt, ENT_QUOTES, 'UTF-8'); ?></td>
-        <?php if ($sort === 'filedate'): ?>
-        <td class="text-nowrap"><?php echo $filedate_str !== '' ? htmlspecialchars($filedate_str, ENT_QUOTES, 'UTF-8') : '<span class="text-muted">-</span>'; ?></td>
-        <?php endif; ?>
         <td class="text-nowrap">
           <?php if ($status['status'] === 'ok' || $status['status'] === 'relocated'): ?>
             <a href="<?php echo htmlspecialchars($req_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-sm">リクエスト</a>
@@ -127,7 +126,6 @@ function sort_link_f($label, $sort_key, $cur_sort, $cur_order) {
     <?php endforeach; ?>
     </tbody>
   </table>
-  </div>
   <?php endif; ?>
 </div>
 </body>

--- a/mypage_favorite_song.php
+++ b/mypage_favorite_song.php
@@ -72,6 +72,7 @@ function sort_link_f($label, $sort_key, $cur_sort, $cur_order) {
       <tr>
         <th>曲名</th>
         <th class="text-nowrap">登録日時</th>
+        <?php if ($sort === 'filedate'): ?><th class="text-nowrap">動画更新日</th><?php endif; ?>
         <th>操作</th>
       </tr>
     </thead>
@@ -87,6 +88,10 @@ function sort_link_f($label, $sort_key, $cur_sort, $cur_order) {
         $req_fullpath = ($status['status'] === 'relocated') ? $status['fullpath'] : $fullpath;
         $req_url    = MypageUser::makeRequestConfirmUrl($req_fullpath, $songfile, $kind);
         $search_url = MypageUser::makeSearchFallbackUrl($songfile);
+        $filedate_str = '';
+        if ($sort === 'filedate' && !empty($row['_filedate_ts'])) {
+            $filedate_str = date('Y/m/d', $row['_filedate_ts']);
+        }
     ?>
       <tr>
         <td>
@@ -101,6 +106,9 @@ function sort_link_f($label, $sort_key, $cur_sort, $cur_order) {
           <?php endif; ?>
         </td>
         <td class="text-nowrap"><?php echo htmlspecialchars($added_dt, ENT_QUOTES, 'UTF-8'); ?></td>
+        <?php if ($sort === 'filedate'): ?>
+        <td class="text-nowrap"><?php echo $filedate_str !== '' ? htmlspecialchars($filedate_str, ENT_QUOTES, 'UTF-8') : '<span class="text-muted">-</span>'; ?></td>
+        <?php endif; ?>
         <td class="text-nowrap">
           <?php if ($status['status'] === 'ok' || $status['status'] === 'relocated'): ?>
             <a href="<?php echo htmlspecialchars($req_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-sm">リクエスト</a>

--- a/mypage_history.php
+++ b/mypage_history.php
@@ -67,15 +67,11 @@ function sort_link_h($label, $sort_key, $cur_sort, $cur_order) {
   <?php if (empty($history)): ?>
   <p class="text-muted">まだ選曲履歴がありません。</p>
   <?php else: ?>
-  <div class="table-responsive">
   <table class="table table-striped table-sm table-hover align-middle">
     <thead class="table-dark">
       <tr>
         <th>曲名</th>
-        <th class="text-nowrap">回数</th>
-        <th class="text-nowrap">最終リクエスト日時</th>
-        <?php if ($sort === 'filedate'): ?><th class="text-nowrap">動画更新日</th><?php endif; ?>
-        <th>操作</th>
+        <th class="text-nowrap">操作</th>
       </tr>
     </thead>
     <tbody>
@@ -98,26 +94,27 @@ function sort_link_h($label, $sort_key, $cur_sort, $cur_order) {
     ?>
       <tr>
         <td>
-          <?php echo htmlspecialchars($songname, ENT_QUOTES, 'UTF-8'); ?>
+          <div><?php echo htmlspecialchars($songname, ENT_QUOTES, 'UTF-8'); ?></div>
           <?php if ($basename !== $songname): ?>
-            <br><span class="text-muted" style="font-size:x-small;"><?php echo htmlspecialchars($basename, ENT_QUOTES, 'UTF-8'); ?></span>
+            <div class="text-muted" style="font-size:x-small;"><?php echo htmlspecialchars($basename, ENT_QUOTES, 'UTF-8'); ?></div>
           <?php endif; ?>
+          <div class="text-muted small">
+            <?php echo $times; ?>回 ｜ <?php echo htmlspecialchars($last_dt, ENT_QUOTES, 'UTF-8'); ?>
+            <?php if ($filedate_str !== ''): ?>
+              ｜ 動画更新日: <?php echo htmlspecialchars($filedate_str, ENT_QUOTES, 'UTF-8'); ?>
+            <?php endif; ?>
+          </div>
           <?php if ($status['status'] === 'notfound'): ?>
-            <br><span class="text-danger small">[!] ファイルが見つかりません</span>
+            <div class="text-danger small">[!] ファイルが見つかりません</div>
           <?php elseif ($status['status'] === 'relocated'): ?>
-            <br><span class="text-warning small">[!] 別フォルダで見つかりました</span>
+            <div class="text-warning small">[!] 別フォルダで見つかりました</div>
           <?php endif; ?>
         </td>
-        <td class="text-nowrap"><?php echo $times; ?>回</td>
-        <td class="text-nowrap"><?php echo htmlspecialchars($last_dt, ENT_QUOTES, 'UTF-8'); ?></td>
-        <?php if ($sort === 'filedate'): ?>
-        <td class="text-nowrap"><?php echo $filedate_str !== '' ? htmlspecialchars($filedate_str, ENT_QUOTES, 'UTF-8') : '<span class="text-muted">-</span>'; ?></td>
-        <?php endif; ?>
         <td class="text-nowrap">
           <?php if ($status['status'] === 'ok' || $status['status'] === 'relocated'): ?>
             <a href="<?php echo htmlspecialchars($req_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-sm">再選曲</a>
           <?php else: ?>
-            <a href="<?php echo htmlspecialchars($search_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-warning btn-sm">曲名で再検索</a>
+            <a href="<?php echo htmlspecialchars($search_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-warning btn-sm">再検索</a>
           <?php endif; ?>
           <form method="POST" action="mypage_history.php?sort=<?php echo urlencode($sort); ?>&order=<?php echo urlencode($order); ?>"
                 class="d-inline"
@@ -131,7 +128,6 @@ function sort_link_h($label, $sort_key, $cur_sort, $cur_order) {
     <?php endforeach; ?>
     </tbody>
   </table>
-  </div>
   <?php endif; ?>
 </div>
 </body>

--- a/mypage_history.php
+++ b/mypage_history.php
@@ -1,4 +1,5 @@
-<html>
+<!doctype html>
+<html lang="ja">
 <head>
 <?php
 require_once 'commonfunc.php';
@@ -6,16 +7,17 @@ require_once 'mypage_class.php';
 print_meta_header();
 ?>
 <title>選曲履歴 - マイページ</title>
-<link href="css/bootstrap.min.css" rel="stylesheet">
-<script src="js/jquery.js"></script>
-<script src="js/bootstrap.min.js"></script>
+<link href="css/bootstrap5/bootstrap.min.css" rel="stylesheet">
+<link href="css/themes/_variables.css" rel="stylesheet">
+<style>body { background-color: var(--bg-page); background-image: var(--bg-page-image); background-size: cover; background-attachment: fixed; padding-top: 70px; }</style>
+<script src="js/bootstrap5/bootstrap.bundle.min.js"></script>
 </head>
 <body>
 <?php
-shownavigatioinbar('mypage_history.php');
+shownavigatioinbar_bs5('mypage_history.php');
 
 if (!configbool("usemypage", true)) {
-    print '<div class="container" style="margin-top:80px;"><p>マイページ機能は無効です。</p></div>';
+    print '<div class="container py-3"><p>マイページ機能は無効です。</p></div>';
     print '</body></html>';
     exit;
 }
@@ -25,45 +27,53 @@ $mypage = new MypageUser($db);
 // 削除処理
 if (isset($_POST['action']) && $_POST['action'] === 'delete' && !empty($_POST['fullpath'])) {
     $mypage->deleteHistoryByFullpath($_POST['fullpath']);
-    header('Location: mypage_history.php?sort=' . urlencode($_GET['sort'] ?? 'date') . '&order=' . urlencode($_GET['order'] ?? 'desc'));
+    $qs = http_build_query(['sort' => $_GET['sort'] ?? 'date', 'order' => $_GET['order'] ?? 'desc']);
+    header('Location: mypage_history.php?' . $qs);
     exit;
 }
 
-$sort  = isset($_GET['sort'])  && $_GET['sort']  === 'count' ? 'count' : 'date';
-$order = isset($_GET['order']) && $_GET['order'] === 'asc'   ? 'asc'   : 'desc';
+$valid_sorts = ['date', 'count', 'filedate'];
+$sort  = in_array($_GET['sort'] ?? '', $valid_sorts, true) ? $_GET['sort'] : 'date';
+$order = isset($_GET['order']) && $_GET['order'] === 'asc' ? 'asc' : 'desc';
 
 $history = $mypage->getHistory($sort, $order);
 
-function sort_link($label, $sort_key, $cur_sort, $cur_order) {
+function sort_link_h($label, $sort_key, $cur_sort, $cur_order) {
     $next_order = ($cur_sort === $sort_key && $cur_order === 'desc') ? 'asc' : 'desc';
-    $active = ($cur_sort === $sort_key) ? ' class="active"' : '';
-    $arrow  = '';
+    $arrow = '';
+    $active_class = '';
     if ($cur_sort === $sort_key) {
         $arrow = $cur_order === 'desc' ? ' ▼' : ' ▲';
+        $active_class = ' fw-bold';
     }
-    return '<a href="mypage_history.php?sort=' . $sort_key . '&order=' . $next_order . '"' . $active . '>'
+    $url = 'mypage_history.php?sort=' . urlencode($sort_key) . '&order=' . urlencode($next_order);
+    return '<a href="' . htmlspecialchars($url, ENT_QUOTES, 'UTF-8') . '" class="link-secondary' . $active_class . '">'
          . htmlspecialchars($label . $arrow, ENT_QUOTES, 'UTF-8') . '</a>';
 }
 ?>
-<div class="container" style="margin-top:80px;">
-  <h2>選曲履歴</h2>
-  <p><a href="mypage.php">&laquo; マイページへ戻る</a></p>
+<div class="container py-3">
+  <h2 class="mb-2">選曲履歴</h2>
+  <p class="mb-2"><a href="mypage.php">&laquo; マイページへ戻る</a></p>
 
-  <p>
-    並び替え: <?php echo sort_link('日付順', 'date', $sort, $order); ?>
-    &nbsp;|&nbsp;
-    <?php echo sort_link('回数順', 'count', $sort, $order); ?>
-  </p>
+  <div class="mb-3 d-flex flex-wrap gap-2 align-items-center">
+    <span class="text-muted small">並び替え:</span>
+    <?php echo sort_link_h('リクエスト日順', 'date', $sort, $order); ?>
+    <span class="text-muted">|</span>
+    <?php echo sort_link_h('回数順', 'count', $sort, $order); ?>
+    <span class="text-muted">|</span>
+    <?php echo sort_link_h('動画更新日順', 'filedate', $sort, $order); ?>
+  </div>
 
   <?php if (empty($history)): ?>
   <p class="text-muted">まだ選曲履歴がありません。</p>
   <?php else: ?>
-  <table class="table table-striped table-condensed">
-    <thead>
+  <div class="table-responsive">
+  <table class="table table-striped table-sm table-hover align-middle">
+    <thead class="table-dark">
       <tr>
         <th>曲名</th>
-        <th>リクエスト回数</th>
-        <th>最終リクエスト日時</th>
+        <th class="text-nowrap">回数</th>
+        <th class="text-nowrap">最終リクエスト日時</th>
         <th>操作</th>
       </tr>
     </thead>
@@ -77,7 +87,6 @@ function sort_link($label, $sort_key, $cur_sort, $cur_order) {
         $basename  = !empty($fullpath) ? basename_jp($fullpath) : $songfile;
         $status = MypageUser::checkFileStatus($fullpath, $songfile);
         $songname  = !empty($status['song_name']) ? $status['song_name'] : makesongnamefromfilename($basename);
-        // relocated の場合は新パスでリクエスト
         $req_fullpath = ($status['status'] === 'relocated') ? $status['fullpath'] : $fullpath;
         $req_url    = MypageUser::makeRequestConfirmUrl($req_fullpath, $songfile, $kind);
         $search_url = MypageUser::makeSearchFallbackUrl($songfile);
@@ -89,32 +98,32 @@ function sort_link($label, $sort_key, $cur_sort, $cur_order) {
             <br><span class="text-muted" style="font-size:x-small;"><?php echo htmlspecialchars($basename, ENT_QUOTES, 'UTF-8'); ?></span>
           <?php endif; ?>
           <?php if ($status['status'] === 'notfound'): ?>
-            <br><span class="text-danger" style="font-size:small;">[!] ファイルが見つかりません</span>
+            <br><span class="text-danger small">[!] ファイルが見つかりません</span>
           <?php elseif ($status['status'] === 'relocated'): ?>
-            <br><span class="text-warning" style="font-size:small;">[!] 別フォルダで見つかりました</span>
+            <br><span class="text-warning small">[!] 別フォルダで見つかりました</span>
           <?php endif; ?>
         </td>
-        <td><?php echo $times; ?>回</td>
-        <td><?php echo htmlspecialchars($last_dt, ENT_QUOTES, 'UTF-8'); ?></td>
-        <td>
+        <td class="text-nowrap"><?php echo $times; ?>回</td>
+        <td class="text-nowrap"><?php echo htmlspecialchars($last_dt, ENT_QUOTES, 'UTF-8'); ?></td>
+        <td class="text-nowrap">
           <?php if ($status['status'] === 'ok' || $status['status'] === 'relocated'): ?>
-            <a href="<?php echo htmlspecialchars($req_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-xs">再選曲</a>
+            <a href="<?php echo htmlspecialchars($req_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-sm">再選曲</a>
           <?php else: ?>
-            <a href="<?php echo htmlspecialchars($search_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-warning btn-xs">曲名で再検索</a>
+            <a href="<?php echo htmlspecialchars($search_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-warning btn-sm">曲名で再検索</a>
           <?php endif; ?>
-          &nbsp;
           <form method="POST" action="mypage_history.php?sort=<?php echo urlencode($sort); ?>&order=<?php echo urlencode($order); ?>"
-                style="display:inline;"
+                class="d-inline"
                 onsubmit="return confirm('この曲の履歴をすべて削除しますか？');">
             <input type="hidden" name="action" value="delete" />
             <input type="hidden" name="fullpath" value="<?php echo htmlspecialchars($fullpath, ENT_QUOTES, 'UTF-8'); ?>" />
-            <button type="submit" class="btn btn-danger btn-xs">削除</button>
+            <button type="submit" class="btn btn-outline-danger btn-sm">削除</button>
           </form>
         </td>
       </tr>
     <?php endforeach; ?>
     </tbody>
   </table>
+  </div>
   <?php endif; ?>
 </div>
 </body>

--- a/mypage_history.php
+++ b/mypage_history.php
@@ -74,6 +74,7 @@ function sort_link_h($label, $sort_key, $cur_sort, $cur_order) {
         <th>曲名</th>
         <th class="text-nowrap">回数</th>
         <th class="text-nowrap">最終リクエスト日時</th>
+        <?php if ($sort === 'filedate'): ?><th class="text-nowrap">動画更新日</th><?php endif; ?>
         <th>操作</th>
       </tr>
     </thead>
@@ -90,6 +91,10 @@ function sort_link_h($label, $sort_key, $cur_sort, $cur_order) {
         $req_fullpath = ($status['status'] === 'relocated') ? $status['fullpath'] : $fullpath;
         $req_url    = MypageUser::makeRequestConfirmUrl($req_fullpath, $songfile, $kind);
         $search_url = MypageUser::makeSearchFallbackUrl($songfile);
+        $filedate_str = '';
+        if ($sort === 'filedate' && !empty($row['_filedate_ts'])) {
+            $filedate_str = date('Y/m/d', $row['_filedate_ts']);
+        }
     ?>
       <tr>
         <td>
@@ -105,6 +110,9 @@ function sort_link_h($label, $sort_key, $cur_sort, $cur_order) {
         </td>
         <td class="text-nowrap"><?php echo $times; ?>回</td>
         <td class="text-nowrap"><?php echo htmlspecialchars($last_dt, ENT_QUOTES, 'UTF-8'); ?></td>
+        <?php if ($sort === 'filedate'): ?>
+        <td class="text-nowrap"><?php echo $filedate_str !== '' ? htmlspecialchars($filedate_str, ENT_QUOTES, 'UTF-8') : '<span class="text-muted">-</span>'; ?></td>
+        <?php endif; ?>
         <td class="text-nowrap">
           <?php if ($status['status'] === 'ok' || $status['status'] === 'relocated'): ?>
             <a href="<?php echo htmlspecialchars($req_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-sm">再選曲</a>

--- a/mypage_later.php
+++ b/mypage_later.php
@@ -1,4 +1,5 @@
-<html>
+<!doctype html>
+<html lang="ja">
 <head>
 <?php
 require_once 'commonfunc.php';
@@ -6,16 +7,17 @@ require_once 'mypage_class.php';
 print_meta_header();
 ?>
 <title>後で歌う - マイページ</title>
-<link href="css/bootstrap.min.css" rel="stylesheet">
-<script src="js/jquery.js"></script>
-<script src="js/bootstrap.min.js"></script>
+<link href="css/bootstrap5/bootstrap.min.css" rel="stylesheet">
+<link href="css/themes/_variables.css" rel="stylesheet">
+<style>body { background-color: var(--bg-page); background-image: var(--bg-page-image); background-size: cover; background-attachment: fixed; padding-top: 70px; }</style>
+<script src="js/bootstrap5/bootstrap.bundle.min.js"></script>
 </head>
 <body>
 <?php
-shownavigatioinbar('mypage_later.php');
+shownavigatioinbar_bs5('mypage_later.php');
 
 if (!configbool("usemypage", true)) {
-    print '<div class="container" style="margin-top:80px;"><p>マイページ機能は無効です。</p></div>';
+    print '<div class="container py-3"><p>マイページ機能は無効です。</p></div>';
     print '</body></html>';
     exit;
 }
@@ -29,22 +31,47 @@ if (isset($_POST['action']) && $_POST['action'] === 'remove' && !empty($_POST['f
     exit;
 }
 
-$list = $mypage->getLaterList();
+$valid_sorts = ['date', 'filedate'];
+$sort  = in_array($_GET['sort'] ?? '', $valid_sorts, true) ? $_GET['sort'] : 'date';
+$order = isset($_GET['order']) && $_GET['order'] === 'asc' ? 'asc' : 'desc';
+
+$list = $mypage->getLaterList($sort, $order);
+
+function sort_link_l($label, $sort_key, $cur_sort, $cur_order) {
+    $next_order = ($cur_sort === $sort_key && $cur_order === 'desc') ? 'asc' : 'desc';
+    $arrow = '';
+    $active_class = '';
+    if ($cur_sort === $sort_key) {
+        $arrow = $cur_order === 'desc' ? ' ▼' : ' ▲';
+        $active_class = ' fw-bold';
+    }
+    $url = 'mypage_later.php?sort=' . urlencode($sort_key) . '&order=' . urlencode($next_order);
+    return '<a href="' . htmlspecialchars($url, ENT_QUOTES, 'UTF-8') . '" class="link-secondary' . $active_class . '">'
+         . htmlspecialchars($label . $arrow, ENT_QUOTES, 'UTF-8') . '</a>';
+}
 ?>
-<div class="container" style="margin-top:80px;">
-  <h2>後で歌う</h2>
-  <p><a href="mypage.php">&laquo; マイページへ戻る</a></p>
+<div class="container py-3">
+  <h2 class="mb-2">後で歌う</h2>
+  <p class="mb-2"><a href="mypage.php">&laquo; マイページへ戻る</a></p>
+
+  <div class="mb-3 d-flex flex-wrap gap-2 align-items-center">
+    <span class="text-muted small">並び替え:</span>
+    <?php echo sort_link_l('追加日順', 'date', $sort, $order); ?>
+    <span class="text-muted">|</span>
+    <?php echo sort_link_l('動画更新日順', 'filedate', $sort, $order); ?>
+  </div>
 
   <?php if (empty($list)): ?>
   <p class="text-muted">リストに曲がありません。<br>
     検索結果の画面で「後で歌う」リンクを押すと追加できます。
   </p>
   <?php else: ?>
-  <table class="table table-striped table-condensed">
-    <thead>
+  <div class="table-responsive">
+  <table class="table table-striped table-sm table-hover align-middle">
+    <thead class="table-dark">
       <tr>
         <th>曲名</th>
-        <th>追加日時</th>
+        <th class="text-nowrap">追加日時</th>
         <th>操作</th>
       </tr>
     </thead>
@@ -68,31 +95,31 @@ $list = $mypage->getLaterList();
             <br><span class="text-muted" style="font-size:x-small;"><?php echo htmlspecialchars($basename, ENT_QUOTES, 'UTF-8'); ?></span>
           <?php endif; ?>
           <?php if ($status['status'] === 'notfound'): ?>
-            <br><span class="text-danger" style="font-size:small;">[!] ファイルが見つかりません</span>
+            <br><span class="text-danger small">[!] ファイルが見つかりません</span>
           <?php elseif ($status['status'] === 'relocated'): ?>
-            <br><span class="text-warning" style="font-size:small;">[!] 別フォルダで見つかりました</span>
+            <br><span class="text-warning small">[!] 別フォルダで見つかりました</span>
           <?php endif; ?>
         </td>
-        <td><?php echo htmlspecialchars($added_dt, ENT_QUOTES, 'UTF-8'); ?></td>
-        <td>
+        <td class="text-nowrap"><?php echo htmlspecialchars($added_dt, ENT_QUOTES, 'UTF-8'); ?></td>
+        <td class="text-nowrap">
           <?php if ($status['status'] === 'ok' || $status['status'] === 'relocated'): ?>
-            <a href="<?php echo htmlspecialchars($req_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-xs">リクエスト</a>
-            <a href="<?php echo htmlspecialchars($search_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-default btn-xs">曲名で再検索</a>
+            <a href="<?php echo htmlspecialchars($req_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-sm">リクエスト</a>
+            <a href="<?php echo htmlspecialchars($search_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-outline-secondary btn-sm">再検索</a>
           <?php else: ?>
-            <a href="<?php echo htmlspecialchars($search_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-warning btn-xs">曲名で再検索</a>
+            <a href="<?php echo htmlspecialchars($search_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-warning btn-sm">曲名で再検索</a>
           <?php endif; ?>
-          &nbsp;
-          <form method="POST" action="mypage_later.php" style="display:inline;"
+          <form method="POST" action="mypage_later.php" class="d-inline"
                 onsubmit="return confirm('リストから削除しますか？');">
             <input type="hidden" name="action" value="remove" />
             <input type="hidden" name="fullpath" value="<?php echo htmlspecialchars($fullpath, ENT_QUOTES, 'UTF-8'); ?>" />
-            <button type="submit" class="btn btn-danger btn-xs">削除</button>
+            <button type="submit" class="btn btn-outline-danger btn-sm">削除</button>
           </form>
         </td>
       </tr>
     <?php endforeach; ?>
     </tbody>
   </table>
+  </div>
   <?php endif; ?>
 </div>
 </body>

--- a/mypage_later.php
+++ b/mypage_later.php
@@ -66,14 +66,11 @@ function sort_link_l($label, $sort_key, $cur_sort, $cur_order) {
     検索結果の画面で「後で歌う」リンクを押すと追加できます。
   </p>
   <?php else: ?>
-  <div class="table-responsive">
   <table class="table table-striped table-sm table-hover align-middle">
     <thead class="table-dark">
       <tr>
         <th>曲名</th>
-        <th class="text-nowrap">追加日時</th>
-        <?php if ($sort === 'filedate'): ?><th class="text-nowrap">動画更新日</th><?php endif; ?>
-        <th>操作</th>
+        <th class="text-nowrap">操作</th>
       </tr>
     </thead>
     <tbody>
@@ -95,20 +92,22 @@ function sort_link_l($label, $sort_key, $cur_sort, $cur_order) {
     ?>
       <tr>
         <td>
-          <?php echo htmlspecialchars($songname, ENT_QUOTES, 'UTF-8'); ?>
+          <div><?php echo htmlspecialchars($songname, ENT_QUOTES, 'UTF-8'); ?></div>
           <?php if ($basename !== $songname): ?>
-            <br><span class="text-muted" style="font-size:x-small;"><?php echo htmlspecialchars($basename, ENT_QUOTES, 'UTF-8'); ?></span>
+            <div class="text-muted" style="font-size:x-small;"><?php echo htmlspecialchars($basename, ENT_QUOTES, 'UTF-8'); ?></div>
           <?php endif; ?>
+          <div class="text-muted small">
+            追加: <?php echo htmlspecialchars($added_dt, ENT_QUOTES, 'UTF-8'); ?>
+            <?php if ($filedate_str !== ''): ?>
+              ｜ 動画更新日: <?php echo htmlspecialchars($filedate_str, ENT_QUOTES, 'UTF-8'); ?>
+            <?php endif; ?>
+          </div>
           <?php if ($status['status'] === 'notfound'): ?>
-            <br><span class="text-danger small">[!] ファイルが見つかりません</span>
+            <div class="text-danger small">[!] ファイルが見つかりません</div>
           <?php elseif ($status['status'] === 'relocated'): ?>
-            <br><span class="text-warning small">[!] 別フォルダで見つかりました</span>
+            <div class="text-warning small">[!] 別フォルダで見つかりました</div>
           <?php endif; ?>
         </td>
-        <td class="text-nowrap"><?php echo htmlspecialchars($added_dt, ENT_QUOTES, 'UTF-8'); ?></td>
-        <?php if ($sort === 'filedate'): ?>
-        <td class="text-nowrap"><?php echo $filedate_str !== '' ? htmlspecialchars($filedate_str, ENT_QUOTES, 'UTF-8') : '<span class="text-muted">-</span>'; ?></td>
-        <?php endif; ?>
         <td class="text-nowrap">
           <?php if ($status['status'] === 'ok' || $status['status'] === 'relocated'): ?>
             <a href="<?php echo htmlspecialchars($req_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-sm">リクエスト</a>
@@ -127,7 +126,6 @@ function sort_link_l($label, $sort_key, $cur_sort, $cur_order) {
     <?php endforeach; ?>
     </tbody>
   </table>
-  </div>
   <?php endif; ?>
 </div>
 </body>

--- a/mypage_later.php
+++ b/mypage_later.php
@@ -72,6 +72,7 @@ function sort_link_l($label, $sort_key, $cur_sort, $cur_order) {
       <tr>
         <th>曲名</th>
         <th class="text-nowrap">追加日時</th>
+        <?php if ($sort === 'filedate'): ?><th class="text-nowrap">動画更新日</th><?php endif; ?>
         <th>操作</th>
       </tr>
     </thead>
@@ -87,6 +88,10 @@ function sort_link_l($label, $sort_key, $cur_sort, $cur_order) {
         $req_fullpath = ($status['status'] === 'relocated') ? $status['fullpath'] : $fullpath;
         $req_url    = MypageUser::makeRequestConfirmUrl($req_fullpath, $songfile, $kind);
         $search_url = MypageUser::makeSearchFallbackUrl($songfile);
+        $filedate_str = '';
+        if ($sort === 'filedate' && !empty($row['_filedate_ts'])) {
+            $filedate_str = date('Y/m/d', $row['_filedate_ts']);
+        }
     ?>
       <tr>
         <td>
@@ -101,6 +106,9 @@ function sort_link_l($label, $sort_key, $cur_sort, $cur_order) {
           <?php endif; ?>
         </td>
         <td class="text-nowrap"><?php echo htmlspecialchars($added_dt, ENT_QUOTES, 'UTF-8'); ?></td>
+        <?php if ($sort === 'filedate'): ?>
+        <td class="text-nowrap"><?php echo $filedate_str !== '' ? htmlspecialchars($filedate_str, ENT_QUOTES, 'UTF-8') : '<span class="text-muted">-</span>'; ?></td>
+        <?php endif; ?>
         <td class="text-nowrap">
           <?php if ($status['status'] === 'ok' || $status['status'] === 'relocated'): ?>
             <a href="<?php echo htmlspecialchars($req_url, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-sm">リクエスト</a>


### PR DESCRIPTION
## 概要

マイページ関連画面のデザイン・機能改善を行いました。

## 変更内容

### 1. マイページトップ（mypage.php）- 背景色修正
- `css/style.css` の固定背景色 `#F8ECE0` が設定画面の背景色設定（`--bg-page`）を上書きしていた問題を修正
- `css/themes/_variables.css` を読み込み、`body` に `var(--bg-page)` を適用するスタイルを追加
- 他ページと同様に設定した背景色・背景画像が反映されるようになりました

### 2. サブページのBS5化（mypage_history / later / favorite_song / favorite_keyword）
- Bootstrap 3 → Bootstrap 5 に移行（CSS/JS、`shownavigatioinbar_bs5()` 呼び出し）
- `table-condensed` → `table-sm`、`btn-xs` → `btn-sm`、`btn-default` → `btn-outline-secondary` 等
- テーブルを「曲名」「操作」の2列構成に変更し、回数・日時をサブテキストとして曲名セル内に表示
  - スマホで横スクロールなしに閲覧できるよう改善

### 3. 動画更新日順ソート（mypage_history / later / favorite_song）
- ListerDB の `found_last_write_time`（Modified Julian Date形式）を参照した動画更新日順ソートを追加
- **別フォルダ対応**：`found_path` 完全一致で見つからない場合はファイル名末尾一致で検索
- `sort=filedate` のとき、曲名下に「動画更新日: YYYY/MM/DD」を表示
- ListerDB がない環境ではフォールバック（ファイル日付0扱い）で無害に動作

### 4. 動画更新日の日付修正
- `found_last_write_time` はExcel/OLE形式（epoch: 1899-12-30）ではなく **Modified Julian Date (MJD)** 形式（epoch: 1858-11-17）で格納されていることが判明
- 変換定数を `25569`（OLE用）→ `40587`（MJD用のUnixエポック値）に修正
- 2067年等の誤った年が表示されていた問題を解消

## 変更ファイル
- `mypage.php`
- `mypage_class.php`
- `mypage_history.php`
- `mypage_later.php`
- `mypage_favorite_song.php`
- `mypage_favorite_keyword.php`

https://claude.ai/code/session_012zdQj2bZ91QQLxFogXKyyW

---
_Generated by [Claude Code](https://claude.ai/code/session_012zdQj2bZ91QQLxFogXKyyW)_