### PR TITLE
コメントフォーム送信時にcommentpost.phpへ遷移しないよう修正

### DIFF
--- a/comment.php
+++ b/comment.php
@@ -99,5 +99,30 @@ require_once 'commonfunc.php';
 
 </div><!-- /container -->
 
+<script>
+$(document).ready(function(){
+    $(".sendcomment").submit(function(event){
+        event.preventDefault();
+        var $form = $(this);
+        var $button = $form.find('button');
+        $.ajax({
+            url: $form.attr('action'),
+            type: $form.attr('method'),
+            data: $form.serialize(),
+            timeout: 10000,
+            beforeSend: function(){
+                $button.attr('disabled', true);
+            },
+            complete: function(){
+                $button.attr('disabled', false);
+            },
+            error: function(){
+                alert('NG...');
+            }
+        });
+    });
+});
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
## 概要

BS5化後、コメント送信ボタンを押すと `commentpost.php` へページ遷移してしまう問題を修正。

## 原因

BS3版では `requsetlist_ctrl.js` が読み込まれており、`.sendcomment` フォームの `submit` イベントを `event.preventDefault()` + jQuery AJAX でハンドリングしていた。  
BS5化の際、`print_bs5_search_head()` は `jquery.js` と `bootstrap.bundle.min.js` のみを読み込む実装になっており、`requsetlist_ctrl.js` が `comment.php` で読み込まれなくなった。その結果、フォームが通常送信（ページ遷移）されるようになっていた。

## 修正内容

- `comment.php` の末尾にインラインスクリプトを追加
- `.sendcomment` フォームの `submit` イベントを `event.preventDefault()` + jQuery AJAX で処理するよう対応
- コメント送信後もページは `comment.php` にとどまる（BS3と同じ挙動）

## 確認項目

- [ ] コメント送信後に `commentpost.php` へ遷移しないこと
- [ ] コメントが正常に送信されること
- [ ] 送信中はボタンが無効化され、二重送信が防止されること

https://claude.ai/code/session_011cDmbgdZpTpMRqdHiPYXFr

---
_Generated by [Claude Code](https://claude.ai/code/session_011cDmbgdZpTpMRqdHiPYXFr)_