### PR TITLE
検索ワードを保存リンクをパンくずリスト右に移動 & Google Drive 自動同期機能追加

### DIFF
--- a/mypage_api.php
+++ b/mypage_api.php
@@ -85,5 +85,7 @@ switch ($action) {
 
     default:
         echo json_encode(['status' => 'error', 'message' => 'unknown action']);
-        break;
+        exit;
 }
+
+$mypage->autoSyncToDrive();

--- a/mypage_class.php
+++ b/mypage_class.php
@@ -84,9 +84,10 @@ class MypageUser {
         // Migrate existing tables: add icon_path if missing
         try {
             $this->db->exec("ALTER TABLE mypage_user ADD COLUMN icon_path TEXT DEFAULT ''");
-        } catch (Exception $e) {
-            // Column already exists; ignore
-        }
+        } catch (Exception $e) {}
+        try {
+            $this->db->exec("ALTER TABLE mypage_google_link ADD COLUMN auto_sync INTEGER NOT NULL DEFAULT 0");
+        } catch (Exception $e) {}
         // Migrate: expand UNIQUE constraint on mypage_favorite_keyword to include search_params
         $row = $this->db->query(
             "SELECT sql FROM sqlite_master WHERE type='table' AND name='mypage_favorite_keyword'"
@@ -787,11 +788,40 @@ class MypageUser {
 
     public function getGoogleLink() {
         $stmt = $this->db->prepare(
-            "SELECT google_sub, google_email, access_token, refresh_token, token_expires_at, last_synced_at
+            "SELECT google_sub, google_email, access_token, refresh_token, token_expires_at, last_synced_at, auto_sync
              FROM mypage_google_link WHERE userid=?"
         );
         $stmt->execute([$this->userid]);
         return $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
+    }
+
+    public function setGoogleAutoSync(bool $enabled) {
+        $this->db->prepare(
+            "UPDATE mypage_google_link SET auto_sync=? WHERE userid=?"
+        )->execute([$enabled ? 1 : 0, $this->userid]);
+    }
+
+    public function autoSyncToDrive() {
+        global $config_ini;
+        $link = $this->getGoogleLink();
+        if (!$link || empty($link['auto_sync'])) return;
+
+        $relay_url    = $config_ini['google_relay_url']    ?? '';
+        $relay_secret = $config_ini['google_relay_secret'] ?? '';
+        if (empty($relay_secret)) return;
+
+        require_once __DIR__ . '/mypage_google_drive.php';
+        $drive = new GoogleDriveHelper(
+            $link['access_token'],
+            $link['refresh_token'],
+            $link['token_expires_at'],
+            $relay_url,
+            $relay_secret
+        );
+        $ok = @$drive->writeData($this->exportData());
+        [$new_at, $new_exp, $refreshed] = $drive->getNewTokens();
+        if ($refreshed) $this->updateGoogleTokens($new_at, $new_exp);
+        if ($ok) $this->updateGoogleSyncTime();
     }
 
     public function updateGoogleTokens($access_token, $expires_at) {

--- a/mypage_class.php
+++ b/mypage_class.php
@@ -86,7 +86,8 @@ class MypageUser {
             $this->db->exec("ALTER TABLE mypage_user ADD COLUMN icon_path TEXT DEFAULT ''");
         } catch (Exception $e) {}
         try {
-            $this->db->exec("ALTER TABLE mypage_google_link ADD COLUMN auto_sync INTEGER NOT NULL DEFAULT 0");
+            $this->db->exec("ALTER TABLE mypage_google_link ADD COLUMN auto_sync INTEGER NOT NULL DEFAULT 1");
+            $this->db->exec("UPDATE mypage_google_link SET auto_sync=1");
         } catch (Exception $e) {}
         // Migrate: expand UNIQUE constraint on mypage_favorite_keyword to include search_params
         $row = $this->db->query(
@@ -776,8 +777,8 @@ class MypageUser {
     public function linkGoogle($google_sub, $email, $access_token, $refresh_token, $expires_at) {
         $stmt = $this->db->prepare(
             "INSERT OR REPLACE INTO mypage_google_link
-             (userid, google_sub, google_email, access_token, refresh_token, token_expires_at, linked_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?)"
+             (userid, google_sub, google_email, access_token, refresh_token, token_expires_at, linked_at, auto_sync)
+             VALUES (?, ?, ?, ?, ?, ?, ?, 1)"
         );
         $stmt->execute([$this->userid, $google_sub, $email, $access_token, $refresh_token, $expires_at, time()]);
     }

--- a/mypage_google_sync.php
+++ b/mypage_google_sync.php
@@ -63,6 +63,13 @@ if (isset($_POST['action']) && $_POST['action'] === 'unlink') {
     exit;
 }
 
+// 自動同期 オン/オフ切り替え
+if (isset($_POST['action']) && $_POST['action'] === 'set_auto_sync') {
+    $mypage->setGoogleAutoSync(!empty($_POST['auto_sync']));
+    header('Location: mypage_google_sync.php');
+    exit;
+}
+
 // 手動同期（Drive → ローカル merge）
 if (isset($_POST['action']) && $_POST['action'] === 'sync_from_drive') {
     $link = $mypage->getGoogleLink();
@@ -170,6 +177,26 @@ $link = $mypage->getGoogleLink(); // 最新状態を再取得
             <span class="glyphicon glyphicon-download-alt"></span>
             DriveのデータをこのサーバーにMerge
           </button>
+        </form>
+      </div>
+
+      <div style="margin-top:14px;">
+        <form method="POST" action="mypage_google_sync.php">
+          <input type="hidden" name="action" value="set_auto_sync" />
+          <?php if (!empty($link['auto_sync'])): ?>
+            <p><span class="label label-success">自動同期: ON</span>
+            &nbsp;お気に入り・検索ワードを追加・削除するたびに自動でDriveに保存されます。</p>
+            <button type="submit" class="btn btn-default btn-sm">自動同期を無効にする</button>
+          <?php else: ?>
+            <p><span class="label label-default">自動同期: OFF</span></p>
+            <button type="submit" name="auto_sync" value="1" class="btn btn-success btn-sm">
+              <span class="glyphicon glyphicon-refresh"></span>
+              自動同期を有効にする
+            </button>
+            <p class="text-muted" style="margin-top:6px;font-size:12px;">
+              有効にすると、お気に入り・検索ワードの追加・削除のたびに自動でDriveに保存されます。
+            </p>
+          <?php endif; ?>
         </form>
       </div>
 

--- a/search_listerdb_filelist_bs5.php
+++ b/search_listerdb_filelist_bs5.php
@@ -299,10 +299,33 @@ mypage_action_script();
   <div class="notice-box" role="alert"><?php echo htmlspecialchars($errmsg, ENT_QUOTES, 'UTF-8'); ?></div>
 <?php else: ?>
 
+<?php
+if      (!empty($anyword))     { $_kp = 'anyword';     $_kv = $anyword; }
+elseif  (!empty($song_name))   { $_kp = 'song_name';   $_kv = $song_name; }
+elseif  (!empty($filename))    { $_kp = 'filename';    $_kv = $filename; }
+elseif  (!empty($artist))      { $_kp = 'artist';      $_kv = $artist; }
+elseif  (!empty($program_name)){ $_kp = 'program_name';$_kv = $program_name; }
+elseif  (!empty($maker_name))  { $_kp = 'maker_name';  $_kv = $maker_name; }
+else                           { $_kp = '';             $_kv = ''; }
+$_kw_savelink = '';
+if (!empty($_kv)) {
+    $_sp = !empty($lister_dbpath) ? 'lister_dbpath=' . urlencode($lister_dbpath) : '';
+    $_kw_sp = 'param=' . $_kp . (!empty($_sp) ? '&' . $_sp : '') . (!empty($match) ? '&match=' . urlencode($match) : '');
+    $_kw_savelink = mypage_save_keyword_link($_kv, 'listerdb_filelist', $_kw_sp);
+}
+?>
 <?php if (!empty($program_name) && !empty($category)): ?>
-  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($category, ENT_QUOTES, 'UTF-8'); ?>」「<?php echo htmlspecialchars($program_name, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧</h2>
+  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($category, ENT_QUOTES, 'UTF-8'); ?>」「<?php echo htmlspecialchars($program_name, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧<?php echo $_kw_savelink; ?></h2>
 <?php elseif (!empty($artist)): ?>
-  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($artist, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧</h2>
+  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($artist, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧<?php echo $_kw_savelink; ?></h2>
+<?php elseif (!empty($anyword)): ?>
+  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($anyword, ENT_QUOTES, 'UTF-8'); ?>」の検索結果<?php echo $_kw_savelink; ?></h2>
+<?php elseif (!empty($song_name)): ?>
+  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($song_name, ENT_QUOTES, 'UTF-8'); ?>」の検索結果<?php echo $_kw_savelink; ?></h2>
+<?php elseif (!empty($filename)): ?>
+  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($filename, ENT_QUOTES, 'UTF-8'); ?>」の検索結果<?php echo $_kw_savelink; ?></h2>
+<?php elseif (!empty($maker_name)): ?>
+  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($maker_name, ENT_QUOTES, 'UTF-8'); ?>」の検索結果<?php echo $_kw_savelink; ?></h2>
 <?php endif; ?>
 
 <!-- 再検索 -->
@@ -328,20 +351,6 @@ mypage_action_script();
     </div>
   </div>
 </div>
-<?php
-      if      (!empty($anyword))     { $_kp = 'anyword';     $_kv = $anyword; }
-      elseif  (!empty($song_name))   { $_kp = 'song_name';   $_kv = $song_name; }
-      elseif  (!empty($filename))    { $_kp = 'filename';    $_kv = $filename; }
-      elseif  (!empty($artist))      { $_kp = 'artist';      $_kv = $artist; }
-      elseif  (!empty($program_name)){ $_kp = 'program_name';$_kv = $program_name; }
-      elseif  (!empty($maker_name))  { $_kp = 'maker_name';  $_kv = $maker_name; }
-      else                           { $_kp = '';             $_kv = ''; }
-      if (!empty($_kv)) {
-          $sp = !empty($lister_dbpath) ? 'lister_dbpath=' . urlencode($lister_dbpath) : '';
-          $kw_sp = 'param=' . $_kp . (!empty($sp) ? '&' . $sp : '') . (!empty($match) ? '&match=' . urlencode($match) : '');
-          echo mypage_save_keyword_link($_kv, 'listerdb_filelist', $kw_sp);
-      }
-?>
 <?php endif; ?>
 
 <!-- 並び替え & おすすめ -->

--- a/search_listerdb_filelist_bs5.php
+++ b/search_listerdb_filelist_bs5.php
@@ -294,11 +294,6 @@ mypage_action_script();
 <?php showuppermenu('filename', $linkoptionbare); ?>
 
 <div class="container py-3">
-<?php build_breadcrumbs_bs5($crumbs); ?>
-<?php if (!empty($errmsg)): ?>
-  <div class="notice-box" role="alert"><?php echo htmlspecialchars($errmsg, ENT_QUOTES, 'UTF-8'); ?></div>
-<?php else: ?>
-
 <?php
 if      (!empty($anyword))     { $_kp = 'anyword';     $_kv = $anyword; }
 elseif  (!empty($song_name))   { $_kp = 'song_name';   $_kv = $song_name; }
@@ -314,18 +309,18 @@ if (!empty($_kv)) {
     $_kw_savelink = mypage_save_keyword_link($_kv, 'listerdb_filelist', $_kw_sp);
 }
 ?>
+<div class="d-flex justify-content-between align-items-center mb-2">
+  <?php build_breadcrumbs_bs5($crumbs); ?>
+  <?php if (!empty($_kw_savelink)): ?><small class="text-muted"><?php echo $_kw_savelink; ?></small><?php endif; ?>
+</div>
+<?php if (!empty($errmsg)): ?>
+  <div class="notice-box" role="alert"><?php echo htmlspecialchars($errmsg, ENT_QUOTES, 'UTF-8'); ?></div>
+<?php else: ?>
+
 <?php if (!empty($program_name) && !empty($category)): ?>
-  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($category, ENT_QUOTES, 'UTF-8'); ?>」「<?php echo htmlspecialchars($program_name, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧<?php echo $_kw_savelink; ?></h2>
+  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($category, ENT_QUOTES, 'UTF-8'); ?>」「<?php echo htmlspecialchars($program_name, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧</h2>
 <?php elseif (!empty($artist)): ?>
-  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($artist, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧<?php echo $_kw_savelink; ?></h2>
-<?php elseif (!empty($anyword)): ?>
-  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($anyword, ENT_QUOTES, 'UTF-8'); ?>」の検索結果<?php echo $_kw_savelink; ?></h2>
-<?php elseif (!empty($song_name)): ?>
-  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($song_name, ENT_QUOTES, 'UTF-8'); ?>」の検索結果<?php echo $_kw_savelink; ?></h2>
-<?php elseif (!empty($filename)): ?>
-  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($filename, ENT_QUOTES, 'UTF-8'); ?>」の検索結果<?php echo $_kw_savelink; ?></h2>
-<?php elseif (!empty($maker_name)): ?>
-  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($maker_name, ENT_QUOTES, 'UTF-8'); ?>」の検索結果<?php echo $_kw_savelink; ?></h2>
+  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($artist, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧</h2>
 <?php endif; ?>
 
 <!-- 再検索 -->

--- a/search_listerdb_filelist_bs5.php
+++ b/search_listerdb_filelist_bs5.php
@@ -325,7 +325,10 @@ mypage_action_script();
         <?php if (!empty($selectid)):       ?><input type="hidden" name="selectid"     value="<?php echo htmlspecialchars($selectid, ENT_QUOTES, 'UTF-8'); ?>"><?php endif; ?>
         <button type="submit" class="btn-secondary-themed">再検索</button>
       </form>
-      <?php
+    </div>
+  </div>
+</div>
+<?php
       if      (!empty($anyword))     { $_kp = 'anyword';     $_kv = $anyword; }
       elseif  (!empty($song_name))   { $_kp = 'song_name';   $_kv = $song_name; }
       elseif  (!empty($filename))    { $_kp = 'filename';    $_kv = $filename; }
@@ -338,10 +341,7 @@ mypage_action_script();
           $kw_sp = 'param=' . $_kp . (!empty($sp) ? '&' . $sp : '') . (!empty($match) ? '&match=' . urlencode($match) : '');
           echo mypage_save_keyword_link($_kv, 'listerdb_filelist', $kw_sp);
       }
-      ?>
-    </div>
-  </div>
-</div>
+?>
 <?php endif; ?>
 
 <!-- 並び替え & おすすめ -->

--- a/search_listerdb_songlist_bs5.php
+++ b/search_listerdb_songlist_bs5.php
@@ -130,11 +130,6 @@ mypage_action_script();
 <?php showuppermenu('', $linkoptionbare); ?>
 
 <div class="container py-3">
-<?php build_breadcrumbs_bs5($crumbs); ?>
-<?php if (!empty($errmsg)): ?>
-  <div class="notice-box" role="alert"><?php echo htmlspecialchars($errmsg, ENT_QUOTES, 'UTF-8'); ?></div>
-<?php else: ?>
-
 <?php
 if      (!empty($song_name))    { $_kp = 'song_name';    $_kv = $song_name; }
 elseif  (!empty($artist))       { $_kp = 'artist';       $_kv = $artist; }
@@ -148,14 +143,18 @@ if (!empty($_kv)) {
     $_kw_savelink = mypage_save_keyword_link($_kv, 'listerdb_songlist', $_kw_sp);
 }
 ?>
+<div class="d-flex justify-content-between align-items-center mb-2">
+  <?php build_breadcrumbs_bs5($crumbs); ?>
+  <?php if (!empty($_kw_savelink)): ?><small class="text-muted"><?php echo $_kw_savelink; ?></small><?php endif; ?>
+</div>
+<?php if (!empty($errmsg)): ?>
+  <div class="notice-box" role="alert"><?php echo htmlspecialchars($errmsg, ENT_QUOTES, 'UTF-8'); ?></div>
+<?php else: ?>
+
 <?php if (!empty($program_name) && !empty($category)): ?>
-  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($category, ENT_QUOTES, 'UTF-8'); ?>」「<?php echo htmlspecialchars($program_name, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧<?php echo $_kw_savelink; ?></h2>
+  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($category, ENT_QUOTES, 'UTF-8'); ?>」「<?php echo htmlspecialchars($program_name, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧</h2>
 <?php elseif (!empty($artist)): ?>
-  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($artist, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧<?php echo $_kw_savelink; ?></h2>
-<?php elseif (!empty($song_name)): ?>
-  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($song_name, ENT_QUOTES, 'UTF-8'); ?>」の検索結果<?php echo $_kw_savelink; ?></h2>
-<?php elseif (!empty($maker_name)): ?>
-  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($maker_name, ENT_QUOTES, 'UTF-8'); ?>」の検索結果<?php echo $_kw_savelink; ?></h2>
+  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($artist, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧</h2>
 <?php endif; ?>
 
 <!-- 再検索フォーム -->

--- a/search_listerdb_songlist_bs5.php
+++ b/search_listerdb_songlist_bs5.php
@@ -135,10 +135,27 @@ mypage_action_script();
   <div class="notice-box" role="alert"><?php echo htmlspecialchars($errmsg, ENT_QUOTES, 'UTF-8'); ?></div>
 <?php else: ?>
 
+<?php
+if      (!empty($song_name))    { $_kp = 'song_name';    $_kv = $song_name; }
+elseif  (!empty($artist))       { $_kp = 'artist';       $_kv = $artist; }
+elseif  (!empty($program_name)) { $_kp = 'program_name'; $_kv = $program_name; }
+elseif  (!empty($maker_name))   { $_kp = 'maker_name';   $_kv = $maker_name; }
+else                            { $_kp = ''; $_kv = ''; }
+$_kw_savelink = '';
+if (!empty($_kv)) {
+    $_sp = !empty($lister_dbpath) ? 'lister_dbpath=' . urlencode($lister_dbpath) : '';
+    $_kw_sp = 'param=' . $_kp . (!empty($_sp) ? '&' . $_sp : '') . (!empty($match) ? '&match=' . urlencode($match) : '');
+    $_kw_savelink = mypage_save_keyword_link($_kv, 'listerdb_songlist', $_kw_sp);
+}
+?>
 <?php if (!empty($program_name) && !empty($category)): ?>
-  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($category, ENT_QUOTES, 'UTF-8'); ?>」「<?php echo htmlspecialchars($program_name, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧</h2>
+  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($category, ENT_QUOTES, 'UTF-8'); ?>」「<?php echo htmlspecialchars($program_name, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧<?php echo $_kw_savelink; ?></h2>
 <?php elseif (!empty($artist)): ?>
-  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($artist, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧</h2>
+  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($artist, ENT_QUOTES, 'UTF-8'); ?>」の曲一覧<?php echo $_kw_savelink; ?></h2>
+<?php elseif (!empty($song_name)): ?>
+  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($song_name, ENT_QUOTES, 'UTF-8'); ?>」の検索結果<?php echo $_kw_savelink; ?></h2>
+<?php elseif (!empty($maker_name)): ?>
+  <h2 class="h5 mb-3">「<?php echo htmlspecialchars($maker_name, ENT_QUOTES, 'UTF-8'); ?>」の検索結果<?php echo $_kw_savelink; ?></h2>
 <?php endif; ?>
 
 <!-- 再検索フォーム -->
@@ -164,18 +181,6 @@ mypage_action_script();
     </div>
   </div>
 </div>
-<?php
-      if      (!empty($song_name))    { $_kp = 'song_name';    $_kv = $song_name; }
-      elseif  (!empty($artist))       { $_kp = 'artist';       $_kv = $artist; }
-      elseif  (!empty($program_name)) { $_kp = 'program_name'; $_kv = $program_name; }
-      elseif  (!empty($maker_name))   { $_kp = 'maker_name';   $_kv = $maker_name; }
-      else                            { $_kp = ''; $_kv = ''; }
-      if (!empty($_kv)) {
-          $sp = !empty($lister_dbpath) ? 'lister_dbpath=' . urlencode($lister_dbpath) : '';
-          $kw_sp = 'param=' . $_kp . (!empty($sp) ? '&' . $sp : '') . (!empty($match) ? '&match=' . urlencode($match) : '');
-          echo mypage_save_keyword_link($_kv, 'listerdb_songlist', $kw_sp);
-      }
-?>
 <?php endif; ?>
 
 <!-- 並び替え -->

--- a/search_listerdb_songlist_bs5.php
+++ b/search_listerdb_songlist_bs5.php
@@ -161,7 +161,10 @@ mypage_action_script();
         <?php if (!empty($selectid)): ?><input type="hidden" name="selectid" value="<?php echo htmlspecialchars($selectid, ENT_QUOTES, 'UTF-8'); ?>"><?php endif; ?>
         <button type="submit" class="btn-secondary-themed">再検索</button>
       </form>
-      <?php
+    </div>
+  </div>
+</div>
+<?php
       if      (!empty($song_name))    { $_kp = 'song_name';    $_kv = $song_name; }
       elseif  (!empty($artist))       { $_kp = 'artist';       $_kv = $artist; }
       elseif  (!empty($program_name)) { $_kp = 'program_name'; $_kv = $program_name; }
@@ -172,10 +175,7 @@ mypage_action_script();
           $kw_sp = 'param=' . $_kp . (!empty($sp) ? '&' . $sp : '') . (!empty($match) ? '&match=' . urlencode($match) : '');
           echo mypage_save_keyword_link($_kv, 'listerdb_songlist', $kw_sp);
       }
-      ?>
-    </div>
-  </div>
-</div>
+?>
 <?php endif; ?>
 
 <!-- 並び替え -->


### PR DESCRIPTION
## 変更内容

### 検索ワードを保存リンクの移動

アコーディオン（再検索・絞り込み）の中に隠れていた「検索ワードを保存」リンクを、パンくずリストの右端に控えめ（`small / text-muted`）に表示するよう移動。

対象ファイル:
- `search_listerdb_songlist_bs5.php`
- `search_listerdb_filelist_bs5.php`

### Google Drive 自動同期機能

お気に入り・検索ワードの追加/削除のたびに、自動で Google Drive へアップロードする機能を追加。

**動作フロー**
- 旧サーバーで自動同期ON → 操作のたびに Drive へ自動アップロード
- 新サーバーで「Googleアカウントで連携する」ボタンを押す → Drive のデータを自動 merge → マイページが復元される

**デフォルト: ON**（Google 連携済みユーザーは自動的に有効。Google同期設定画面からOFFにも切り替え可能）

対象ファイル:
- `mypage_class.php` — `auto_sync` カラム追加（既存DBはマイグレーションで全員ON）、`setGoogleAutoSync()` / `autoSyncToDrive()` メソッド追加
- `mypage_api.php` — 書き込み系アクション後に `autoSyncToDrive()` を呼び出し
- `mypage_google_sync.php` — 自動同期のON/OFF切り替えUIを追加

---
_Generated by [Claude Code](https://claude.ai/code/session_017ufy8D7Er1wgVUSmg4ebat)_