### PR TITLE
検索結果に「動画制作者」と「ファイル名」を追加

### DIFF
--- a/commonfunc.php
+++ b/commonfunc.php
@@ -516,7 +516,7 @@ function searchlocalfilename_part($kerwords, &$result_array,$start = 0, $length 
 		    $orderstr = 'sort=size&ascending=0';
 		  if(empty($order)){
 		    $orderstr = 'sort=size&ascending=0';
-		  }else if($order[0]['column']==3  ){
+		  }else if($order[0]['column']==4  ){
 		    if($order[0]['dir']=='asc'){
 		       $orderstr='sort=size&ascending=1';
 		    }else {
@@ -528,7 +528,7 @@ function searchlocalfilename_part($kerwords, &$result_array,$start = 0, $length 
 		    }else {
 		       $orderstr='sort=name&ascending=0';
 		    }
-		  }else if($order[0]['column']==4  ){
+		  }else if($order[0]['column']==5  ){
 		    if($order[0]['dir']=='asc'){
 		       $orderstr='sort=path&ascending=1';
 		    }else {
@@ -539,7 +539,7 @@ function searchlocalfilename_part($kerwords, &$result_array,$start = 0, $length 
 		  if(empty($order)){
 		    $result_array = search_order_priority($kerwords,$start,$length);
 		    return $result_array;
-		  }else if($order[0]['column']==3  ){
+		  }else if($order[0]['column']==4  ){
 		    if($order[0]['dir']=='asc'){
 		       $orderstr='sort=size&ascending=1';
 		    }else {
@@ -551,7 +551,7 @@ function searchlocalfilename_part($kerwords, &$result_array,$start = 0, $length 
 		    }else {
 		       $orderstr='sort=name&ascending=0';
 		    }
-		  }else if($order[0]['column']==4  ){
+		  }else if($order[0]['column']==5  ){
 		    if($order[0]['dir']=='asc'){
 		       $orderstr='sort=path&ascending=1';
 		    }else {
@@ -865,13 +865,14 @@ $(document).ready(function(){
       { "data": "no", "className":"no"},
       { "data": "reqbtn", "className":"reqbtn"},
       { "data": "filename", "className":"filename"},
+      { "data": "worker", "className":"worker"},
       { "data": "filesize", "className":"filesize"},
       { "data": "filepath", "className":"filepath"},
   ],
   "sDom": '<"H"lrip>t<"F"ip>',
   columnDefs: [
-  { type: 'currency', targets: [3] },
-  { "orderable": false , targets: [1]} 
+  { type: 'currency', targets: [4] },
+  { "orderable": false , targets: [1]}
    ],
    }
   );
@@ -890,6 +891,7 @@ EOD;
 <th>No. <font size="-2" class="searchresult_comment">(おすすめ順)</font></th>
 <th>リクエスト </th>
 <th>ファイル名(プレビューリンク) </th>
+<th>動画制作者 </th>
 <th>サイズ </th>
 <th>パス </th>
 </tr>

--- a/search_listerdb_filelist_bs5.php
+++ b/search_listerdb_filelist_bs5.php
@@ -417,7 +417,11 @@ $displaylast = min($displayfrom + $displaynum, $programlist['recordsTotal']);
           <?php endif; ?>
           <span><?php echo formatBytes($program['found_file_size']); ?></span>
           <span><?php echo fmt_date_bs5($program['found_last_write_time']); ?></span>
+          <?php if (!empty($program['found_worker'])): ?>
+            <a href="search_listerdb_filelist.php?worker=<?php echo urlencode($program['found_worker']); ?><?php echo $linkoption; ?>" class="text-decoration-none text-muted"><?php echo htmlspecialchars($program['found_worker'], ENT_QUOTES, 'UTF-8'); ?></a>
+          <?php endif; ?>
         </div>
+        <div class="text-muted mt-1" style="font-size:0.7rem;word-break:break-all;"><?php echo htmlspecialchars($program['found_path'], ENT_QUOTES, 'UTF-8'); ?></div>
       </div>
       <?php echo mypage_action_links($program['found_path'], $display); ?>
       <?php if (!check_access_from_online()): ?>

--- a/searchfilefromkeyword_json_part.php
+++ b/searchfilefromkeyword_json_part.php
@@ -65,6 +65,18 @@ if(array_key_exists("etorder", $_REQUEST)) {
 searchlocalfilename_part($keyword,$result_a,$start,$length,$r_order,$path);
 //var_dump($result_a);
 
+// Initialize ListerDB for worker lookup
+$lister_kw = null;
+if (array_key_exists('listerDBPATH', $config_ini)) {
+    $lister_dbpath_kw = urldecode($config_ini['listerDBPATH']);
+    if (!empty($lister_dbpath_kw) && file_exist_check_japanese_cf($lister_dbpath_kw)) {
+        require_once('function_search_listerdb.php');
+        $lister_kw = new ListerDB();
+        $lister_kw->listerdbfile = $lister_dbpath_kw;
+        $lister_kw->initdb();
+    }
+}
+
 if( $result_a["totalResults"] >= 1) {
     //build search result 
     $result_withp = addpriority($priority_db,$result_a);
@@ -127,7 +139,17 @@ $draw++;
 			 $fn = $fn . '</div>';
 		 }
 		 $oneresult += array("filename" => $fn);
-		 
+
+		 $worker_val = '';
+		 if ($lister_kw && $lister_kw->ListerDBFD) {
+		     $sql = 'SELECT found_worker FROM t_found WHERE found_path LIKE ' . $lister_kw->ListerDBFD->quote('%' . $v['name'] . '%') . ' LIMIT 1';
+		     $worker_result = $lister_kw->select($sql);
+		     if ($worker_result && !empty($worker_result[0]['found_worker'])) {
+		         $worker_val = htmlspecialchars($worker_result[0]['found_worker'], ENT_QUOTES, 'UTF-8');
+		     }
+		 }
+		 $oneresult += array("worker" => $worker_val);
+
 		 $fs = formatBytes($v['size']);
 		 $oneresult += array("filesize" => $fs);
 		 


### PR DESCRIPTION
## Summary

- `search_listerdb_filelist_bs5.php`: `anyword=XXX` 検索結果（複数曲名が混在するケース）に「動画制作者」と「ファイル名（パス）」の表示を追加
  - 1曲のみのケース（`filelistfromsong_bs5()`）では既に表示されていたが、複数曲名ケースの `else` ブランチには表示が抜けていた
- `searchfilefromkeyword_json_part.php` / `commonfunc.php`: ファイル名検索（Everything）の結果テーブルにも「動画制作者」列を追加（ListerDB を参照）

## Test plan

- [ ] `search_listerdb_filelist_bs5.php?anyword=XXX` で複数曲名が混在する検索結果を表示し、各行に「動画制作者」と「ファイルパス」が表示されることを確認
- [ ] 1曲のみのケースで従来通り表示されることを確認
- [ ] ファイル名検索（Everything）の結果テーブルに「動画制作者」列が表示されることを確認

https://claude.ai/code/session_01PJnVbkS7qvjXnSgpRdRLiE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJnVbkS7qvjXnSgpRdRLiE)_