### PR TITLE
BS5プレイヤー UI改善: ボタン整理・利用頻度色付け・登録者表示

### DIFF
--- a/css/themes/player.css
+++ b/css/themes/player.css
@@ -167,8 +167,9 @@ body {
   letter-spacing: 0.02em;
 }
 .player-nowplaying-singer::before {
-  content: '♪ ';
+  content: '登録者: ';
   opacity: 0.7;
+  font-size: 0.72rem;
 }
 
 /* --- コントロールカード --- */
@@ -349,6 +350,11 @@ body {
   font-size: 0.78rem;
   color: var(--color-text-muted);
   margin-top: 2px;
+}
+.player-nextsong-singer::before {
+  content: '登録者: ';
+  opacity: 0.7;
+  font-size: 0.72rem;
 }
 .player-nextsong-file {
   font-size: 0.72rem;

--- a/css/themes/player.css
+++ b/css/themes/player.css
@@ -160,6 +160,17 @@ body {
   color: #a0aec0;
 }
 
+.player-nowplaying-singer {
+  font-size: 0.8rem;
+  color: #a0aec0;
+  margin-top: 4px;
+  letter-spacing: 0.02em;
+}
+.player-nowplaying-singer::before {
+  content: '♪ ';
+  opacity: 0.7;
+}
+
 /* --- コントロールカード --- */
 .player-controls-card {
   background: var(--bg-card);
@@ -352,6 +363,21 @@ body {
   margin-top: 2px;
   font-style: italic;
   opacity: 0.8;
+}
+
+/* 更新ボタン (小) */
+.player-refresh-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  opacity: 0.65;
+  font-size: 0.78rem;
+  touch-action: manipulation;
+}
+.player-refresh-btn:hover,
+.player-refresh-btn:focus {
+  opacity: 1;
 }
 
 /* foobar 用 プレイヤー種別バッジ */

--- a/foobarctl_bs5.php
+++ b/foobarctl_bs5.php
@@ -36,6 +36,22 @@ $ic_vol_u  = _fb_svg('<path d="M11.536 14.01A8.473 8.473 0 0 0 14.026 8a8.473 8.
 
 <script src="foobarctrl.js"></script>
 
+<?php
+/* Now Playing の singer を DB から取得 */
+$_fb_singer = '';
+try {
+    global $db;
+    $_sql_np = "SELECT singer FROM requesttable WHERE nowplaying = '再生中' ORDER BY reqorder ASC LIMIT 1";
+    $_sel_np = $db->query($_sql_np);
+    if ($_sel_np) {
+        $_row_np = $_sel_np->fetch(PDO::FETCH_ASSOC);
+        $_sel_np->closeCursor();
+        if ($_row_np && !empty($_row_np['singer'])) {
+            $_fb_singer = htmlspecialchars($_row_np['singer'], ENT_QUOTES, 'UTF-8');
+        }
+    }
+} catch (Exception $e) { /* silent */ }
+?>
 <!-- === Now Playing カード (foobar) === -->
 <div class="card player-nowplaying mb-3">
   <div class="card-body p-3">
@@ -44,6 +60,9 @@ $ic_vol_u  = _fb_svg('<path d="M11.536 14.01A8.473 8.473 0 0 0 14.026 8a8.473 8.
       <span class="player-kind-badge">foobar2000</span>
     </div>
     <div class="player-title text-muted" style="opacity:.6;">音楽再生中</div>
+    <?php if ($_fb_singer): ?>
+    <div class="player-nowplaying-singer"><?= $_fb_singer ?></div>
+    <?php endif; ?>
   </div>
 </div>
 
@@ -54,7 +73,7 @@ $ic_vol_u  = _fb_svg('<path d="M11.536 14.01A8.473 8.473 0 0 0 14.026 8a8.473 8.
     <!-- 行1: 曲頭へ / 一時停止・再開 / 曲終了 -->
     <div class="row g-2 mb-2">
       <div class="col-4">
-        <button class="btn btn-outline-secondary player-btn player-btn-main w-100"
+        <button class="btn btn-outline-info player-btn player-btn-main w-100"
                 onclick="song_startfirst()" aria-label="曲の最初から">
           <?= $ic_skip_s ?>
           <span>曲頭へ</span>
@@ -68,7 +87,7 @@ $ic_vol_u  = _fb_svg('<path d="M11.536 14.01A8.473 8.473 0 0 0 14.026 8a8.473 8.
         </button>
       </div>
       <div class="col-4">
-        <button class="btn btn-danger player-btn player-btn-main w-100"
+        <button class="btn btn-outline-secondary player-btn player-btn-main w-100"
                 onclick="foobar_cmd_songnext()" aria-label="曲終了">
           <?= $ic_skip_e ?>
           <span>曲終了</span>
@@ -80,14 +99,14 @@ $ic_vol_u  = _fb_svg('<path d="M11.536 14.01A8.473 8.473 0 0 0 14.026 8a8.473 8.
     <div class="player-section-label">ボリューム</div>
     <div class="row g-2">
       <div class="col-6">
-        <button class="btn btn-outline-secondary player-btn w-100"
+        <button class="btn btn-outline-primary player-btn w-100"
                 onclick="song_vdown()" aria-label="ボリュームDOWN">
           <?= $ic_vol_d ?>
           <span class="small">Vol−</span>
         </button>
       </div>
       <div class="col-6">
-        <button class="btn btn-outline-secondary player-btn w-100"
+        <button class="btn btn-outline-primary player-btn w-100"
                 onclick="song_vup()" aria-label="ボリュームUP">
           <?= $ic_vol_u ?>
           <span class="small">Vol＋</span>
@@ -98,23 +117,14 @@ $ic_vol_u  = _fb_svg('<path d="M11.536 14.01A8.473 8.473 0 0 0 14.026 8a8.473 8.
   </div>
 </div>
 
-<!-- === 再生開始 / 更新 === -->
-<div class="row g-2 mb-3">
-  <div class="col-6">
-    <button class="btn btn-success w-100 player-btn player-btn-main"
-            onclick="foobar_cmd_songstart()" aria-label="再生開始">
-      <?= $ic_play ?>
-      <span>再生開始</span>
-    </button>
-  </div>
-  <div class="col-6">
-    <a href="playerctrl_portal_bs5.php"
-       class="btn btn-outline-secondary w-100 player-btn player-btn-main"
-       aria-label="画面を更新">
-      <?= _fb_svg('<path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z"/><path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z"/>') ?>
-      <span>更新</span>
-    </a>
-  </div>
+<!-- === 更新 (小) === -->
+<div class="d-grid mb-2">
+  <a href="playerctrl_portal_bs5.php"
+     class="btn btn-sm btn-outline-secondary player-refresh-btn"
+     aria-label="画面を更新">
+    <?= _fb_svg('<path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z"/><path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z"/>', 14, 14) ?>
+    更新
+  </a>
 </div>
 
 <script src="js/player_bs5.js"></script>

--- a/func_playerprogress.php
+++ b/func_playerprogress.php
@@ -13,6 +13,7 @@ class PlayerProgress {
     public $status = 0;
     public $playingtitle = "";
     public $playingfile = "";
+    public $playingsinger = "";
     public $playercommandname = "";
     
     
@@ -113,6 +114,7 @@ class PlayerProgress {
 
               $this->playingtitle = !empty($song_name) ? $song_name : $rowall[0]['songfile'];
               $this->playingfile = $rowall[0]['songfile'] ?? '';
+              $this->playingsinger = $rowall[0]['singer'] ?? '';
               break;
           }
         }
@@ -130,6 +132,7 @@ class PlayerProgress {
         $ret += array('status'=>$this->status);
         $ret += array('playingtitle'=>$this->playingtitle);
         $ret += array('playingfile'=>$this->playingfile);
+        $ret += array('playingsinger'=>$this->playingsinger);
 
         return json_encode($ret);
         }else {

--- a/js/player_bs5.js
+++ b/js/player_bs5.js
@@ -157,6 +157,19 @@ function _updateStatusBadge(stateNum) {
     }
 }
 
+/* Now Playing 歌唱者表示を更新 */
+function _updateSingerDisplay(singer) {
+    var el = document.getElementById('player-singer');
+    if (!el) return;
+    if (singer) {
+        el.textContent = singer;
+        el.classList.remove('d-none');
+    } else {
+        el.textContent = '';
+        el.classList.add('d-none');
+    }
+}
+
 /* Now Playing タイトル: 曲名 ⇄ ファイル名 のタップ切り替え
    "title" を表示中か "file" を表示中かを保持。曲が変わったら "title" にリセット */
 var _titleMode = 'title';
@@ -265,15 +278,18 @@ var _lastPlayingTitle = null;
                 /* Now Playing タイトルを BS5 構造で更新 (data 属性に反映してから再描画) */
                 var titleDisplay = document.getElementById('player-title-display');
                 if (titleDisplay) {
-                    var pt = ps.playingtitle || '';
-                    var pf = ps.playingfile  || '';
+                    var pt = ps.playingtitle  || '';
+                    var pf = ps.playingfile   || '';
+                    var ps_singer = ps.playingsinger || '';
                     /* 曲が変わったら表示モードをタイトル側にリセット */
                     if (pt !== titleDisplay.dataset.songTitle) {
                         _titleMode = 'title';
                     }
-                    titleDisplay.dataset.songTitle = pt;
-                    titleDisplay.dataset.songFile  = pf;
+                    titleDisplay.dataset.songTitle  = pt;
+                    titleDisplay.dataset.songFile   = pf;
+                    titleDisplay.dataset.songSinger = ps_singer;
                     _renderPlayerTitle();
+                    _updateSingerDisplay(ps_singer);
                 }
 
                 /* 次の曲カードを更新 */

--- a/mpcctrl_bs5.php
+++ b/mpcctrl_bs5.php
@@ -156,7 +156,10 @@ $song_title  = ($has_song && !empty($playstat->playingtitle))
 $song_file   = ($has_song && !empty($playstat->playingfile))
                ? htmlspecialchars($playstat->playingfile, ENT_QUOTES, 'UTF-8')
                : '';
-$has_alt_file = ($song_file !== '' && $song_file !== $song_title);
+$has_alt_file   = ($song_file !== '' && $song_file !== $song_title);
+$playing_singer = ($has_song && !empty($playstat->playingsinger))
+               ? htmlspecialchars($playstat->playingsinger, ENT_QUOTES, 'UTF-8')
+               : '';
 // state: 2=再生中, 1=一時停止
 $state_num   = $has_song ? (int)$playstat->status : 0;
 
@@ -260,7 +263,8 @@ $playpause_cls  = ($state_num == 2) ? 'player-btn-playpause' : 'btn-outline-prim
     <!-- BS5 表示用: player_bs5.js が song_name で更新する -->
     <div id="player-title-display"
          data-song-title="<?= $song_title ?>"
-         data-song-file="<?= $song_file ?>">
+         data-song-file="<?= $song_file ?>"
+         data-song-singer="<?= $playing_singer ?>">
       <?php if ($song_title): ?>
         <div class="player-label">Now Playing</div>
         <div class="player-title<?= $has_alt_file ? ' player-title-toggleable' : '' ?>"
@@ -277,6 +281,8 @@ $playpause_cls  = ($state_num == 2) ? 'player-btn-playpause' : 'btn-outline-prim
         <div class="player-title text-muted" id="player-title-text" style="opacity:.5;">曲が選択されていません</div>
       <?php endif; ?>
     </div>
+    <div class="player-nowplaying-singer<?= $playing_singer ? '' : ' d-none' ?>"
+         id="player-singer"><?= $playing_singer ?></div>
     <div class="progress mt-3 mb-2" style="height:6px;" role="progressbar"
          aria-valuenow="<?= round($prog_pct) ?>" aria-valuemin="0" aria-valuemax="100">
       <div class="progress-bar" id="divprogress" style="width:<?= $prog_pct ?>%;"></div>
@@ -314,7 +320,7 @@ $playpause_cls  = ($state_num == 2) ? 'player-btn-playpause' : 'btn-outline-prim
     <!-- 行1: 曲頭へ / 再生・一時停止 / 曲終了 -->
     <div class="row g-2 mb-2">
       <div class="col-4">
-        <button class="btn btn-outline-secondary player-btn player-btn-main w-100"
+        <button class="btn btn-outline-info player-btn player-btn-main w-100"
                 onclick="song_startfirst()" aria-label="曲の最初から">
           <?= $ic_skip_s ?>
           <span>曲の最初から</span>
@@ -334,7 +340,7 @@ $playpause_cls  = ($state_num == 2) ? 'player-btn-playpause' : 'btn-outline-prim
         </button>
       </div>
       <div class="col-4">
-        <button class="btn btn-danger player-btn player-btn-main w-100"
+        <button class="btn btn-outline-secondary player-btn player-btn-main w-100"
                 onclick="cmd_songnext()" aria-label="曲終了">
           <?= $ic_skip_e ?>
           <span>曲終了</span>
@@ -379,14 +385,14 @@ $playpause_cls  = ($state_num == 2) ? 'player-btn-playpause' : 'btn-outline-prim
     <div class="player-section-label">ボリューム</div>
     <!-- スライダー行 -->
     <div class="d-flex align-items-center gap-2 mb-2">
-      <button class="btn btn-outline-secondary player-btn flex-shrink-0"
+      <button class="btn btn-outline-primary player-btn flex-shrink-0"
               style="min-width:var(--tap-target);padding:8px;"
               onclick="vol_btn_down()" aria-label="ボリュームDOWN">
         <?= $ic_vol_d ?>
       </button>
       <input type="range" class="form-range flex-grow-1" id="volume-slider"
              min="0" max="100" value="50" aria-label="ボリューム">
-      <button class="btn btn-outline-secondary player-btn flex-shrink-0"
+      <button class="btn btn-outline-primary player-btn flex-shrink-0"
               style="min-width:var(--tap-target);padding:8px;"
               onclick="vol_btn_up()" aria-label="ボリュームUP">
         <?= $ic_vol_u ?>
@@ -403,7 +409,7 @@ $playpause_cls  = ($state_num == 2) ? 'player-btn-playpause' : 'btn-outline-prim
         </button>
       </div>
       <div class="col-6">
-        <button class="btn btn-warning player-btn w-100"
+        <button class="btn btn-outline-secondary player-btn w-100"
                 onclick="exec_fadeout()" aria-label="フェードアウト">
           <?= $ic_fade ?>
           <span class="small">フェードアウト</span>
@@ -423,7 +429,7 @@ $playpause_cls  = ($state_num == 2) ? 'player-btn-playpause' : 'btn-outline-prim
         </button>
       </div>
       <div class="col-4">
-        <button class="btn btn-outline-secondary player-btn w-100"
+        <button class="btn btn-outline-primary player-btn w-100"
                 onclick="song_changeaudio()" aria-label="音声トラック変更">
           <?= _svg('<path d="M6 3a3 3 0 1 1-6 0 3 3 0 0 1 6 0zM3.5 6.5a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 1 0v1a.5.5 0 0 1-.5.5zM16 3a3 3 0 1 1-6 0 3 3 0 0 1 6 0zm-2.5 3.5a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 1 0v1a.5.5 0 0 1-.5.5z"/><path d="M0 9a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V9zm2-1a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V9a1 1 0 0 0-1-1H2z"/><path d="M3 10.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 0 1h-6a.5.5 0 0 1-.5-.5z"/>') ?>
           <span class="small">音声切替</span>
@@ -449,7 +455,7 @@ $playpause_cls  = ($state_num == 2) ? 'player-btn-playpause' : 'btn-outline-prim
         </button>
       </div>
       <div class="col-6">
-        <button class="btn btn-outline-secondary player-btn w-100"
+        <button class="btn btn-outline-primary player-btn w-100"
                 onclick="song_changeaudio()" aria-label="音声トラック変更">
           <?= _svg('<path d="M6 3a3 3 0 1 1-6 0 3 3 0 0 1 6 0zM3.5 6.5a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 1 0v1a.5.5 0 0 1-.5.5zM16 3a3 3 0 1 1-6 0 3 3 0 0 1 6 0zm-2.5 3.5a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 1 0v1a.5.5 0 0 1-.5.5z"/><path d="M0 9a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V9zm2-1a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V9a1 1 0 0 0-1-1H2z"/>') ?>
           <span class="small">音声トラック変更</span>
@@ -488,25 +494,6 @@ $playpause_cls  = ($state_num == 2) ? 'player-btn-playpause' : 'btn-outline-prim
 
   </div><!-- /card-body -->
 </div><!-- /controls-card -->
-
-<!-- === 再生開始 / 更新 === -->
-<div class="row g-2 mb-3">
-  <div class="col-6">
-    <button class="btn btn-success w-100 player-btn player-btn-main"
-            onclick="cmd_songstart()" aria-label="再生開始">
-      <?= $ic_play ?>
-      <span>再生開始</span>
-    </button>
-  </div>
-  <div class="col-6">
-    <a href="playerctrl_portal_bs5.php"
-       class="btn btn-outline-secondary w-100 player-btn player-btn-main"
-       aria-label="画面を更新">
-      <?= _svg('<path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z"/><path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z"/>') ?>
-      <span>更新</span>
-    </a>
-  </div>
-</div>
 
 <!-- === 詳細設定アコーディオン === -->
 <div class="accordion mb-3" id="playerAdvanced">
@@ -633,4 +620,14 @@ $playpause_cls  = ($state_num == 2) ? 'player-btn-playpause' : 'btn-outline-prim
       </div><!-- /accordion-body -->
     </div>
   </div>
+</div>
+
+<!-- === 更新 (小) === -->
+<div class="d-grid mb-2">
+  <a href="playerctrl_portal_bs5.php"
+     class="btn btn-sm btn-outline-secondary player-refresh-btn"
+     aria-label="画面を更新">
+    <?= _svg('<path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z"/><path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z"/>', 14, 14) ?>
+    更新
+  </a>
 </div>


### PR DESCRIPTION
## 変更内容

### 「再生開始」ボタンの削除
- 詳細設定の上にあった「再生開始」ボタンを削除
- 一時停止/再開ボタンで代替できるため不要

### 「更新」ボタンの移動・小型化
- 詳細設定アコーディオンの下（ページ最下部）に `btn-sm` で配置
- 通常時は `opacity: 0.65` で控えめに表示、ホバー時に通常表示

### ボタン色を利用頻度ベースに変更
| 頻度 | 対象ボタン | 色 |
|------|-----------|-----|
| 最高 | Vol＋ / Vol− / 音声トラック変更 | `btn-outline-primary`（青） |
| 中 | 曲の最初から | `btn-outline-info`（水色） |
| 通常 | 曲終了 / フェードアウト / その他 | `btn-outline-secondary`（グレー） |
| 特別 | 一時停止/再開 | `player-btn-playpause`（既存スタイル維持） |

### Now Playing / Next カードに登録者表示
- タイトル下に `登録者: 〇〇` 形式で表示（登録者がいない場合は非表示）
- `func_playerprogress.php` に `playingsinger` プロパティを追加し、AJAX更新（`get_playingstatus_json`）でもリアルタイム反映
- CSS `::before` でラベルを付与しHTMLの変更を最小化
- MPC版・foobar2000版 両方対応

## 変更ファイル
- `mpcctrl_bs5.php`
- `foobarctl_bs5.php`
- `func_playerprogress.php`
- `js/player_bs5.js`
- `css/themes/player.css`

---
_Generated by [Claude Code](https://claude.ai/code/session_014RLBHPsbuADzjT9wriBGxd)_