### PR TITLE
リクエスト確認画面のBootstrap 5対応

### DIFF
--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1423,7 +1423,7 @@ function build_reservation_tabs($selectid = '', $current = 'search', $prefix = '
             'id'    => 'url',
             'label' => 'URL指定',
             'icon'  => $icon_url,
-            'href'  => $pfx . 'request_confirm_url.php?shop_karaoke=0&set_directurl=1' . $sid,
+            'href'  => $pfx . 'request_confirm_url_bs5.php?shop_karaoke=0&set_directurl=1' . $sid,
         ];
     }
 
@@ -1674,7 +1674,7 @@ function selectrequestkind_bs5_dd($prefix = '', $id = '') {
     }
     $ci = isset($connectinternet) ? (int)$connectinternet : 0;
     if ($ci == 1) {
-        $items[] = ['href' => $pfx . 'request_confirm_url.php?shop_karaoke=0&set_directurl=1', 'label' => 'URL(youtube等)'];
+        $items[] = ['href' => $pfx . 'request_confirm_url_bs5.php?shop_karaoke=0&set_directurl=1', 'label' => 'URL(youtube等)'];
     }
     if (isset($usenfrequset) && $usenfrequset == 1) {
         $items[] = ['href' => $pfx . 'notfoundrequest/notfoundrequest.php', 'label' => '未発見曲報告'];

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1404,7 +1404,7 @@ function build_reservation_tabs($selectid = '', $current = 'search', $prefix = '
                 'id'    => 'karaoke',
                 'label' => 'カラオケ配信',
                 'icon'  => $icon_karaoke,
-                'href'  => $pfx . 'request_confirm.php?shop_karaoke=1' . $sid,
+                'href'  => $pfx . 'request_confirm_bs5.php?shop_karaoke=1' . $sid,
             ];
         }
         if (configbool("useuserpause", false) || (isset($user) && $user == 'admin')) {
@@ -1412,7 +1412,7 @@ function build_reservation_tabs($selectid = '', $current = 'search', $prefix = '
                 'id'    => 'pause',
                 'label' => '小休止',
                 'icon'  => $icon_pause,
-                'href'  => $pfx . 'request_confirm.php?pause=1' . $sid,
+                'href'  => $pfx . 'request_confirm_bs5.php?pause=1' . $sid,
             ];
         }
     }
@@ -1659,10 +1659,10 @@ function selectrequestkind_bs5_dd($prefix = '', $id = '') {
     $pm = isset($playmode) ? (int)$playmode : 0;
     if ($pm != 4 && $pm != 5) {
         if (configbool("usehaishin", true)) {
-            $items[] = ['href' => $pfx . 'request_confirm.php?shop_karaoke=1', 'label' => 'カラオケ配信'];
+            $items[] = ['href' => $pfx . 'request_confirm_bs5.php?shop_karaoke=1', 'label' => 'カラオケ配信'];
         }
         if (configbool("useuserpause", false) || (isset($user) && $user == 'admin')) {
-            $items[] = ['href' => $pfx . 'request_confirm.php?pause=1', 'label' => '小休止'];
+            $items[] = ['href' => $pfx . 'request_confirm_bs5.php?pause=1', 'label' => '小休止'];
         }
     }
 

--- a/func_audiotracklist.php
+++ b/func_audiotracklist.php
@@ -136,6 +136,33 @@ function getvideodetails($filename) {
         $details['frame_rate'] = round($info['video']['frame_rate'], 2);
     }
 
+    if (!empty($info['video']['resolution_x']) && !empty($info['video']['resolution_y'])) {
+        $details['resolution'] = $info['video']['resolution_x'] . 'x' . $info['video']['resolution_y'];
+    }
+
+    if (!empty($info['video']['codec'])) {
+        $details['video_codec'] = $info['video']['codec'];
+    } elseif (!empty($info['video']['fourcc_lookup'])) {
+        $details['video_codec'] = $info['video']['fourcc_lookup'];
+    }
+
+    if (!empty($info['audio']['codec'])) {
+        $details['audio_codec'] = $info['audio']['codec'];
+    }
+
+    if (!empty($info['audio']['channels'])) {
+        $ch = (int)$info['audio']['channels'];
+        $details['audio_channels'] = $ch === 1 ? 'モノラル' : ($ch === 2 ? 'ステレオ' : $ch . 'ch');
+    }
+
+    if (!empty($info['audio']['sample_rate'])) {
+        $details['audio_sample_rate'] = number_format($info['audio']['sample_rate']) . ' Hz';
+    }
+
+    if (!empty($info['bitrate'])) {
+        $details['bitrate'] = round($info['bitrate'] / 1000) . ' kbps';
+    }
+
     return $details;
 }
 

--- a/func_audiotracklist.php
+++ b/func_audiotracklist.php
@@ -52,17 +52,16 @@ function checktracktype($trackinfo){
     if($mediainfo['audio_channels'] == 0 && $mediainfo['width'] > 0 &&  $mediainfo['height'] > 0 ) {
         return array(1, NULL);
     }
+    // トラック名: udta/name があれば優先、なければ mdia/hdlr の component_name
     if($typeafalse == 0 ){
         $trackname = $trackinfo['subatoms'][$udtakey]["subatoms"][$namekey]['data'];
     }else {
-        $trackname = $trackinfo['subatoms'][$mdiakey]['subatoms'][1]['component_name'];
+        $hdlrkey = array_search_key('name', 'hdlr', $trackinfo['subatoms'][$mdiakey]['subatoms']);
+        $trackname = ($hdlrkey !== false) ? $trackinfo['subatoms'][$mdiakey]['subatoms'][$hdlrkey]['component_name'] : '';
     }
-    
+
     // audio check
     if($mediainfo['audio_channels'] > 0  ) {
-        $trackname = $mediainfo = $trackinfo['subatoms'][$mdiakey]['subatoms'][1]['component_name'];
-        // print mb_convert_encoding($trackname, 'SJIS-win');
-        
         return array(2, $trackname);
     }
     return false;

--- a/request_confirm_bs5.php
+++ b/request_confirm_bs5.php
@@ -1,0 +1,724 @@
+<?php
+$filename = "";
+if(array_key_exists("filename", $_REQUEST)) {
+    $filename = $_REQUEST["filename"];
+}
+
+$fullpath = "";
+if(array_key_exists("fullpath", $_REQUEST)) {
+    $fullpath = $_REQUEST["fullpath"];
+}
+
+$shop_karaoke = 0;
+if(array_key_exists("shop_karaoke", $_REQUEST)) {
+    $shop_karaoke = $_REQUEST["shop_karaoke"];
+}
+
+$set_directurl = 0;
+if(array_key_exists("set_directurl", $_REQUEST)) {
+    $set_directurl = $_REQUEST["set_directurl"];
+}
+
+
+$forcebgv = 0;
+if(array_key_exists("forcebgv", $_REQUEST)) {
+    $forcebgv = $_REQUEST["forcebgv"];
+}
+
+$set_pause = 0;
+if(array_key_exists("pause", $_REQUEST)) {
+    $set_pause = $_REQUEST["pause"];
+}
+
+
+$selectid = 'none';
+if(array_key_exists("selectid", $_REQUEST)) {
+    $selectid = $_REQUEST["selectid"];
+    if(!is_numeric($selectid)){
+        $selectid = 'none';
+    }
+}
+
+$bgvfile = "";
+if(array_key_exists("bgvfile", $_REQUEST)) {
+    $bgvfile = $_REQUEST["bgvfile"];
+    if($forcebgv == 1) $fullpath=$bgvfile;
+}
+
+/** リクエスト者を毎回新規入力にするかどうか（共有端末用とか） **/
+/** (今のところハードコーディング) **/
+$blank_username = false;
+
+require_once 'commonfunc.php';
+require_once 'easyauth_class.php';
+require_once 'func_audiotracklist.php';
+
+$lister_dbpath = '';
+if(array_key_exists("listerDBPATH", $config_ini)) {
+    $lister_dbpath = urldecode($config_ini['listerDBPATH']);
+}
+
+$easyauth = new EasyAuth();
+$easyauth -> do_eashauthcheck();
+
+if($shop_karaoke == 1 && is_numeric($selectid)){
+    $forcebgv = 1;
+}
+
+$stmt = $db->prepare("SELECT * FROM requesttable ORDER BY reqorder DESC");
+$stmt->execute();
+$allrequest = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$stmt->closeCursor();
+
+$selectrequest = array();
+if(is_numeric($selectid)){
+    $stmt = $db->prepare("SELECT * FROM requesttable WHERE id = :id");
+    $stmt->bindValue(':id', (int)$selectid, PDO::PARAM_INT);
+    $stmt->execute();
+    $selectrequest = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->closeCursor();
+}
+
+function pickupsinger($rt, $moreuser = "")
+{
+   $singerlist = array();
+   if(!empty($moreuser)){
+       $singerlist[] = $moreuser;
+   }
+   foreach($rt as $row)
+   {
+       $foundflg = 0;
+       foreach($singerlist as $esinger ){
+           if( $esinger === $row['singer']){
+               $foundflg = 1;
+               break;
+           }
+       }
+       if($foundflg === 0){
+           $singerlist[] = $row['singer'];
+       }
+   }
+
+   return $singerlist;
+}
+
+function selectedcheck_rc($rt,$singer,$beforesinger = 'none' ){
+    if($beforesinger == 'none'){
+      foreach($rt as $row){
+
+          if($row['singer'] === $singer){
+            if($row['clientip'] === $_SERVER["REMOTE_ADDR"] ) {
+              if($row['clientua'] === $_SERVER["HTTP_USER_AGENT"] ) {
+                return TRUE;
+              }
+            }
+          }
+      }
+    }else{
+        if($singer === $beforesinger){
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
+function json_safe_encode($data){
+    return json_encode($data, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
+}
+
+function extention_musiccheck($fn){
+    if(empty($fn)) return 0;
+    $extension = pathinfo($fn, PATHINFO_EXTENSION);
+    if( empty($extension) ){
+        logtocmd ("ERROR : File has no extension : $fn");
+        return false;
+    // Audio File
+    }elseif( strcasecmp($extension,"mp3") == 0 ){
+        return 2;
+    }elseif(strcasecmp($extension,"m4a") == 0 ){
+        return 2;
+    }elseif(strcasecmp($extension,"wav") == 0 ){
+        return 2;
+    }elseif(strcasecmp($extension,"ogg") == 0 ){
+        return 2;
+    }elseif(strcasecmp($extension,"flac") == 0 ){
+        return 2;
+    }elseif(strcasecmp($extension,"wma") == 0 ){
+        return 2;
+    }elseif(strcasecmp($extension,"aac") == 0 ){
+        return 2;
+    // Movie File
+    }elseif(strcasecmp($extension,"mp4") == 0 ){
+        return 1;
+    }elseif(strcasecmp($extension,"avi") == 0 ){
+        return 1;
+    }elseif(strcasecmp($extension,"mkv") == 0 ){
+        return 1;
+    }elseif(strcasecmp($extension,"mpg") == 0 ){
+        return 1;
+    }elseif(strcasecmp($extension,"flv") == 0 ){
+        return 1;
+    }elseif(strcasecmp($extension,"webm") == 0 ){
+        return 1;
+    }elseif(strcasecmp($extension,"wmv") == 0 ){
+        return 1;
+    }elseif(strcasecmp($extension,"ogm") == 0 ){
+        return 1;
+    }elseif(strcasecmp($extension,"mov") == 0 ){
+        return 1;
+    }else{
+    // unknown file set to movie
+        return 1;
+    }
+}
+?>
+<!doctype html>
+<html lang="ja">
+<head>
+<?php print_meta_header(); ?>
+<link rel="stylesheet" href="css/bootstrap5/bootstrap.min.css">
+<script src="js/bootstrap5/bootstrap.bundle.min.js"></script>
+<script src="js/jquery.js"></script>
+<title>リクエスト確認画面</title>
+<link type="text/css" rel="stylesheet" href="css/style.css" />
+<script type="text/javascript">
+
+function check(selectf){
+flg=(document.getElementById('singer').selectedIndex==0);
+if (!flg) document.getElementById('freesinger').value='';
+document.getElementById('freesinger').parentNode.style.visibility=flg?'visible':'hidden';
+}
+
+
+window.onload = function(){
+document.getElementById("requestconfirm").onsubmit = function(){
+var newname = document.getElementById("freesinger").value;
+var existname = document.getElementById("singer").value;
+
+if (newname == "" && existname =="<?php print(urldecode($config_ini['nonameusername']));?>") {
+<?php
+if($config_ini['nonamerequest'] != 1){
+print 'alert("リクエスト者が空欄です。名前を入れてください\n(次からはドロップダウンで選べます)");';
+print 'return false;';
+}
+?>
+
+}
+}
+}
+
+</script>
+<?php
+$nanasyname = $config_ini["nonameusername"];
+?>
+<script id="nanasycheck" type="text/javascript" charset="utf8" src="js/requsetlist_confirm.js"
+     data-nanasy ='<?php echo json_safe_encode(urldecode($nanasyname)); ?>'
+     data-nanasyflg ='<?php echo json_safe_encode($config_ini['nonamerequest']); ?>'
+> </script>
+
+</head>
+<body>
+<?php
+$YkariUsername = "";
+if(array_key_exists("YkariUsername", $_COOKIE)) {
+    $YkariUsername = $_COOKIE["YkariUsername"];
+}
+?>
+<?php
+shownavigatioinbar_bs5();
+?>
+<div class="container py-3">
+<form method="post" action="exec.php" id="requestconfirm">
+<div class="mb-3">
+<label class="form-label">
+曲名(ファイル名)
+</label>
+<textarea name="filename" id="filename" class="form-control" rows="4" wrap="soft" style="width:100%"
+<?php
+if(is_numeric($selectid) && !empty($selectrequest) && $selectrequest[0]['kind'] == "カラオケ配信"){
+    echo "> ";
+    print htmlspecialchars($selectrequest[0]['songfile'], ENT_QUOTES, 'UTF-8');
+    echo "</textarea> ";
+}else if($shop_karaoke == 1){
+    print 'placeholder="後でセットリスト作成の参考のためにできれば曲名を入れておいてください" >';
+
+    if (empty($filename)){
+      echo "";
+    }else{
+      echo htmlspecialchars($filename, ENT_QUOTES, 'UTF-8');
+    }
+
+    echo "</textarea> ";
+}else if($set_directurl == 1 ){
+    print 'placeholder="直接再生できるURLを指定を入れてください(youtubeのURLもOK)" >';
+    if (empty($filename)){
+      echo "";
+    }else{
+      echo htmlspecialchars($filename, ENT_QUOTES, 'UTF-8');
+    }
+    echo "</textarea> ";
+}else if($set_pause == 1 ){
+    print 'placeholder="小休止時のリストに表示するメッセージ" >';
+    if (!empty($filename)){
+      echo htmlspecialchars($filename, ENT_QUOTES, 'UTF-8');
+    }else if(!empty($config_ini['pause_default_filename'])){
+      echo htmlspecialchars(urldecode($config_ini['pause_default_filename']), ENT_QUOTES, 'UTF-8');
+    }
+    echo "</textarea> ";
+}else {
+    print 'placeholder="曲名" disabled >';
+
+    if (empty($filename)){
+      echo "";
+    }else{
+      echo htmlspecialchars($filename, ENT_QUOTES, 'UTF-8');
+    }
+    echo "</textarea> ";
+    print '<input type="hidden" name="filename" id="filename" style="width:100%" value="'.htmlspecialchars($filename, ENT_QUOTES, 'UTF-8').'"  />';
+    }
+?>
+
+    <input type="hidden" name="fullpath" id="fullpath" style="width:100%" value="<?php echo htmlspecialchars($fullpath, ENT_QUOTES, 'UTF-8'); ?>" />
+<?php
+if(is_numeric($selectid) && !empty($selectrequest) && $selectrequest[0]['kind'] == "カラオケ配信"){
+    print '<dt> BGV曲名 </dt>';
+    print '<dd>'. htmlspecialchars($filename, ENT_QUOTES, 'UTF-8').' <dd>';
+}
+?>
+</div>
+
+<div class="mb-3">
+<label class="form-label">リクエスト者</label>
+<select name="singer" onchange="check(this.form)" onfocus="check(this.form)" id="singer" class="form-select">
+<option value="<?php print(urldecode($config_ini['nonameusername']));?>">新規入力↓</option>
+<?php
+$num = 1;
+
+$beforesinger = 'none';
+if(is_numeric($selectid) && !empty($selectrequest)){
+  $beforesinger = $selectrequest[0]['singer'];
+}
+$selectedcounter = 0;
+$singerlist = pickupsinger($allrequest,$YkariUsername);
+$pausecount = 0;
+foreach($singerlist as $singer)
+{
+  print "<option value=\"";
+  print htmlspecialchars($singer, ENT_QUOTES, 'UTF-8');
+  print "\"";
+  if($set_pause) {
+      // 小休止モード: 「小休止」のみ選択
+      if($singer === '小休止') {
+          print " selected ";
+          $selectedcounter = $selectedcounter + 1;
+      }
+  } else if(is_numeric($selectid) && !empty($selectrequest)) {
+      // 差し替えモード: 元のリクエスト者を優先
+      if($singer === $beforesinger && $selectedcounter === 0) {
+          print " selected ";
+          $selectedcounter = $selectedcounter + 1;
+      }
+  } else if($blank_username){
+  } else if(!empty($YkariUsername)){
+      if($singer === $YkariUsername){
+         print " selected ";
+         $selectedcounter = $selectedcounter + 1 ;
+      }
+  } else if( selectedcheck_rc($allrequest,$singer,$beforesinger) && $selectedcounter === 0 )
+  {
+      print " selected ";
+      $selectedcounter = $selectedcounter + 1 ;
+  }
+  print "> ";
+  print htmlspecialchars($singer);
+  print "</option>";
+  if($singer == '小休止'){
+      $pausecount++;
+  }
+}
+if($set_pause && $pausecount == 0) {
+print '<option value="小休止" selected>小休止</option>';
+$selectedcounter = $selectedcounter + 1;
+}
+
+?>
+
+
+
+</select>
+<?php
+if($selectedcounter === 0){
+print('<span style="visibility:visible;">');
+}else{
+print('<span style="visibility:hidden;">');
+}
+?>
+<input type="text" name="freesinger" id="freesinger" class="form-control mt-2" placeholder="名前を書いてね。２回目からは上のドロップダウンから選べるようになります。" value="" >
+</span>
+</div>
+
+<div class="mb-3">
+<label class="form-label">コメント</label>
+<textarea name="comment" id="comment" class="form-control" rows="4" wrap="soft" placeholder="<?php print htmlspecialchars($requestcomment);?>" style="width:100%" >
+<?php
+if(is_numeric($selectid) && !empty($selectrequest) ){
+    print htmlspecialchars($selectrequest[0]['comment']);
+}else if($set_pause == 1 && !empty($config_ini['pause_default_comment'])){
+    print htmlspecialchars(urldecode($config_ini['pause_default_comment']), ENT_QUOTES, 'UTF-8');
+}
+?>
+</textarea>
+</div>
+
+<div class="mb-3">
+<dl>
+<dt>再生方法</dt>
+<dd>
+<?php
+  if(is_numeric($selectid) && !empty($selectrequest) && $selectrequest[0]['kind'] == "カラオケ配信"){
+      print htmlspecialchars($selectrequest[0]['kind'], ENT_QUOTES, 'UTF-8');
+      print '<input type="hidden" name="kind" id="kind"  value="'.htmlspecialchars($selectrequest[0]['kind'], ENT_QUOTES, 'UTF-8').'" />'."\n";
+      $forcebgv = 1;
+  }else if($shop_karaoke == 1){
+      print 'カラオケ配信'."\n";
+      print '<input type="hidden" name="kind" id="kind"  value="カラオケ配信" />'."\n";
+  }else if($set_directurl == 1){
+      print 'URL指定'."\n";
+      print '<input type="hidden" name="kind" id="kind"  value="URL指定" />'."\n";
+  }else if($set_pause == 1){
+      print '小休止'."\n";
+      print '<input type="hidden" name="kind" id="kind"  value="小休止" />'."\n";
+  }else{
+      print 'ファイル再生(動画/音楽)'."\n";
+      print '<input type="hidden" name="kind" id="kind"  value="動画" />'."\n";
+  }
+?>
+</dd>
+</dl>
+<?php
+
+/* ファイルの存在チェック */
+$fullpath_utf8 = "";
+$audiotracklist = array();
+if($shop_karaoke != 1 ){
+    get_fullfilename($fullpath,$filename,$fullpath_utf8,$lister_dbpath);
+    $filetype = extention_musiccheck($fullpath_utf8);
+    if(!empty($fullpath_utf8) && $filetype == 1 ) {
+        $audiotracklist = getaudiotracklist($fullpath_utf8);
+    }
+}
+
+/* キー変更が有効かどうかのチェック */
+/* 配信→無効 */
+/* 設定で無効 → 無効 */
+/* 設定で有効 → 有効 */
+function keychangecheck($config_ini, $shop_karaoke){
+    if($shop_karaoke == 1) return false;
+    if(array_key_exists('usekeychange' ,$config_ini )) {
+        if( $config_ini['usekeychange'] == 1 ) return true;
+    }
+    return false;
+}
+
+/* キー変更 */
+if(keychangecheck($config_ini, $shop_karaoke) && $filetype == 1){
+    print <<<EOT
+<dl>
+<dt>キー変更</dt>
+<dd>
+<div class="btn-group flex-wrap" role="group" aria-label="キー変更">
+    <input type="radio" class="btn-check" name="keychange" id="key_m6" value="-6" autocomplete="off">
+    <label class="btn btn-outline-secondary" for="key_m6">-6</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_m5" value="-5" autocomplete="off">
+    <label class="btn btn-outline-secondary" for="key_m5">-5</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_m4" value="-4" autocomplete="off">
+    <label class="btn btn-outline-secondary" for="key_m4">-4</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_m3" value="-3" autocomplete="off">
+    <label class="btn btn-outline-secondary" for="key_m3">-3</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_m2" value="-2" autocomplete="off">
+    <label class="btn btn-outline-secondary" for="key_m2">-2</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_m1" value="-1" autocomplete="off">
+    <label class="btn btn-outline-secondary" for="key_m1">-1</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_0" value="0" autocomplete="off" checked>
+    <label class="btn btn-outline-secondary" for="key_0">原曲</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_p1" value="1" autocomplete="off">
+    <label class="btn btn-outline-secondary" for="key_p1">1</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_p2" value="2" autocomplete="off">
+    <label class="btn btn-outline-secondary" for="key_p2">2</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_p3" value="3" autocomplete="off">
+    <label class="btn btn-outline-secondary" for="key_p3">3</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_p4" value="4" autocomplete="off">
+    <label class="btn btn-outline-secondary" for="key_p4">4</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_p5" value="5" autocomplete="off">
+    <label class="btn btn-outline-secondary" for="key_p5">5</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_p6" value="6" autocomplete="off">
+    <label class="btn btn-outline-secondary" for="key_p6">6</label>
+</div>
+</dd>
+</dl>
+EOT;
+
+}
+
+if( $shop_karaoke != 1 && $filetype == 1){
+
+    print <<<EOT
+<dl>
+<dt>トラック選択</dt>
+<dd>
+EOT;
+    if(empty($audiotracklist)){
+        print '<div >オーディオトラックが判別できなかったのでとりあえず3トラック表示しています </div>';
+        print '<select name="track" class="form-select">';
+        $maxtrack = 3;
+        for($c = 0; $c < $maxtrack ; $c++ ){
+          print '  <option value="'.$c.'" >'.($c+1).'トラック目'.'</option>'."\n";
+        }
+    } else {
+        $maxtrack = count($audiotracklist);
+        if(  $maxtrack == 1  &&   (  strlen($audiotracklist[0][1]) == 0 || strpos( $audiotracklist[0][1] , 'Sound Media Handler' ) !== false || strpos( $audiotracklist[0][1] , 'GPAC ISO Audio Handler' ) !== false || strpos( $audiotracklist[0][1] , 'SoundHandler' ) !== false )){
+        print "<pre> 1トラックのみ </pre>";
+        }else {
+        print '<select size="'. $maxtrack .'" name="track"  class="form-select">';
+        for($c = 0; $c < $maxtrack ; $c++ ){
+          if($c == 0 ){
+              print '  <option value="'.$c.'" selected >'.($c+1).'トラック目：'.$audiotracklist[$c][1].'</option>'."\n";
+          }else {
+              print '  <option value="'.$c.'" >'.($c+1).'トラック目：'.$audiotracklist[$c][1].'</option>'."\n";
+          }
+        }
+        }
+
+    }
+    print <<<EOT
+</select>
+</dd>
+</dl>
+EOT;
+}
+
+$videodetails = array();
+$duration_seconds = 0;
+if ($shop_karaoke != 1 && !empty($fullpath_utf8) && ($filetype == 1 || $filetype == 2)) {
+    $videodetails = getvideodetails($fullpath_utf8);
+    if (isset($videodetails['duration_seconds'])) {
+        $duration_seconds = $videodetails['duration_seconds'];
+    }
+}
+if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8) && !empty($videodetails)) {
+        print '<div class="card mt-2">'."\n";
+        print '<div class="card-header" id="videoDetailsHeading">'."\n";
+        print '<button class="btn btn-link btn-sm text-start p-0 collapsed" type="button"'
+              . ' data-bs-toggle="collapse" data-bs-target="#videoDetailsCollapse"'
+              . ' aria-expanded="false" aria-controls="videoDetailsCollapse">'."\n";
+        print '動画詳細情報 ▼'."\n";
+        print '</button>'."\n";
+        print '</div>'."\n";
+        print '<div id="videoDetailsCollapse" class="collapse" aria-labelledby="videoDetailsHeading">'."\n";
+        print '<div class="card-body py-2">'."\n";
+        print '<dl class="row mb-0">'."\n";
+        if (isset($videodetails['duration'])) {
+            print '<dt class="col-sm-3">曲の長さ</dt><dd class="col-sm-9">'.htmlspecialchars($videodetails['duration']).'</dd>'."\n";
+        }
+        if (isset($videodetails['frame_rate'])) {
+            print '<dt class="col-sm-3">フレームレート</dt><dd class="col-sm-9">'.htmlspecialchars($videodetails['frame_rate']).' fps</dd>'."\n";
+        }
+        print '</dl>'."\n";
+        print '</div>'."\n";
+        print '</div>'."\n";
+        print '</div>'."\n";
+}
+echo '<input type="hidden" name="duration" value="' . (int)$duration_seconds . '" />' . "\n";
+
+// 制作者別音ズレ・音量デフォルト値を取得（ListerDB の found_worker と完全一致で判定）
+$audiodelay_init = 0;
+$volume_init = 0; // 0 = 変更なし（全体設定の戻す音量をそのまま使用）
+if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8)) {
+    $delay_file = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'creator_audiodelay.json';
+    if (file_exists($delay_file)) {
+        $delay_rules = json_decode(file_get_contents($delay_file), true);
+        if (is_array($delay_rules) && !empty($delay_rules)) {
+            // ListerDB から found_worker を取得
+            $found_worker = '';
+            if (!empty($lister_dbpath)) {
+                require_once('function_search_listerdb.php');
+                $lister = new ListerDB();
+                $lister->listerdbfile = $lister_dbpath;
+                $listerdb = $lister->initdb();
+                if ($listerdb) {
+                    $songbasename = basename($fullpath_utf8);
+                    $sql = 'SELECT found_worker FROM t_found WHERE found_path LIKE '
+                         . $listerdb->quote('%' . $songbasename . '%') . ' LIMIT 1';
+                    $rows = $lister->select($sql);
+                    if (!empty($rows) && isset($rows[0]['found_worker'])) {
+                        $found_worker = $rows[0]['found_worker'];
+                    }
+                }
+            }
+            if ($found_worker !== '') {
+                $vd_fps = isset($videodetails['frame_rate']) ? floatval($videodetails['frame_rate']) : null;
+                foreach ($delay_rules as $drule) {
+                    $dk = isset($drule['keyword']) ? $drule['keyword'] : '';
+                    if ($dk === '') continue;
+                    if ($found_worker !== $dk) continue;
+                    if (!empty($drule['fps']) && $vd_fps !== null) {
+                        $rule_fps  = floatval($drule['fps']);
+                        $fps_cond  = isset($drule['fps_cond']) ? $drule['fps_cond'] : '以下';
+                        if ($fps_cond === '以上') {
+                            if ($vd_fps < $rule_fps) continue;
+                        } else {
+                            if ($vd_fps > $rule_fps) continue;
+                        }
+                    }
+                    $audiodelay_init = isset($drule['delay']) ? intval($drule['delay']) : 0;
+                    if (isset($drule['volume']) && $drule['volume'] !== '') {
+                        $v = intval($drule['volume']);
+                        if ($v >= -100 && $v <= 100) $volume_init = $v;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}
+// 差し替えモードの場合は元のリクエストの音ズレ・音量値を優先
+if (is_numeric($selectid) && !empty($selectrequest)) {
+    $audiodelay_init = intval($selectrequest[0]['audiodelay']);
+    if (array_key_exists('volume', $selectrequest[0]) && $selectrequest[0]['volume'] !== null && $selectrequest[0]['volume'] !== '') {
+        $v = intval($selectrequest[0]['volume']);
+        if ($v >= -100 && $v <= 100) $volume_init = $v;
+    }
+}
+?>
+<?php if ($shop_karaoke != 1 && $filetype == 1): ?>
+<div class="mt-2 mb-1 text-secondary">
+  <small>音ズレ補正：
+  <button type="button" class="btn btn-outline-secondary btn-sm" onclick="changeAudioDelay(-100)">-100ms</button>
+  <span id="audiodelay_disp" style="display:inline-block; min-width:65px; text-align:center;"><?php echo intval($audiodelay_init); ?> ms</span>
+  <button type="button" class="btn btn-outline-secondary btn-sm" onclick="changeAudioDelay(100)">+100ms</button>
+  <input type="hidden" name="audiodelay" id="audiodelay_val" value="<?php echo intval($audiodelay_init); ?>" />
+  </small>
+</div>
+<div class="mt-1 mb-1 text-secondary">
+  <small>音量増減：
+  <button type="button" class="btn btn-outline-secondary btn-sm" onclick="changeVolume(-5)">-5%</button>
+  <span id="volume_disp" style="display:inline-block; min-width:80px; text-align:center;"><?php $vi = intval($volume_init); echo ($vi > 0 ? '+' : '') . $vi . ' %'; ?></span>
+  <button type="button" class="btn btn-outline-secondary btn-sm" onclick="changeVolume(5)">+5%</button>
+  <button type="button" class="btn btn-outline-secondary btn-sm" onclick="resetVolume()">±0に戻す</button>
+  <input type="hidden" name="volume" id="volume_val" value="<?php echo intval($volume_init); ?>" />
+  </small>
+</div>
+<script>
+function changeAudioDelay(delta){
+  var inp = document.getElementById('audiodelay_val');
+  var disp = document.getElementById('audiodelay_disp');
+  var v = parseInt(inp.value, 10) + delta;
+  if(v < -9900) v = -9900;
+  if(v > 9900) v = 9900;
+  inp.value = v;
+  disp.textContent = v + ' ms';
+}
+function changeVolume(delta){
+  var inp = document.getElementById('volume_val');
+  var disp = document.getElementById('volume_disp');
+  var cur = parseInt(inp.value, 10);
+  if(isNaN(cur)) cur = 0;
+  cur = cur + delta;
+  if(cur < -100) cur = -100;
+  if(cur > 100) cur = 100;
+  inp.value = cur;
+  disp.textContent = (cur > 0 ? '+' : '') + cur + ' %';
+}
+function resetVolume(){
+  var inp = document.getElementById('volume_val');
+  var disp = document.getElementById('volume_disp');
+  inp.value = 0;
+  disp.textContent = '0 %';
+}
+</script>
+<?php endif; ?>
+
+</div>
+<div class="mb-2 form-check">
+<input type="checkbox" class="form-check-input" name="secret" value="1" id="chk_secret" />
+<label class="form-check-label" for="chk_secret">シークレット予約(歌うまで曲名を表示しません)</label>
+</div>
+<?php
+if($config_ini['usebgv'] == 1 && $shop_karaoke != 1 && $filetype == 1){
+print '<div class="mb-2 form-check">';
+print '<input type="checkbox" class="form-check-input" name="loop" value="1" id="chk_bgv" ';
+if($forcebgv == 1 ){
+    print 'checked';
+}
+print ' />';
+print '<label class="form-check-label" for="chk_bgv">BGVモード <small class="text-muted"> この動画をカラオケ配信のBGVとして予約します。</small></label>';
+print '</div>';
+}
+
+$typecheckfn = "";
+if(empty($fullpath)){
+  if(!empty($filename))
+      $typecheckfn = $filename;
+}else{
+$typecheckfn = $fullpath;
+}
+
+if($config_ini['useotherplayer'] == 1 && $shop_karaoke != 1 && extention_musiccheck($typecheckfn) == 1){
+print '<div class="mb-2 form-check">';
+print '<input type="checkbox" class="form-check-input" name="otherplayer" value="1" id="chk_other" />';
+print '<label class="form-check-label" for="chk_other">';
+if(empty($config_ini["otherplayer_disc"])){
+print '別プレイヤー再生';
+}else{
+print urldecode($config_ini["otherplayer_disc"]);
+}
+print '</label>';
+print '</div>';
+}
+
+if(configbool("useuserpause", false) || $user == 'admin' ){
+print '<div class="mb-2 form-check">';
+print '<input type="checkbox" class="form-check-input" name="pause" value="1" id="chk_pause" ';
+if($set_pause == 1 ){
+print 'checked';
+}
+print '/>';
+print '<label class="form-check-label" for="chk_pause">小休止リクエスト</label>';
+print '</div>';
+}
+if(is_numeric($selectid)){
+print '<input type="hidden" name="selectid" id="selectid"  value='.$selectid.' />'."\n";
+}
+
+if($shop_karaoke == 1){
+print '<div class="alert alert-info mt-2">';
+print '<ul class="mb-0">';
+print '<li>自分の番が回ってきたら、「デンモク」から歌いたい曲をリクエストしてください</li>';
+print '<li>歌い終わったら、「予約一覧」から「曲終了」ボタンを押してください</li>';
+if($config_ini['usebgv'] == 1 ){
+  print '<li>このカラオケ配信予約の後、「リスト操作」ボタンを押した後に出てくる「BGV選択」から配信曲の字幕の裏に流す動画を選ぶことができます</li>';
+}
+print '</ul>';
+print '</div>';
+}
+?>
+<div class="row mt-3">
+<div class="col-12 col-sm-8">
+<input type="submit" value="実行" name="requestnow" class="requestconfirm btn btn-primary btn-lg w-100" />
+</div>
+</div>
+
+</form>
+<div class="mt-3 d-flex gap-2">
+<button type="button" onclick="location.href='search.php' " class="btn btn-outline-secondary">
+通常検索に戻る
+</button>
+
+<button type="button" onclick="location.href='requestlist_top.php' " class="btn btn-outline-secondary">
+トップに戻る
+</button>
+</div>
+</div>
+</body>
+</html>

--- a/request_confirm_bs5.php
+++ b/request_confirm_bs5.php
@@ -519,10 +519,29 @@ if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8) && !empty($vi
         print '<div class="card-body py-2">'."\n";
         print '<dl class="row mb-0">'."\n";
         if (isset($videodetails['duration'])) {
-            print '<dt class="col-sm-3">曲の長さ</dt><dd class="col-sm-9">'.htmlspecialchars($videodetails['duration']).'</dd>'."\n";
+            print '<dt class="col-sm-4">曲の長さ</dt><dd class="col-sm-8">'.htmlspecialchars($videodetails['duration']).'</dd>'."\n";
+        }
+        if (isset($videodetails['resolution'])) {
+            print '<dt class="col-sm-4">解像度</dt><dd class="col-sm-8">'.htmlspecialchars($videodetails['resolution']).'</dd>'."\n";
         }
         if (isset($videodetails['frame_rate'])) {
-            print '<dt class="col-sm-3">フレームレート</dt><dd class="col-sm-9">'.htmlspecialchars($videodetails['frame_rate']).' fps</dd>'."\n";
+            print '<dt class="col-sm-4">フレームレート</dt><dd class="col-sm-8">'.htmlspecialchars($videodetails['frame_rate']).' fps</dd>'."\n";
+        }
+        if (isset($videodetails['video_codec'])) {
+            print '<dt class="col-sm-4">映像コーデック</dt><dd class="col-sm-8">'.htmlspecialchars($videodetails['video_codec']).'</dd>'."\n";
+        }
+        if (isset($videodetails['audio_codec'])) {
+            $audio_info = htmlspecialchars($videodetails['audio_codec']);
+            if (isset($videodetails['audio_channels'])) {
+                $audio_info .= ' / ' . htmlspecialchars($videodetails['audio_channels']);
+            }
+            if (isset($videodetails['audio_sample_rate'])) {
+                $audio_info .= ' / ' . htmlspecialchars($videodetails['audio_sample_rate']);
+            }
+            print '<dt class="col-sm-4">音声コーデック</dt><dd class="col-sm-8">'.$audio_info.'</dd>'."\n";
+        }
+        if (isset($videodetails['bitrate'])) {
+            print '<dt class="col-sm-4">ビットレート</dt><dd class="col-sm-8">'.htmlspecialchars($videodetails['bitrate']).'</dd>'."\n";
         }
         print '</dl>'."\n";
         print '</div>'."\n";

--- a/request_confirm_bs5.php
+++ b/request_confirm_bs5.php
@@ -429,31 +429,31 @@ if(keychangecheck($config_ini, $shop_karaoke) && $filetype == 1){
 <dd>
 <div class="btn-group flex-wrap" role="group" aria-label="キー変更">
     <input type="radio" class="btn-check" name="keychange" id="key_m6" value="-6" autocomplete="off">
-    <label class="btn btn-outline-secondary" for="key_m6">-6</label>
+    <label class="btn btn-secondary" for="key_m6">-6</label>
     <input type="radio" class="btn-check" name="keychange" id="key_m5" value="-5" autocomplete="off">
-    <label class="btn btn-outline-secondary" for="key_m5">-5</label>
+    <label class="btn btn-secondary" for="key_m5">-5</label>
     <input type="radio" class="btn-check" name="keychange" id="key_m4" value="-4" autocomplete="off">
-    <label class="btn btn-outline-secondary" for="key_m4">-4</label>
+    <label class="btn btn-secondary" for="key_m4">-4</label>
     <input type="radio" class="btn-check" name="keychange" id="key_m3" value="-3" autocomplete="off">
-    <label class="btn btn-outline-secondary" for="key_m3">-3</label>
+    <label class="btn btn-secondary" for="key_m3">-3</label>
     <input type="radio" class="btn-check" name="keychange" id="key_m2" value="-2" autocomplete="off">
-    <label class="btn btn-outline-secondary" for="key_m2">-2</label>
+    <label class="btn btn-secondary" for="key_m2">-2</label>
     <input type="radio" class="btn-check" name="keychange" id="key_m1" value="-1" autocomplete="off">
-    <label class="btn btn-outline-secondary" for="key_m1">-1</label>
+    <label class="btn btn-secondary" for="key_m1">-1</label>
     <input type="radio" class="btn-check" name="keychange" id="key_0" value="0" autocomplete="off" checked>
-    <label class="btn btn-outline-secondary" for="key_0">原曲</label>
+    <label class="btn btn-secondary" for="key_0">原曲</label>
     <input type="radio" class="btn-check" name="keychange" id="key_p1" value="1" autocomplete="off">
-    <label class="btn btn-outline-secondary" for="key_p1">1</label>
+    <label class="btn btn-secondary" for="key_p1">1</label>
     <input type="radio" class="btn-check" name="keychange" id="key_p2" value="2" autocomplete="off">
-    <label class="btn btn-outline-secondary" for="key_p2">2</label>
+    <label class="btn btn-secondary" for="key_p2">2</label>
     <input type="radio" class="btn-check" name="keychange" id="key_p3" value="3" autocomplete="off">
-    <label class="btn btn-outline-secondary" for="key_p3">3</label>
+    <label class="btn btn-secondary" for="key_p3">3</label>
     <input type="radio" class="btn-check" name="keychange" id="key_p4" value="4" autocomplete="off">
-    <label class="btn btn-outline-secondary" for="key_p4">4</label>
+    <label class="btn btn-secondary" for="key_p4">4</label>
     <input type="radio" class="btn-check" name="keychange" id="key_p5" value="5" autocomplete="off">
-    <label class="btn btn-outline-secondary" for="key_p5">5</label>
+    <label class="btn btn-secondary" for="key_p5">5</label>
     <input type="radio" class="btn-check" name="keychange" id="key_p6" value="6" autocomplete="off">
-    <label class="btn btn-outline-secondary" for="key_p6">6</label>
+    <label class="btn btn-secondary" for="key_p6">6</label>
 </div>
 </dd>
 </dl>
@@ -594,18 +594,18 @@ if (is_numeric($selectid) && !empty($selectrequest)) {
 <?php if ($shop_karaoke != 1 && $filetype == 1): ?>
 <div class="mt-2 mb-1 text-secondary">
   <small>音ズレ補正：
-  <button type="button" class="btn btn-outline-secondary btn-sm" onclick="changeAudioDelay(-100)">-100ms</button>
+  <button type="button" class="btn btn-secondary btn-sm" onclick="changeAudioDelay(-100)">-100ms</button>
   <span id="audiodelay_disp" style="display:inline-block; min-width:65px; text-align:center;"><?php echo intval($audiodelay_init); ?> ms</span>
-  <button type="button" class="btn btn-outline-secondary btn-sm" onclick="changeAudioDelay(100)">+100ms</button>
+  <button type="button" class="btn btn-secondary btn-sm" onclick="changeAudioDelay(100)">+100ms</button>
   <input type="hidden" name="audiodelay" id="audiodelay_val" value="<?php echo intval($audiodelay_init); ?>" />
   </small>
 </div>
 <div class="mt-1 mb-1 text-secondary">
   <small>音量増減：
-  <button type="button" class="btn btn-outline-secondary btn-sm" onclick="changeVolume(-5)">-5%</button>
+  <button type="button" class="btn btn-secondary btn-sm" onclick="changeVolume(-5)">-5%</button>
   <span id="volume_disp" style="display:inline-block; min-width:80px; text-align:center;"><?php $vi = intval($volume_init); echo ($vi > 0 ? '+' : '') . $vi . ' %'; ?></span>
-  <button type="button" class="btn btn-outline-secondary btn-sm" onclick="changeVolume(5)">+5%</button>
-  <button type="button" class="btn btn-outline-secondary btn-sm" onclick="resetVolume()">±0に戻す</button>
+  <button type="button" class="btn btn-secondary btn-sm" onclick="changeVolume(5)">+5%</button>
+  <button type="button" class="btn btn-secondary btn-sm" onclick="resetVolume()">±0に戻す</button>
   <input type="hidden" name="volume" id="volume_val" value="<?php echo intval($volume_init); ?>" />
   </small>
 </div>
@@ -711,11 +711,11 @@ print '</div>';
 
 </form>
 <div class="mt-3 d-flex gap-2">
-<button type="button" onclick="location.href='search.php' " class="btn btn-outline-secondary">
+<button type="button" onclick="location.href='search.php' " class="btn btn-secondary">
 通常検索に戻る
 </button>
 
-<button type="button" onclick="location.href='requestlist_top.php' " class="btn btn-outline-secondary">
+<button type="button" onclick="location.href='requestlist_top.php' " class="btn btn-secondary">
 トップに戻る
 </button>
 </div>

--- a/request_confirm_bs5.php
+++ b/request_confirm_bs5.php
@@ -177,7 +177,10 @@ function extention_musiccheck($fn){
 <html lang="ja">
 <head>
 <?php print_meta_header(); ?>
+<script>(function(){if(window.__ykThemeInit)return;window.__ykThemeInit=true;try{var t=localStorage.getItem("ykari-theme")||"light",f=localStorage.getItem("ykari-fontsize")||"normal";document.documentElement.setAttribute("data-theme",t);document.documentElement.setAttribute("data-fontsize",f);}catch(e){}})();</script>
 <link rel="stylesheet" href="css/bootstrap5/bootstrap.min.css">
+<link rel="stylesheet" href="css/themes/_variables.css">
+<link rel="stylesheet" href="css/themes/theme-toggle.css">
 <script src="js/bootstrap5/bootstrap.bundle.min.js"></script>
 <script src="js/jquery.js"></script>
 <title>リクエスト確認画面</title>

--- a/request_confirm_url_bs5.php
+++ b/request_confirm_url_bs5.php
@@ -110,7 +110,10 @@ function json_safe_encode($data){
 <html lang="ja">
 <head>
 <?php print_meta_header(); ?>
+<script>(function(){if(window.__ykThemeInit)return;window.__ykThemeInit=true;try{var t=localStorage.getItem("ykari-theme")||"light",f=localStorage.getItem("ykari-fontsize")||"normal";document.documentElement.setAttribute("data-theme",t);document.documentElement.setAttribute("data-fontsize",f);}catch(e){}})();</script>
 <link rel="stylesheet" href="css/bootstrap5/bootstrap.min.css">
+<link rel="stylesheet" href="css/themes/_variables.css">
+<link rel="stylesheet" href="css/themes/theme-toggle.css">
 <script src="js/bootstrap5/bootstrap.bundle.min.js"></script>
 <script src="js/jquery.js"></script>
 <title>リクエスト確認画面</title>

--- a/request_confirm_url_bs5.php
+++ b/request_confirm_url_bs5.php
@@ -1,0 +1,334 @@
+<?php
+$filename = "";
+if(array_key_exists("filename", $_REQUEST)) {
+    $filename = $_REQUEST["filename"];
+}
+
+$fullpath = "";
+if(array_key_exists("fullpath", $_REQUEST)) {
+    $fullpath = $_REQUEST["fullpath"];
+}
+
+$shop_karaoke = 0;
+if(array_key_exists("shop_karaoke", $_REQUEST)) {
+    $shop_karaoke = $_REQUEST["shop_karaoke"];
+}
+
+$set_directurl = 0;
+if(array_key_exists("set_directurl", $_REQUEST)) {
+    $set_directurl = $_REQUEST["set_directurl"];
+}
+
+$forcebgv = 0;
+if(array_key_exists("forcebgv", $_REQUEST)) {
+    $forcebgv = $_REQUEST["forcebgv"];
+}
+
+$selectid = 'none';
+if(array_key_exists("selectid", $_REQUEST)) {
+    $selectid = $_REQUEST["selectid"];
+    if(!is_numeric($selectid)){
+        $selectid = 'none';
+    }
+}
+
+if($shop_karaoke == 1 && is_numeric($selectid)){
+    $forcebgv = 1;
+}
+
+require_once 'commonfunc.php';
+require_once 'easyauth_class.php';
+$easyauth = new EasyAuth();
+$easyauth -> do_eashauthcheck();
+
+$sql = "SELECT * FROM requesttable ORDER BY reqorder DESC";
+$select = $db->query($sql);
+$allrequest = $select->fetchAll(PDO::FETCH_ASSOC);
+$select->closeCursor();
+
+$selectrequest = array();
+if(is_numeric($selectid)){
+    $stmt = $db->prepare("SELECT * FROM requesttable WHERE id = :id");
+    $stmt->bindValue(':id', (int)$selectid, PDO::PARAM_INT);
+    $stmt->execute();
+    $selectrequest = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->closeCursor();
+}
+
+
+function pickupsinger($rt, $moreuser = "")
+{
+   $singerlist = array();
+   if(!empty($moreuser)){
+       $singerlist[] = $moreuser;
+   }
+   foreach($rt as $row)
+   {
+       $foundflg = 0;
+       foreach($singerlist as $esinger ){
+           if( $esinger === $row['singer']){
+               $foundflg = 1;
+               break;
+           }
+       }
+       if($foundflg === 0){
+           $singerlist[] = $row['singer'];
+       }
+   }
+
+   return $singerlist;
+}
+
+function selectedcheck_request($rt,$singer,$beforesinger = 'none' ){
+    $rt_i = array_reverse($rt);
+
+    if($beforesinger == 'none'){
+      foreach($rt_i as $row){
+          if($row['singer'] === $singer){
+            if($row['clientip'] === $_SERVER["REMOTE_ADDR"] ) {
+              if($row['clientua'] === $_SERVER["HTTP_USER_AGENT"] ) {
+                return TRUE;
+              }
+            }
+          }
+      }
+    }else{
+        if($singer === $beforesinger){
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
+function json_safe_encode($data){
+    return json_encode($data, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
+}
+
+?>
+<!doctype html>
+<html lang="ja">
+<head>
+<?php print_meta_header(); ?>
+<link rel="stylesheet" href="css/bootstrap5/bootstrap.min.css">
+<script src="js/bootstrap5/bootstrap.bundle.min.js"></script>
+<script src="js/jquery.js"></script>
+<title>リクエスト確認画面</title>
+<link type="text/css" rel="stylesheet" href="css/style.css" />
+<script type="text/javascript">
+
+function check(selectf){
+flg=(document.getElementById('singer').selectedIndex==0);
+if (!flg) document.getElementById('freesinger').value='';
+document.getElementById('freesinger').parentNode.style.visibility=flg?'visible':'hidden';
+}
+
+
+window.onload = function(){
+document.getElementById("requestconfirm").onsubmit = function(){
+var newname = document.getElementById("freesinger").value;
+var existname = document.getElementById("singer").value;
+
+if (newname == "" && existname =="<?php print(urldecode($config_ini['nonameusername']));?>") {
+<?php
+if($config_ini['nonamerequest'] != 1){
+print 'alert("リクエスト者が空欄です。名前を入れてください\n(次からはドロップダウンで選べます)");';
+print 'return false;';
+}
+?>
+
+}
+}
+}
+
+</script>
+<?php
+$nanasyname = $config_ini["nonameusername"];
+?>
+<script id="nanasycheck" type="text/javascript" charset="utf8" src="js/requsetlist_confirm.js"
+     data-nanasy ='<?php echo json_safe_encode(urldecode($nanasyname)); ?>'
+     data-nanasyflg ='<?php echo json_safe_encode($config_ini['nonamerequest']); ?>'
+> </script>
+</head>
+<body>
+<?php
+$YkariUsername = "";
+if(array_key_exists("YkariUsername", $_COOKIE)) {
+    $YkariUsername = $_COOKIE["YkariUsername"];
+}
+?>
+<?php
+shownavigatioinbar_bs5();
+?>
+<div class="container py-3">
+<form method="post" action="exec.php" id="requestconfirm">
+<div class="mb-3">
+<label class="form-label">URL</label>
+<input type="text" name="fullpath" id="fullpath" class="form-control"
+    placeholder="直接再生できるURLを指定を入れてください(youtubeやニコニコ動画のURLもOK)"
+    value="<?php echo htmlspecialchars((string)$filename, ENT_QUOTES, 'UTF-8'); ?>" />
+</div>
+<div class="mb-3">
+<label class="form-label">曲名</label>
+<textarea name="filename" id="filename" class="form-control" rows="4" wrap="soft"
+    placeholder="後でセットリスト作成の参考のためにできれば曲名を入れておいてください"></textarea>
+</div>
+
+<div class="mb-3">
+<label class="form-label">リクエスト者</label>
+<select name="singer" onchange="check(this.form)" onfocus="check(this.form)" id="singer" class="form-select">
+<option value="<?php print(urldecode($config_ini['nonameusername']));?>">新規入力↓</option>
+<?php
+$beforesinger = 'none';
+if(is_numeric($selectid) && !empty($selectrequest)){
+  $beforesinger = $selectrequest[0]['singer'];
+}
+$selectedcounter = 0;
+$singerlist = pickupsinger($allrequest,$YkariUsername);
+foreach($singerlist as $singer){
+{
+  print "<option value=\"";
+  print htmlspecialchars((string)$singer, ENT_QUOTES, 'UTF-8');
+  print "\"";
+  if( selectedcheck_request($allrequest,$singer,$beforesinger) && $selectedcounter === 0 )
+  {
+      print " selected ";
+      $selectedcounter = $selectedcounter + 1 ;
+  }
+  print "> ";
+  print htmlspecialchars((string)$singer, ENT_QUOTES, 'UTF-8');
+  print "</option>";
+}
+}
+?>
+</select>
+<?php
+if($selectedcounter === 0){
+print('<span style="visibility:visible;">');
+}else{
+print('<span style="visibility:hidden;">');
+}
+?>
+<input type="text" name="freesinger" id="freesinger" class="form-control mt-2" placeholder="名前を書いてね。２回目からは上のドロップダウンから選べるようになります。" value="" >
+</span>
+</div>
+
+<div class="mb-3">
+<label class="form-label">コメント</label>
+<textarea name="comment" id="comment" class="form-control" rows="4" wrap="soft"
+    placeholder="<?php print htmlspecialchars((string)$requestcomment, ENT_QUOTES, 'UTF-8');?>" style="width:100%">
+<?php
+if(is_numeric($selectid) && !empty($selectrequest)){
+    print htmlspecialchars((string)$selectrequest[0]['comment'], ENT_QUOTES, 'UTF-8');
+    if($selectrequest[0]['kind'] == "カラオケ配信"){
+      print "\n";
+      print htmlspecialchars((string)$selectrequest[0]['songfile'], ENT_QUOTES, 'UTF-8');
+    }
+}
+?>
+</textarea>
+</div>
+
+<div class="mb-3">
+<dl>
+<dt>再生方法</dt>
+<dd>
+<?php
+  if(is_numeric($selectid) && !empty($selectrequest) && $selectrequest[0]['kind'] == "カラオケ配信"){
+      $esc_kind = htmlspecialchars((string)$selectrequest[0]['kind'], ENT_QUOTES, 'UTF-8');
+      print $esc_kind.'＋URL指定';
+      print '<input type="hidden" name="kind" id="kind"  value="'.$esc_kind.'＋URL指定" />'."\n";
+      $forcebgv = 1;
+  }else if($shop_karaoke == 1){
+      print 'カラオケ配信'."\n";
+      print '<input type="hidden" name="kind" id="kind"  value="カラオケ配信" />'."\n";
+  }else if($set_directurl == 1){
+      print 'URL指定'."\n";
+      print '<input type="hidden" name="kind" id="kind"  value="URL指定" />'."\n";
+  }else{
+      print 'ファイル再生(動画/音楽)'."\n";
+      print '<input type="hidden" name="kind" id="kind"  value="動画" />'."\n";
+  }
+?>
+</dd>
+</dl>
+<?php
+if(isset($config_ini['usekeychange']) && $config_ini['usekeychange'] == 1 ){
+    print <<<EOT
+<dl>
+<dt>キー変更</dt>
+<dd>
+<div class="btn-group flex-wrap" role="group" aria-label="キー変更">
+    <input type="radio" class="btn-check" name="keychange" id="key_m6" value="-6" autocomplete="off">
+    <label class="btn btn-secondary" for="key_m6">-6</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_m5" value="-5" autocomplete="off">
+    <label class="btn btn-secondary" for="key_m5">-5</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_m4" value="-4" autocomplete="off">
+    <label class="btn btn-secondary" for="key_m4">-4</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_m3" value="-3" autocomplete="off">
+    <label class="btn btn-secondary" for="key_m3">-3</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_m2" value="-2" autocomplete="off">
+    <label class="btn btn-secondary" for="key_m2">-2</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_m1" value="-1" autocomplete="off">
+    <label class="btn btn-secondary" for="key_m1">-1</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_0" value="0" autocomplete="off" checked>
+    <label class="btn btn-secondary" for="key_0">原曲</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_p1" value="1" autocomplete="off">
+    <label class="btn btn-secondary" for="key_p1">1</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_p2" value="2" autocomplete="off">
+    <label class="btn btn-secondary" for="key_p2">2</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_p3" value="3" autocomplete="off">
+    <label class="btn btn-secondary" for="key_p3">3</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_p4" value="4" autocomplete="off">
+    <label class="btn btn-secondary" for="key_p4">4</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_p5" value="5" autocomplete="off">
+    <label class="btn btn-secondary" for="key_p5">5</label>
+    <input type="radio" class="btn-check" name="keychange" id="key_p6" value="6" autocomplete="off">
+    <label class="btn btn-secondary" for="key_p6">6</label>
+</div>
+</dd>
+</dl>
+EOT;
+}
+?>
+</div>
+
+<div class="mb-2 form-check">
+<input type="checkbox" class="form-check-input" name="secret" value="1" id="chk_secret" />
+<label class="form-check-label" for="chk_secret">シークレット予約(歌うまで曲名を表示しません)</label>
+</div>
+<?php
+if($config_ini['usebgv'] == 1 ){
+print '<div class="mb-2 form-check">';
+print '<input type="checkbox" class="form-check-input" name="loop" value="1" id="chk_bgv" ';
+if($forcebgv == 1 ){
+    print 'checked';
+}
+print ' />';
+print '<label class="form-check-label" for="chk_bgv">BGVモード</label>';
+print '</div>';
+}
+if(is_numeric($selectid)){
+print '<input type="hidden" name="selectid" id="selectid"  value="'.(int)$selectid.'" />'."\n";
+print '<input type="hidden" name="urlreq" id="urlreq"  value="1" />'."\n";
+}
+?>
+<div class="row mt-3">
+<div class="col-12 col-sm-8">
+<input type="submit" value="実行" class="requestconfirm btn btn-primary btn-lg w-100" />
+</div>
+</div>
+
+</form>
+<div class="mt-3 d-flex gap-2">
+<button type="button" onclick="location.href='search.php'" class="btn btn-secondary">
+通常検索に戻る
+</button>
+
+<button type="button" onclick="location.href='requestlist_top.php'" class="btn btn-secondary">
+トップに戻る
+</button>
+</div>
+</div>
+</body>
+</html>

--- a/search_listerdb_filelist_bs5.php
+++ b/search_listerdb_filelist_bs5.php
@@ -147,7 +147,7 @@ function fmt_date_bs5($jd) {
 
 function create_requestconfirmlink_bs5($songinfo, $linkoption) {
     $fp = $songinfo['found_path'];
-    return 'request_confirm.php?filename=' . urlencode(basename_jp($fp)) . '&fullpath=' . urlencode($fp) . $linkoption;
+    return 'request_confirm_bs5.php?filename=' . urlencode(basename_jp($fp)) . '&fullpath=' . urlencode($fp) . $linkoption;
 }
 
 function filelistfromsong_bs5($filelist, $linkoption, $listerpreviewportenable) {


### PR DESCRIPTION
$(cat <<'EOF'
## 概要

- `request_confirm_bs5.php` / `request_confirm_url_bs5.php` を新規作成（Bootstrap 5対応版）
- BS5検索画面・ナビバーのリンクを BS5版に更新
- 既存バグ修正・動画詳細情報の拡充

---

## 変更内容

### 新規ファイル

- **`request_confirm_bs5.php`** — リクエスト確認画面のBS5版
- **`request_confirm_url_bs5.php`** — URL指定リクエスト確認画面のBS5版

主なBS5対応内容:
- Bootstrap 5 CSS/JS (`css/bootstrap5/`, `js/bootstrap5/`)
- `print_meta_header()` / `shownavigatioinbar_bs5()` を使用
- `form-group` → `mb-3`、`form-control`(select) → `form-select`
- `col-xs-*` → `col-*`、`btn-xs` → `btn-sm`
- `data-toggle`/`data-target` → `data-bs-toggle`/`data-bs-target`
- `panel` → `card`、`dl-horizontal` → `dl row`
- `checkbox` div → `form-check`、`well` → `alert alert-info`
- キー変更ラジオ: `btn-check` + `label.btn` パターン
- ボタン: `btn-default` → `btn-secondary` / `btn-primary`（背景透明を解消）
- `css/themes/_variables.css` とテーマ初期化スクリプト追加（ダークモード対応）

### リンク更新（`commonfunc.php`・`search_listerdb_filelist_bs5.php`）

BS5関数内のリンクを新BS5版に変更:

| 関数 | 変更 |
|---|---|
| `build_reservation_tabs()` | `request_confirm.php` → `request_confirm_bs5.php` |
| `build_reservation_tabs()` | `request_confirm_url.php` → `request_confirm_url_bs5.php` |
| `selectrequestkind_bs5_dd()` | 同上 |
| `create_requestconfirmlink_bs5()` | `request_confirm.php` → `request_confirm_bs5.php` |

旧 `shownavigatioinbar()` 内のリンクは旧版ページ向けとして据え置き。

### バグ修正（`func_audiotracklist.php`）

`checktracktype()` のトラック名取得ロジックを修正:

- **バグ1（主因）**: audio check ブロック内で `$trackname` を `mdia/hdlr/component_name` で無条件上書きしており、`udta/name` から取得した値が常に捨てられていた
- **バグ2（副因）**: `hdlr` アトムをインデックス `[1]` のハードコードで参照していたため、アトム順序が異なるファイルで誤動作する恐れがあった → `array_search_key()` で名前検索するよう修正

### 動画詳細情報の拡充（`func_audiotracklist.php`・`request_confirm_bs5.php`）

`getvideodetails()` に以下を追加:

- 解像度（例: `1920x1080`）
- 映像コーデック（例: `H.264`）
- 音声コーデック / チャンネル数 / サンプルレート（例: `AAC / ステレオ / 48,000 Hz`）
- 総ビットレート（例: `8,500 kbps`）

## テスト項目

- [ ] `request_confirm_bs5.php` — ファイル検索からリクエスト確認画面に遷移できる
- [ ] `request_confirm_bs5.php` — キー変更・音ズレ・音量調整が動作する
- [ ] `request_confirm_bs5.php` — 動画詳細情報（解像度・コーデック等）が表示される
- [ ] `request_confirm_url_bs5.php` — URL指定リクエストが送信できる
- [ ] ナビバー「いろいろ予約」ドロップダウンのリンクが BS5版に遷移する
- [ ] `searchreserve_bs5.php` のタブ（カラオケ配信・小休止・URL指定）が BS5版に遷移する
- [ ] ダークモード切り替えが正常に動作する
- [ ] トラック選択に `udta/name` のトラック名が表示される（バグ修正確認）

https://claude.ai/code/session_01AkL8D7zr7yDpJb6UX3f66t
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkL8D7zr7yDpJb6UX3f66t)_