### PR TITLE
Fix pfwd_settings.php form submission issues

### DIFF
--- a/autoplayctrl.php
+++ b/autoplayctrl.php
@@ -102,19 +102,20 @@ if (isset($_GET['action']) && $_GET['action'] === 'check_online_debug') {
         ? "OK HTTP {$code} (接続先IP: {$ip})"
         : "NG curl({$en}): {$es2}";
 
-    // 8. ping パケットロス率 (Windows 環境、日本語ロケール対応)
-    $ping_cmd = 'ping -n 4 -w ' . ($timeout * 1000) . ' ' . escapeshellarg($h_host);
+    // 8. ping パケットロス率 (Windows 環境)
+    // ロケールを英語に設定して ping を実行（出力を統一）
+    $timeout_ms = $timeout * 1000;
+    $ping_cmd = "cmd /c \"chcp 437 >nul && ping -n 4 -w {$timeout_ms} {$h_host}\"";
     @exec($ping_cmd, $ping_output);
     $ping_output_str = implode("\n", $ping_output);
-    // 送受信パケット数から計算（ロケール非依存）
-    // 英語: "Sent = 4, Received = 3"  日本語: "送信 = 4、受信 = 3"
-    if (preg_match('/(?:Sent|送信)\s*=\s*(\d+).*(?:Received|受信)\s*=\s*(\d+)/', $ping_output_str, $m)) {
+    // 英語出力: "Packets: Sent = 4, Received = 3, Lost = 1 (25% loss)"
+    if (preg_match('/Sent\s*=\s*(\d+).*Received\s*=\s*(\d+)/', $ping_output_str, $m)) {
         $sent = (int)$m[1];
         $recv = (int)$m[2];
         $loss = $sent > 0 ? (int)(($sent - $recv) / $sent * 100) : 100;
         $results['ping_loss'] = "Loss {$loss}% ({$sent}回送信)";
     } else {
-        $results['ping_loss'] = "実行失敗 (パース不可)";
+        $results['ping_loss'] = "実行失敗";
     }
 
     echo json_encode(['host' => $host_raw, 'timeout' => $timeout, 'results' => $results]);

--- a/autoplayctrl.php
+++ b/autoplayctrl.php
@@ -1,10 +1,47 @@
 <?php
 require_once 'commonfunc.php';
 
-// --- AJAX: オンライン接続確認（診断情報付き） ---
+// --- pfwd 情報を先行初期化（AJAX ハンドラでも使用するため） ---
+require_once 'pfwdctl.php';
+$pfwdavailable = false;
+$pfwdinfo = new pfwd();
+if (array_key_exists('pfwdplace', $config_ini) && !empty($config_ini['pfwdplace'])) {
+    $pfwdinfo->pfwdpath = urldecode($config_ini['pfwdplace']);
+    ob_start();
+    $pfwdavailable = $pfwdinfo->readpfwdcfg();
+    ob_end_clean();
+}
+
+// --- AJAX: オンライン接続確認 ---
 if (isset($_GET['action']) && $_GET['action'] === 'check_online') {
     header('Content-Type: application/json; charset=utf-8');
 
+    $timeout = (int)(array_key_exists('onlinechecktimeout', $config_ini) ? $config_ini['onlinechecktimeout'] : 5);
+    if ($timeout < 5) $timeout = 5;
+
+    // pfwd 起動中: HTTP ループバックを避け SSH サーバーへの TCP 接続で確認
+    // （pfwd の逆トンネルを介して HTTP チェックすると同一 Apache に折り返しデッドロックになる）
+    $pfwd_running_req = isset($_GET['pfwd_running']) && $_GET['pfwd_running'] === '1';
+    if ($pfwd_running_req && $pfwdavailable) {
+        $ssh_host  = $pfwdinfo->get_pfwdhost();
+        $ssh_port  = (int)$pfwdinfo->get_pfwdport();
+        $check_url = "tcp://{$ssh_host}:{$ssh_port}";
+        if ($ssh_host && $ssh_port) {
+            $fp = @fsockopen($ssh_host, $ssh_port, $sock_errno, $sock_errstr, $timeout);
+            if ($fp) {
+                fclose($fp);
+                $status = 'ok';
+                $detail = "SSH({$ssh_host}:{$ssh_port}) 到達OK (timeout:{$timeout}s)";
+            } else {
+                $status = 'ng';
+                $detail = "({$sock_errno}): {$sock_errstr} (timeout:{$timeout}s)";
+            }
+            echo json_encode(['status' => $status, 'host' => $ssh_host, 'check_url' => $check_url, 'detail' => $detail]);
+            exit;
+        }
+    }
+
+    // 通常の HTTP チェック（pfwd 停止中）
     $internet_enabled = array_key_exists('connectinternet', $config_ini) && $config_ini['connectinternet'] == 1;
     $host_configured  = array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhost']);
 
@@ -21,12 +58,8 @@ if (isset($_GET['action']) && $_GET['action'] === 'check_online') {
 
     $host      = urldecode($config_ini['globalhost']);
     $check_url = 'http://' . $host;
-    $timeout   = (int)(array_key_exists('onlinechecktimeout', $config_ini) ? $config_ini['onlinechecktimeout'] : 5);
-    if ($timeout < 5) $timeout = 5; // SSH 逆トンネル往復を考慮し最低 5 秒確保
 
-    // curl で接続確認（エラー詳細を取得するため直接実行）
-    // FOLLOWLOCATION=false: リダイレクト応答(3xx)が返った時点で到達確認済みとする。
-    //   リダイレクトを辿ると easyauth 等でループしタイムアウトになる場合があるため。
+    // FOLLOWLOCATION=false: 3xx レスポンスが返った時点で到達確認済みとする
     $ch = curl_init($check_url);
     curl_setopt($ch, CURLOPT_HEADER, false);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -36,13 +69,12 @@ if (isset($_GET['action']) && $_GET['action'] === 'check_online') {
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
     curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
     curl_setopt($ch, CURLOPT_USERAGENT, 'KaraokeRequestor/1.0');
-    $curl_result  = curl_exec($ch);
-    $curl_errno   = curl_errno($ch);
-    $curl_error   = curl_strerror($curl_errno);
-    $http_code    = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_exec($ch);
+    $curl_errno = curl_errno($ch);
+    $curl_error = curl_strerror($curl_errno);
+    $http_code  = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
 
-    // 何らかの HTTP レスポンスが返れば（3xx/4xx/5xx 含む）到達成功と判定
     if ($http_code > 0) {
         $status = 'ok';
         $detail = "HTTP {$http_code} (timeout:{$timeout}s)";
@@ -51,12 +83,7 @@ if (isset($_GET['action']) && $_GET['action'] === 'check_online') {
         $detail = "curl({$curl_errno}): {$curl_error} (timeout:{$timeout}s)";
     }
 
-    echo json_encode([
-        'status'    => $status,
-        'host'      => $host,
-        'check_url' => $check_url,
-        'detail'    => $detail,
-    ]);
+    echo json_encode(['status' => $status, 'host' => $host, 'check_url' => $check_url, 'detail' => $detail]);
     exit;
 }
 
@@ -117,21 +144,10 @@ if ($l_karaokeautorunaction === 'stop') {
     stopautoplaywithcheck();
 }
 
-// --- pfwd 情報取得 ---
-require_once 'pfwdctl.php';
-$pfwdavailable = false;
-$pfwdinfo = new pfwd();
-if (array_key_exists('pfwdplace', $config_ini) && !empty($config_ini['pfwdplace'])) {
-    $pfwdinfo->pfwdpath = urldecode($config_ini['pfwdplace']);
-    ob_start();
-    $pfwdavailable = $pfwdinfo->readpfwdcfg();
-    ob_end_clean();
-}
-$pfwd_running = $pfwdavailable ? $pfwdinfo->statpfwdcmd() : false;
-
 // --- ステータス取得 ---
-$ap         = checkautoplay();
-$wg_running = check_wireguard_running();
+$pfwd_running = $pfwdavailable ? $pfwdinfo->statpfwdcmd() : false;
+$ap           = checkautoplay();
+$wg_running   = check_wireguard_running();
 
 $globalhost_display = '';
 if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhost'])) {
@@ -200,13 +216,7 @@ if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhos
           <span id="online-status" class="badge bg-secondary">確認中...</span>
           <button type="button" class="btn btn-sm btn-outline-secondary ms-auto text-nowrap" id="check-online-btn">再確認</button>
         </div>
-        <div id="online-detail" class="small text-muted" style="word-break:break-all;">
-          <?php if (!empty($globalhost_display)): ?>
-            確認先: http://<?= htmlspecialchars($globalhost_display) ?>
-          <?php else: ?>
-            &nbsp;
-          <?php endif; ?>
-        </div>
+        <div id="online-detail" class="small text-muted" style="word-break:break-all;">&nbsp;</div>
       </div>
 
       <!-- WireGuard トンネル確認 -->
@@ -228,15 +238,15 @@ if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhos
     <div class="card-header fw-bold">pfwd (SSH転送)</div>
     <div class="card-body">
 
-      <!-- オンライン接続中の危険警告（pfwd起動中） -->
-      <div id="pfwd-danger-alert" class="alert alert-danger py-2 d-none" role="alert">
-        <strong>⚠ 警告:</strong> オンライン接続中（WireGuard）にもかかわらずpfwdが起動しています。<br>
-        pfwdはオフライン時のみ使用してください。直ちに停止してください。
+      <!-- WireGuard 実行中かつ pfwd も起動中: 危険警告 -->
+      <div id="pfwd-danger-alert" class="alert alert-danger py-2 <?= ($wg_running && $pfwd_running) ? '' : 'd-none' ?>" role="alert">
+        <strong>⚠ 警告:</strong> WireGuard 接続中にもかかわらず pfwd が起動しています。<br>
+        pfwd は WireGuard オフ時のみ使用してください。直ちに停止してください。
       </div>
 
-      <!-- オンライン接続中の注意（pfwd停止中） -->
-      <div id="pfwd-online-alert" class="alert alert-warning py-2 d-none" role="alert">
-        オンライン接続中（WireGuard）です。pfwdは起動しないでください。
+      <!-- WireGuard 実行中かつ pfwd 停止中: 注意 -->
+      <div id="pfwd-online-alert" class="alert alert-warning py-2 <?= ($wg_running && !$pfwd_running) ? '' : 'd-none' ?>" role="alert">
+        WireGuard 接続中です。pfwd は起動しないでください。
       </div>
 
       <p class="mb-3">
@@ -246,7 +256,8 @@ if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhos
         </span>
       </p>
       <div class="d-flex gap-2">
-        <button type="button" id="pfwd-start-btn" class="btn btn-success" onclick="start_pfwdcmd()">起動</button>
+        <button type="button" id="pfwd-start-btn" class="btn btn-success"
+          <?= $wg_running ? 'disabled' : '' ?> onclick="start_pfwdcmd()">起動</button>
         <button type="button" class="btn btn-danger" onclick="stop_pfwdcmd()">停止</button>
       </div>
     </div>
@@ -265,18 +276,15 @@ if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhos
 <?php print_bg_style_block(true); ?>
 
 <script>
-// PHP側のpfwd起動状態をJSに渡す
 var pfwdRunning = <?= $pfwdavailable && $pfwd_running ? 'true' : 'false' ?>;
-// オンライン接続状態（checkOnline()完了後に更新）
-var onlineConnected = false;
+var wgRunning   = <?= $wg_running ? 'true' : 'false' ?>;
 
-function applyPfwdOnlineRestriction(isOnline, pfwdIsRunning) {
+function applyPfwdRestriction(pfwdIsRunning) {
     var startBtn    = document.getElementById('pfwd-start-btn');
     var dangerAlert = document.getElementById('pfwd-danger-alert');
     var onlineAlert = document.getElementById('pfwd-online-alert');
     if (!startBtn) return;
-
-    if (isOnline) {
+    if (wgRunning) {
         startBtn.disabled = true;
         if (pfwdIsRunning) {
             if (dangerAlert) dangerAlert.classList.remove('d-none');
@@ -303,7 +311,7 @@ function updatePfwdStatus(data) {
         el.textContent = '停止中';
         el.className = 'badge fs-6 bg-secondary';
     }
-    applyPfwdOnlineRestriction(onlineConnected, pfwdRunning);
+    applyPfwdRestriction(pfwdRunning);
 }
 
 function start_pfwdcmd() {
@@ -321,39 +329,34 @@ function stop_pfwdcmd() {
 }
 
 function checkOnline() {
-    var el     = document.getElementById('online-status');
+    var el       = document.getElementById('online-status');
     var detailEl = document.getElementById('online-detail');
     if (!el) return;
     el.textContent = '確認中...';
     el.className = 'badge bg-secondary';
     if (detailEl) detailEl.textContent = '確認中...';
-    fetch('autoplayctrl.php?action=check_online')
+    // pfwd 起動中を渡すことで PHP 側が SSH TCP チェックに切り替える
+    fetch('autoplayctrl.php?action=check_online&pfwd_running=' + (pfwdRunning ? '1' : '0'))
         .then(function(r) { return r.json(); })
         .then(function(data) {
-            var urlText = data.check_url ? '確認先: ' + data.check_url : '';
+            var urlText    = data.check_url ? '確認先: ' + data.check_url : '';
             var detailText = data.detail || '';
+            var infoText   = urlText + (detailText ? '  [' + detailText + ']' : '');
             if (data.status === 'ok') {
                 el.textContent = 'OK';
                 el.className = 'badge bg-success';
-                onlineConnected = true;
-                if (detailEl) detailEl.textContent = urlText + (detailText ? '  [' + detailText + ']' : '');
             } else if (data.status === 'ng') {
                 el.textContent = 'NG';
                 el.className = 'badge bg-danger';
-                onlineConnected = false;
-                if (detailEl) detailEl.textContent = urlText + (detailText ? '  [' + detailText + ']' : '');
             } else {
                 el.textContent = '無効';
                 el.className = 'badge bg-secondary';
-                onlineConnected = false;
-                if (detailEl) detailEl.textContent = detailText || urlText;
             }
-            applyPfwdOnlineRestriction(onlineConnected, pfwdRunning);
+            if (detailEl) detailEl.textContent = infoText || detailText;
         })
         .catch(function() {
             el.textContent = 'エラー';
             el.className = 'badge bg-danger';
-            onlineConnected = false;
             if (detailEl) detailEl.textContent = 'AJAX通信エラー';
         });
 }

--- a/autoplayctrl.php
+++ b/autoplayctrl.php
@@ -316,15 +316,9 @@ if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhos
     <div class="card-header fw-bold">pfwd (SSH転送)</div>
     <div class="card-body">
 
-      <!-- WireGuard 実行中かつ pfwd も起動中: 危険警告 -->
-      <div id="pfwd-danger-alert" class="alert alert-danger py-2 <?= ($wg_running && $pfwd_running) ? '' : 'd-none' ?>" role="alert">
-        <strong>⚠ 警告:</strong> WireGuard 接続中にもかかわらず pfwd が起動しています。<br>
-        pfwd は WireGuard オフ時のみ使用してください。直ちに停止してください。
-      </div>
-
-      <!-- WireGuard 実行中かつ pfwd 停止中: 注意 -->
+      <!-- WireGuard 実行中かつ pfwd 停止中: 注意（pfwd が接続元でない可能性） -->
       <div id="pfwd-online-alert" class="alert alert-warning py-2 <?= ($wg_running && !$pfwd_running) ? '' : 'd-none' ?>" role="alert">
-        WireGuard 接続中です。pfwd は起動しないでください。
+        WireGuard 実行中です。オンライン接続が確立されているため pfwd は起動しないでください。
       </div>
 
       <p class="mb-3">
@@ -335,7 +329,7 @@ if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhos
       </p>
       <div class="d-flex gap-2">
         <button type="button" id="pfwd-start-btn" class="btn btn-success"
-          <?= $wg_running ? 'disabled' : '' ?> onclick="start_pfwdcmd()">起動</button>
+          <?= ($wg_running && !$pfwd_running) ? 'disabled' : '' ?> onclick="start_pfwdcmd()">起動</button>
         <button type="button" class="btn btn-danger" onclick="stop_pfwdcmd()">停止</button>
       </div>
     </div>
@@ -359,21 +353,15 @@ var wgRunning   = <?= $wg_running ? 'true' : 'false' ?>;
 
 function applyPfwdRestriction(pfwdIsRunning) {
     var startBtn    = document.getElementById('pfwd-start-btn');
-    var dangerAlert = document.getElementById('pfwd-danger-alert');
     var onlineAlert = document.getElementById('pfwd-online-alert');
     if (!startBtn) return;
-    if (wgRunning) {
+    if (wgRunning && !pfwdIsRunning) {
+        // WireGuard 実行中で pfwd 未起動 → オンライン接続済みなので pfwd 起動禁止
         startBtn.disabled = true;
-        if (pfwdIsRunning) {
-            if (dangerAlert) dangerAlert.classList.remove('d-none');
-            if (onlineAlert) onlineAlert.classList.add('d-none');
-        } else {
-            if (dangerAlert) dangerAlert.classList.add('d-none');
-            if (onlineAlert) onlineAlert.classList.remove('d-none');
-        }
+        if (onlineAlert) onlineAlert.classList.remove('d-none');
     } else {
+        // pfwd 起動中 (pfwd が接続元) または WireGuard 未実行 → 制限なし
         startBtn.disabled = false;
-        if (dangerAlert) dangerAlert.classList.add('d-none');
         if (onlineAlert) onlineAlert.classList.add('d-none');
     }
 }

--- a/autoplayctrl.php
+++ b/autoplayctrl.php
@@ -1,219 +1,267 @@
 <?php
-
 require_once 'commonfunc.php';
 
+// --- AJAX: オンライン接続確認 ---
+if (isset($_GET['action']) && $_GET['action'] === 'check_online') {
+    header('Content-Type: application/json; charset=utf-8');
+    $status = 'disabled';
+    $host   = '';
+    if (
+        array_key_exists('connectinternet', $config_ini) && $config_ini['connectinternet'] == 1 &&
+        array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhost'])
+    ) {
+        $host    = urldecode($config_ini['globalhost']);
+        $timeout = (int)(array_key_exists('onlinechecktimeout', $config_ini) ? $config_ini['onlinechecktimeout'] : 2);
+        $ret     = check_online_available($config_ini['globalhost'], $timeout);
+        $status  = ($ret === 'OK') ? 'ok' : 'ng';
+    }
+    echo json_encode(['status' => $status, 'host' => $host]);
+    exit;
+}
+
+// --- 自動再生制御関数 ---
 function stopautoplay()
 {
-    $execcmd='taskkill /FI "WINDOWTITLE eq karaokeautorun*"';
-    exec($execcmd);
+    exec('taskkill /FI "WINDOWTITLE eq karaokeautorun*"');
 }
 
 function startautoplay()
 {
-    $result=checkautoplay();	//★
-    if($result == 0 ){	//★ 多重起動防止
+    if (checkautoplay() == 0) {
         global $config_ini;
-        $execcmd='start "karaokeautorun" '.urldecode($config_ini["autoplay_exec"]);
-        echo $execcmd;
+        $execcmd = 'start "karaokeautorun" ' . urldecode($config_ini['autoplay_exec']);
         exec($execcmd);
-    }	//★
+    }
 }
 
 function checkautoplay()
 {
-  $pscheck_cmd='tasklist /FI "WINDOWTITLE eq karaokeautorun*" | find /c ".exe"';
-  exec($pscheck_cmd, $psresult );
-  return $psresult[0];
+    exec('tasklist /FI "WINDOWTITLE eq karaokeautorun*" | find /c ".exe"', $psresult);
+    return (int)($psresult[0] ?? 0);
 }
 
 function stopautoplaywithcheck()
 {
-    $result=checkautoplay();
-    if($result != 0 ){
+    if (checkautoplay() != 0) {
         stopautoplay();
     }
 }
 
-$l_karaokeautorunaction = 'none';
-if(array_key_exists("karaokeautorunaction", $_REQUEST)) {
-    $l_karaokeautorunaction = $_REQUEST["karaokeautorunaction"];
-}
-
-$l_nextpage = null;
-if(array_key_exists("nextpage", $_REQUEST)) {
-    $l_nextpage = $_REQUEST["nextpage"];
-}
-
-?>
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<?php 
-if(!empty($l_nextpage)){
-    print '<META http-equiv="refresh" content="1; url='.$l_nextpage.'">'."\n";
-    }
-?>
-<?php 
-print_meta_header();
-?>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <!-- Bootstrap -->
-    <link href="css/bootstrap.min.css" rel="stylesheet">
-
-
-    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
-<link type="text/css" rel="stylesheet" href="css/style.css" />
-<script type="text/javascript" charset="utf8" src="js/jquery.js"></script>
-<script src="js/bootstrap.min.js"></script>
-    
-<title>自動起動プログラム制御</title>
-</head>
-<body>
-<?php
-shownavigatioinbar();
-?>
-<script type="text/javascript">
-function createXMLHttpRequest() {
-  if (window.XMLHttpRequest) {
-    return new XMLHttpRequest();
-  } else if (window.ActiveXObject) {
-    try {
-      return new ActiveXObject("Msxml2.XMLHTTP");
-    } catch (e) {
-      try {
-        return new ActiveXObject("Microsoft.XMLHTTP");
-      } catch (e2) {
-        return null;
-      }
-    }
-  } else {
-    return null;
-  }
-}
-
-function start_pfwdcmd(){
-var request = createXMLHttpRequest();
-url="pfwd_exec.php?pfwdstart=1";
-request.open("GET", url, true);
-request.onreadystatechange = function() {
-    if(request.readyState == 4) {
-        if (request.status === 200) {
-            var request2 = createXMLHttpRequest();
-            request2.open("GET", "pfwdstat.php", false);
-            request2.send(null);
-            var statvalue = JSON.parse(request2.responseText);
-            pfwdstat=document.getElementById("pfwdstatus");
-            if(statvalue.pfwdstat){
-                pfwdstat.innerHTML = "起動中";
-                pfwdstat.className = 'bg-success';
-            }else {
-                pfwdstat.innerHTML = "停止中";
-                pfwdstat.className = 'alert-danger';
-            }
+// --- WireGuard 確認 ---
+function check_wireguard_running()
+{
+    exec('tasklist /fi "imagename eq wireguard.exe" 2>nul', $result);
+    foreach ($result as $line) {
+        if (stripos($line, 'wireguard.exe') !== false) {
+            return true;
         }
     }
-}
-request.send("");
-}
-
-function stop_pfwdcmd(){
-var request = createXMLHttpRequest();
-url="pfwd_exec.php?pfwdstop=1";
-request.open("GET", url, true);
-request.onreadystatechange = function() {
-    if(request.readyState == 4) {
-        if (request.status === 200) {
-            var request2 = createXMLHttpRequest();
-            request2.open("GET", "pfwdstat.php", false);
-            request2.send(null);
-            var statvalue = JSON.parse(request2.responseText);
-            pfwdstat=document.getElementById("pfwdstatus");
-            if(statvalue.pfwdstat){
-                pfwdstat.innerHTML = "起動中";
-                pfwdstat.className = 'bg-success';
-            }else {
-                pfwdstat.innerHTML = "停止中";
-                pfwdstat.className = 'alert-danger';
-            }
-        }
-    }
-}
-request.send("");
+    return false;
 }
 
-</script>
-<?php
+// --- アクション処理 ---
+$l_karaokeautorunaction = $_REQUEST['karaokeautorunaction'] ?? 'none';
+$l_nextpage = $_REQUEST['nextpage'] ?? null;
 
-if($l_karaokeautorunaction == 'start'){
+if ($l_karaokeautorunaction === 'start') {
     $org_timeout = ini_get('default_socket_timeout');
     ini_set('default_socket_timeout', 3);
     @file_get_contents('http://localhost/autoplayctrl.php?karaokeautorunaction=start_exec');
     ini_set('default_socket_timeout', $org_timeout);
-    
 }
-if($l_karaokeautorunaction == 'start_exec'){
+if ($l_karaokeautorunaction === 'start_exec') {
     startautoplay();
 }
-if($l_karaokeautorunaction == 'stop'){
+if ($l_karaokeautorunaction === 'stop') {
     stopautoplaywithcheck();
 }
 
+// --- pfwd 情報取得 ---
 require_once 'pfwdctl.php';
-$pfwdavailable = true;
+$pfwdavailable = false;
 $pfwdinfo = new pfwd();
-$pfwdinfo->pfwdpath = urldecode($config_ini["pfwdplace"]);
-$pfwdavailable = $pfwdinfo->readpfwdcfg();
-
-$ap = checkautoplay();
-//var_dump ($ap);
-print '<div id="autoplaystatus ">';
-if($ap == 0){
-    print '自動再生停止中';
-}else{
-    print '自動再生実行中';
+if (array_key_exists('pfwdplace', $config_ini) && !empty($config_ini['pfwdplace'])) {
+    $pfwdinfo->pfwdpath = urldecode($config_ini['pfwdplace']);
+    ob_start();
+    $pfwdavailable = $pfwdinfo->readpfwdcfg();
+    ob_end_clean();
 }
-print '</div>';
+$pfwd_running = $pfwdavailable ? $pfwdinfo->statpfwdcmd() : false;
 
+// --- ステータス取得 ---
+$ap         = checkautoplay();
+$wg_running = check_wireguard_running();
+
+$globalhost_display = '';
+if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhost'])) {
+    $globalhost_display = urldecode($config_ini['globalhost']);
+}
 ?>
+<!doctype html>
+<html lang="ja">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<?php if (!empty($l_nextpage)): ?>
+<meta http-equiv="refresh" content="1; url=<?= htmlspecialchars($l_nextpage, ENT_QUOTES, 'UTF-8') ?>">
+<?php endif; ?>
+<title>自動起動プログラム制御</title>
+<script>(function(){if(window.__ykThemeInit)return;window.__ykThemeInit=true;try{var t=localStorage.getItem("ykari-theme")||"light",f=localStorage.getItem("ykari-fontsize")||"normal";document.documentElement.setAttribute("data-theme",t);document.documentElement.setAttribute("data-fontsize",f);}catch(e){}})();</script>
+<link rel="stylesheet" href="css/bootstrap5/bootstrap.min.css">
+<link rel="stylesheet" href="css/themes/_variables.css">
+<link rel="stylesheet" href="css/themes/theme-toggle.css">
+<link rel="stylesheet" href="css/themes/player.css">
+<script src="js/jquery.js"></script>
+<script src="js/bootstrap5/bootstrap.bundle.min.js"></script>
+<script src="js/theme-toggle.js"></script>
+</head>
+<body>
+<?php shownavigatioinbar_bs5('playerctrl_portal_bs5.php'); ?>
 
-<form method="GET" >
-<input type="hidden" name="karaokeautorunaction" id="karaokeautorunaction"  value="start" />
-<input type="submit" value="Start" class="requestconfirm btn btn-default btn-lg"/>
-</form>
+<div class="container" style="max-width:540px; padding-bottom:32px;">
 
-<form method="GET" >
-<input type="hidden" name="karaokeautorunaction" id="karaokeautorunaction"  value="stop" />
-<input type="submit" value="Stop" class="requestconfirm btn btn-default btn-lg"/>
-</form>
+  <h5 class="mb-3">自動起動プログラム制御</h5>
 
-<?php
-if($pfwdavailable){
-print <<<EOT
-  <div class="form-group">
-      <label class="control-label" >pfwdプログラム起動停止</label>
-      <button type="button" class="btn btn-default" onClick="start_pfwdcmd()" >起動</button>
-      <button type="button" class="btn btn-default" onClick="stop_pfwdcmd()" >停止</button>
-EOT;
-          if($pfwdavailable == false){
-              print '<span class="alert-danger" id="pfwdstatus" > 利用不可</span>';
-          }
-          else if($pfwdinfo->statpfwdcmd()){
-              print '<span class="bg-success" id="pfwdstatus" > 起動中</span>';
-          } else {
-              print '<span class="alert-danger" id="pfwdstatus" >停止中</span>';
-          }
-      
-print <<<EOT
+  <!-- 自動再生コントロール -->
+  <div class="card mb-3">
+    <div class="card-header fw-bold">自動再生コントロール</div>
+    <div class="card-body">
+      <p class="mb-3">
+        ステータス：
+        <?php if ($ap != 0): ?>
+          <span class="badge bg-success fs-6">実行中</span>
+        <?php else: ?>
+          <span class="badge bg-secondary fs-6">停止中</span>
+        <?php endif; ?>
+      </p>
+      <div class="d-flex gap-2">
+        <form method="GET">
+          <input type="hidden" name="karaokeautorunaction" value="start">
+          <button type="submit" class="btn btn-success">▶ Start</button>
+        </form>
+        <form method="GET">
+          <input type="hidden" name="karaokeautorunaction" value="stop">
+          <button type="submit" class="btn btn-danger">■ Stop</button>
+        </form>
+      </div>
+    </div>
   </div>
-EOT;
+
+  <!-- 接続ステータス -->
+  <div class="card mb-3">
+    <div class="card-header fw-bold">接続ステータス</div>
+    <div class="card-body">
+
+      <!-- オンライン接続確認 -->
+      <div class="mb-3">
+        <div class="d-flex align-items-center gap-2 flex-wrap">
+          <span class="text-nowrap">オンライン接続:</span>
+          <span id="online-status" class="badge bg-secondary">確認中...</span>
+          <?php if (!empty($globalhost_display)): ?>
+            <small class="text-muted"><?= htmlspecialchars($globalhost_display) ?></small>
+          <?php endif; ?>
+          <button type="button" class="btn btn-sm btn-outline-secondary ms-auto text-nowrap" id="check-online-btn">再確認</button>
+        </div>
+      </div>
+
+      <!-- WireGuard トンネル確認 -->
+      <div class="d-flex align-items-center gap-2">
+        <span class="text-nowrap">WireGuard:</span>
+        <?php if ($wg_running): ?>
+          <span class="badge bg-success">実行中</span>
+        <?php else: ?>
+          <span class="badge bg-secondary">停止中</span>
+        <?php endif; ?>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- pfwd (SSH転送) -->
+  <?php if ($pfwdavailable): ?>
+  <div class="card mb-3">
+    <div class="card-header fw-bold">pfwd (SSH転送)</div>
+    <div class="card-body">
+      <p class="mb-3">
+        ステータス：
+        <span id="pfwdstatus" class="badge fs-6 <?= $pfwd_running ? 'bg-success' : 'bg-secondary' ?>">
+          <?= $pfwd_running ? '起動中' : '停止中' ?>
+        </span>
+      </p>
+      <div class="d-flex gap-2">
+        <button type="button" class="btn btn-success" onclick="start_pfwdcmd()">起動</button>
+        <button type="button" class="btn btn-danger" onclick="stop_pfwdcmd()">停止</button>
+      </div>
+    </div>
+  </div>
+  <?php endif; ?>
+
+  <!-- プレイヤーへ戻る -->
+  <div class="d-grid mt-2">
+    <a href="playerctrl_portal_bs5.php" class="btn btn-outline-secondary btn-sm player-refresh-btn">
+      プレイヤーコントローラーへ戻る
+    </a>
+  </div>
+
+</div><!-- /container -->
+
+<?php print_bg_style_block(true); ?>
+
+<script>
+function updatePfwdStatus(data) {
+    var el = document.getElementById('pfwdstatus');
+    if (!el) return;
+    if (data.pfwdstat) {
+        el.textContent = '起動中';
+        el.className = 'badge fs-6 bg-success';
+    } else {
+        el.textContent = '停止中';
+        el.className = 'badge fs-6 bg-secondary';
+    }
 }
-?>
+
+function start_pfwdcmd() {
+    fetch('pfwd_exec.php?pfwdstart=1')
+        .then(function(r) { return r.ok ? fetch('pfwdstat.php') : null; })
+        .then(function(r) { return r ? r.json() : null; })
+        .then(function(data) { if (data) updatePfwdStatus(data); });
+}
+
+function stop_pfwdcmd() {
+    fetch('pfwd_exec.php?pfwdstop=1')
+        .then(function(r) { return r.ok ? fetch('pfwdstat.php') : null; })
+        .then(function(r) { return r ? r.json() : null; })
+        .then(function(data) { if (data) updatePfwdStatus(data); });
+}
+
+function checkOnline() {
+    var el = document.getElementById('online-status');
+    if (!el) return;
+    el.textContent = '確認中...';
+    el.className = 'badge bg-secondary';
+    fetch('autoplayctrl.php?action=check_online')
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.status === 'ok') {
+                el.textContent = 'OK';
+                el.className = 'badge bg-success';
+            } else if (data.status === 'ng') {
+                el.textContent = 'NG';
+                el.className = 'badge bg-danger';
+            } else {
+                el.textContent = '無効';
+                el.className = 'badge bg-secondary';
+            }
+        })
+        .catch(function() {
+            el.textContent = 'エラー';
+            el.className = 'badge bg-danger';
+        });
+}
+
+document.getElementById('check-online-btn').addEventListener('click', checkOnline);
+checkOnline();
+</script>
 
 </body>
 </html>
-

--- a/autoplayctrl.php
+++ b/autoplayctrl.php
@@ -12,8 +12,101 @@ if (array_key_exists('pfwdplace', $config_ini) && !empty($config_ini['pfwdplace'
     ob_end_clean();
 }
 
-// --- AJAX: オンライン接続確認 ---
-if (isset($_GET['action']) && $_GET['action'] === 'check_online') {
+// --- AJAX: 接続診断（IPv4/IPv6/TCP を個別に試行して原因を特定する） ---
+if (isset($_GET['action']) && $_GET['action'] === 'check_online_debug') {
+    header('Content-Type: application/json; charset=utf-8');
+
+    $host_raw = array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhost'])
+        ? urldecode($config_ini['globalhost']) : '';
+    // host:port を分割
+    $host_parts = explode(':', $host_raw, 2);
+    $h_host = $host_parts[0];
+    $h_port = isset($host_parts[1]) ? (int)$host_parts[1] : 80;
+    $http_url = 'http://' . $host_raw;
+    $timeout  = 8;
+
+    $results = [];
+
+    // 1. DNS: IPv4 アドレス解決
+    $ipv4 = @gethostbyname($h_host);
+    $results['dns_v4'] = ($ipv4 !== $h_host) ? $ipv4 : '解決失敗';
+
+    // 2. DNS: IPv6 アドレス解決
+    $aaaa = @dns_get_record($h_host, DNS_AAAA);
+    $results['dns_v6'] = (!empty($aaaa)) ? $aaaa[0]['ipv6'] : '解決失敗(またはAAAAなし)';
+
+    // 3. TCP fsockopen (IPv4 解決済みアドレス直接)
+    if ($ipv4 !== $h_host) {
+        $fp = @fsockopen($ipv4, $h_port, $e, $es, $timeout);
+        if ($fp) { fclose($fp); $results['tcp_v4_direct'] = "OK ({$ipv4}:{$h_port})"; }
+        else { $results['tcp_v4_direct'] = "NG ({$e}): {$es}"; }
+    } else {
+        $results['tcp_v4_direct'] = 'スキップ(DNS解決失敗)';
+    }
+
+    // 4. TCP fsockopen (ホスト名・OS任せ)
+    $fp = @fsockopen($h_host, $h_port, $e, $es, $timeout);
+    if ($fp) { fclose($fp); $results['tcp_hostname'] = "OK"; }
+    else { $results['tcp_hostname'] = "NG ({$e}): {$es}"; }
+
+    // 5. curl: IPRESOLVE 指定なし（OS が IPv4/IPv6 を自動選択）
+    $ch = curl_init($http_url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true, CURLOPT_HEADER => false,
+        CURLOPT_CONNECTTIMEOUT => $timeout, CURLOPT_TIMEOUT => $timeout,
+        CURLOPT_FAILONERROR => false, CURLOPT_FOLLOWLOCATION => false,
+        CURLOPT_USERAGENT => 'KaraokeRequestor/1.0',
+    ]);
+    curl_exec($ch);
+    $code = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $ip   = curl_getinfo($ch, CURLINFO_PRIMARY_IP);
+    $en   = curl_errno($ch); $es2  = curl_strerror($en);
+    curl_close($ch);
+    $results['curl_auto'] = $code > 0
+        ? "OK HTTP {$code} (接続先IP: {$ip})"
+        : "NG curl({$en}): {$es2}";
+
+    // 6. curl: IPv4 強制
+    $ch = curl_init($http_url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true, CURLOPT_HEADER => false,
+        CURLOPT_CONNECTTIMEOUT => $timeout, CURLOPT_TIMEOUT => $timeout,
+        CURLOPT_FAILONERROR => false, CURLOPT_FOLLOWLOCATION => false,
+        CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4,
+        CURLOPT_USERAGENT => 'KaraokeRequestor/1.0',
+    ]);
+    curl_exec($ch);
+    $code = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $ip   = curl_getinfo($ch, CURLINFO_PRIMARY_IP);
+    $en   = curl_errno($ch); $es2  = curl_strerror($en);
+    curl_close($ch);
+    $results['curl_v4'] = $code > 0
+        ? "OK HTTP {$code} (接続先IP: {$ip})"
+        : "NG curl({$en}): {$es2}";
+
+    // 7. curl: IPv6 強制
+    $ch = curl_init($http_url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true, CURLOPT_HEADER => false,
+        CURLOPT_CONNECTTIMEOUT => $timeout, CURLOPT_TIMEOUT => $timeout,
+        CURLOPT_FAILONERROR => false, CURLOPT_FOLLOWLOCATION => false,
+        CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V6,
+        CURLOPT_USERAGENT => 'KaraokeRequestor/1.0',
+    ]);
+    curl_exec($ch);
+    $code = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $ip   = curl_getinfo($ch, CURLINFO_PRIMARY_IP);
+    $en   = curl_errno($ch); $es2  = curl_strerror($en);
+    curl_close($ch);
+    $results['curl_v6'] = $code > 0
+        ? "OK HTTP {$code} (接続先IP: {$ip})"
+        : "NG curl({$en}): {$es2}";
+
+    echo json_encode(['host' => $host_raw, 'timeout' => $timeout, 'results' => $results]);
+    exit;
+}
+
+
     header('Content-Type: application/json; charset=utf-8');
 
     $timeout = (int)(array_key_exists('onlinechecktimeout', $config_ini) ? $config_ini['onlinechecktimeout'] : 5);
@@ -217,6 +310,12 @@ if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhos
           <button type="button" class="btn btn-sm btn-outline-secondary ms-auto text-nowrap" id="check-online-btn">再確認</button>
         </div>
         <div id="online-detail" class="small text-muted" style="word-break:break-all;">&nbsp;</div>
+        <button type="button" class="btn btn-sm btn-outline-secondary mt-2" id="check-debug-btn">詳細診断</button>
+        <div id="debug-result" class="mt-2 d-none">
+          <table class="table table-sm table-bordered small mb-0">
+            <tbody id="debug-tbody"></tbody>
+          </table>
+        </div>
       </div>
 
       <!-- WireGuard トンネル確認 -->
@@ -362,6 +461,49 @@ function checkOnline() {
 }
 
 document.getElementById('check-online-btn').addEventListener('click', checkOnline);
+
+document.getElementById('check-debug-btn').addEventListener('click', function() {
+    var btn    = this;
+    var box    = document.getElementById('debug-result');
+    var tbody  = document.getElementById('debug-tbody');
+    btn.disabled = true;
+    btn.textContent = '診断中...';
+    box.classList.add('d-none');
+    tbody.innerHTML = '';
+    fetch('autoplayctrl.php?action=check_online_debug')
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            var labels = {
+                dns_v4:       'DNS (IPv4解決)',
+                dns_v6:       'DNS (IPv6解決)',
+                tcp_v4_direct:'TCP fsockopen IPv4直接',
+                tcp_hostname: 'TCP fsockopen ホスト名',
+                curl_auto:    'curl (IP自動選択)',
+                curl_v4:      'curl (IPv4強制)',
+                curl_v6:      'curl (IPv6強制)',
+            };
+            var row = '<tr><td colspan="2" class="fw-bold">確認先: ' +
+                data.host + ' (timeout:' + data.timeout + 's)</td></tr>';
+            tbody.innerHTML = row;
+            Object.keys(labels).forEach(function(key) {
+                var val = data.results[key] || '—';
+                var ok  = val.startsWith('OK');
+                tbody.innerHTML += '<tr><td>' + labels[key] + '</td>' +
+                    '<td class="' + (ok ? 'text-success' : 'text-danger') + '">' +
+                    val + '</td></tr>';
+            });
+            box.classList.remove('d-none');
+        })
+        .catch(function() {
+            tbody.innerHTML = '<tr><td colspan="2" class="text-danger">診断通信エラー</td></tr>';
+            box.classList.remove('d-none');
+        })
+        .finally(function() {
+            btn.disabled = false;
+            btn.textContent = '詳細診断';
+        });
+});
+
 checkOnline();
 </script>
 

--- a/autoplayctrl.php
+++ b/autoplayctrl.php
@@ -182,6 +182,18 @@ if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhos
   <div class="card mb-3">
     <div class="card-header fw-bold">pfwd (SSH転送)</div>
     <div class="card-body">
+
+      <!-- オンライン接続中の危険警告（pfwd起動中） -->
+      <div id="pfwd-danger-alert" class="alert alert-danger py-2 d-none" role="alert">
+        <strong>⚠ 警告:</strong> オンライン接続中（WireGuard）にもかかわらずpfwdが起動しています。<br>
+        pfwdはオフライン時のみ使用してください。直ちに停止してください。
+      </div>
+
+      <!-- オンライン接続中の注意（pfwd停止中） -->
+      <div id="pfwd-online-alert" class="alert alert-warning py-2 d-none" role="alert">
+        オンライン接続中（WireGuard）です。pfwdは起動しないでください。
+      </div>
+
       <p class="mb-3">
         ステータス：
         <span id="pfwdstatus" class="badge fs-6 <?= $pfwd_running ? 'bg-success' : 'bg-secondary' ?>">
@@ -189,7 +201,7 @@ if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhos
         </span>
       </p>
       <div class="d-flex gap-2">
-        <button type="button" class="btn btn-success" onclick="start_pfwdcmd()">起動</button>
+        <button type="button" id="pfwd-start-btn" class="btn btn-success" onclick="start_pfwdcmd()">起動</button>
         <button type="button" class="btn btn-danger" onclick="stop_pfwdcmd()">停止</button>
       </div>
     </div>
@@ -208,16 +220,45 @@ if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhos
 <?php print_bg_style_block(true); ?>
 
 <script>
+// PHP側のpfwd起動状態をJSに渡す
+var pfwdRunning = <?= $pfwdavailable && $pfwd_running ? 'true' : 'false' ?>;
+// オンライン接続状態（checkOnline()完了後に更新）
+var onlineConnected = false;
+
+function applyPfwdOnlineRestriction(isOnline, pfwdIsRunning) {
+    var startBtn    = document.getElementById('pfwd-start-btn');
+    var dangerAlert = document.getElementById('pfwd-danger-alert');
+    var onlineAlert = document.getElementById('pfwd-online-alert');
+    if (!startBtn) return;
+
+    if (isOnline) {
+        startBtn.disabled = true;
+        if (pfwdIsRunning) {
+            if (dangerAlert) dangerAlert.classList.remove('d-none');
+            if (onlineAlert) onlineAlert.classList.add('d-none');
+        } else {
+            if (dangerAlert) dangerAlert.classList.add('d-none');
+            if (onlineAlert) onlineAlert.classList.remove('d-none');
+        }
+    } else {
+        startBtn.disabled = false;
+        if (dangerAlert) dangerAlert.classList.add('d-none');
+        if (onlineAlert) onlineAlert.classList.add('d-none');
+    }
+}
+
 function updatePfwdStatus(data) {
     var el = document.getElementById('pfwdstatus');
     if (!el) return;
-    if (data.pfwdstat) {
+    pfwdRunning = !!data.pfwdstat;
+    if (pfwdRunning) {
         el.textContent = '起動中';
         el.className = 'badge fs-6 bg-success';
     } else {
         el.textContent = '停止中';
         el.className = 'badge fs-6 bg-secondary';
     }
+    applyPfwdOnlineRestriction(onlineConnected, pfwdRunning);
 }
 
 function start_pfwdcmd() {
@@ -245,17 +286,22 @@ function checkOnline() {
             if (data.status === 'ok') {
                 el.textContent = 'OK';
                 el.className = 'badge bg-success';
+                onlineConnected = true;
             } else if (data.status === 'ng') {
                 el.textContent = 'NG';
                 el.className = 'badge bg-danger';
+                onlineConnected = false;
             } else {
                 el.textContent = '無効';
                 el.className = 'badge bg-secondary';
+                onlineConnected = false;
             }
+            applyPfwdOnlineRestriction(onlineConnected, pfwdRunning);
         })
         .catch(function() {
             el.textContent = 'エラー';
             el.className = 'badge bg-danger';
+            onlineConnected = false;
         });
 }
 

--- a/autoplayctrl.php
+++ b/autoplayctrl.php
@@ -1,21 +1,60 @@
 <?php
 require_once 'commonfunc.php';
 
-// --- AJAX: オンライン接続確認 ---
+// --- AJAX: オンライン接続確認（診断情報付き） ---
 if (isset($_GET['action']) && $_GET['action'] === 'check_online') {
     header('Content-Type: application/json; charset=utf-8');
-    $status = 'disabled';
-    $host   = '';
-    if (
-        array_key_exists('connectinternet', $config_ini) && $config_ini['connectinternet'] == 1 &&
-        array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhost'])
-    ) {
-        $host    = urldecode($config_ini['globalhost']);
-        $timeout = (int)(array_key_exists('onlinechecktimeout', $config_ini) ? $config_ini['onlinechecktimeout'] : 2);
-        $ret     = check_online_available($config_ini['globalhost'], $timeout);
-        $status  = ($ret === 'OK') ? 'ok' : 'ng';
+
+    $internet_enabled = array_key_exists('connectinternet', $config_ini) && $config_ini['connectinternet'] == 1;
+    $host_configured  = array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhost']);
+
+    if (!$internet_enabled) {
+        echo json_encode(['status' => 'disabled', 'host' => '', 'check_url' => '',
+            'detail' => 'インターネット接続設定が無効 (connectinternet=0)']);
+        exit;
     }
-    echo json_encode(['status' => $status, 'host' => $host]);
+    if (!$host_configured) {
+        echo json_encode(['status' => 'disabled', 'host' => '', 'check_url' => '',
+            'detail' => 'オンライン接続用ホスト (globalhost) が未設定']);
+        exit;
+    }
+
+    $host      = urldecode($config_ini['globalhost']);
+    $check_url = 'http://' . $host;
+    $timeout   = (int)(array_key_exists('onlinechecktimeout', $config_ini) ? $config_ini['onlinechecktimeout'] : 2);
+    if ($timeout < 1) $timeout = 2;
+
+    // curl で接続確認（エラー詳細を取得するため直接実行）
+    $ch = curl_init($check_url);
+    curl_setopt($ch, CURLOPT_HEADER, false);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
+    curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
+    curl_setopt($ch, CURLOPT_FAILONERROR, false); // HTTP エラーでも接続できれば OK とする
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt($ch, CURLOPT_MAXREDIRS, 4);
+    curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+    curl_setopt($ch, CURLOPT_USERAGENT, 'KaraokeRequestor/1.0');
+    $curl_result  = curl_exec($ch);
+    $curl_errno   = curl_errno($ch);
+    $curl_error   = curl_strerror($curl_errno);
+    $http_code    = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($curl_result !== false || $http_code > 0) {
+        $status = 'ok';
+        $detail = "HTTP {$http_code}";
+    } else {
+        $status = 'ng';
+        $detail = "curl({$curl_errno}): {$curl_error}";
+    }
+
+    echo json_encode([
+        'status'    => $status,
+        'host'      => $host,
+        'check_url' => $check_url,
+        'detail'    => $detail,
+    ]);
     exit;
 }
 
@@ -154,13 +193,17 @@ if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhos
 
       <!-- オンライン接続確認 -->
       <div class="mb-3">
-        <div class="d-flex align-items-center gap-2 flex-wrap">
+        <div class="d-flex align-items-center gap-2 flex-wrap mb-1">
           <span class="text-nowrap">オンライン接続:</span>
           <span id="online-status" class="badge bg-secondary">確認中...</span>
-          <?php if (!empty($globalhost_display)): ?>
-            <small class="text-muted"><?= htmlspecialchars($globalhost_display) ?></small>
-          <?php endif; ?>
           <button type="button" class="btn btn-sm btn-outline-secondary ms-auto text-nowrap" id="check-online-btn">再確認</button>
+        </div>
+        <div id="online-detail" class="small text-muted" style="word-break:break-all;">
+          <?php if (!empty($globalhost_display)): ?>
+            確認先: http://<?= htmlspecialchars($globalhost_display) ?>
+          <?php else: ?>
+            &nbsp;
+          <?php endif; ?>
         </div>
       </div>
 
@@ -276,25 +319,32 @@ function stop_pfwdcmd() {
 }
 
 function checkOnline() {
-    var el = document.getElementById('online-status');
+    var el     = document.getElementById('online-status');
+    var detailEl = document.getElementById('online-detail');
     if (!el) return;
     el.textContent = '確認中...';
     el.className = 'badge bg-secondary';
+    if (detailEl) detailEl.textContent = '確認中...';
     fetch('autoplayctrl.php?action=check_online')
         .then(function(r) { return r.json(); })
         .then(function(data) {
+            var urlText = data.check_url ? '確認先: ' + data.check_url : '';
+            var detailText = data.detail || '';
             if (data.status === 'ok') {
                 el.textContent = 'OK';
                 el.className = 'badge bg-success';
                 onlineConnected = true;
+                if (detailEl) detailEl.textContent = urlText + (detailText ? '  [' + detailText + ']' : '');
             } else if (data.status === 'ng') {
                 el.textContent = 'NG';
                 el.className = 'badge bg-danger';
                 onlineConnected = false;
+                if (detailEl) detailEl.textContent = urlText + (detailText ? '  [' + detailText + ']' : '');
             } else {
                 el.textContent = '無効';
                 el.className = 'badge bg-secondary';
                 onlineConnected = false;
+                if (detailEl) detailEl.textContent = detailText || urlText;
             }
             applyPfwdOnlineRestriction(onlineConnected, pfwdRunning);
         })
@@ -302,6 +352,7 @@ function checkOnline() {
             el.textContent = 'エラー';
             el.className = 'badge bg-danger';
             onlineConnected = false;
+            if (detailEl) detailEl.textContent = 'AJAX通信エラー';
         });
 }
 

--- a/autoplayctrl.php
+++ b/autoplayctrl.php
@@ -106,35 +106,10 @@ if (isset($_GET['action']) && $_GET['action'] === 'check_online_debug') {
     exit;
 }
 
-
+// --- AJAX: オンライン接続確認 ---
+if (isset($_GET['action']) && $_GET['action'] === 'check_online') {
     header('Content-Type: application/json; charset=utf-8');
 
-    $timeout = (int)(array_key_exists('onlinechecktimeout', $config_ini) ? $config_ini['onlinechecktimeout'] : 5);
-    if ($timeout < 5) $timeout = 5;
-
-    // pfwd 起動中: HTTP ループバックを避け SSH サーバーへの TCP 接続で確認
-    // （pfwd の逆トンネルを介して HTTP チェックすると同一 Apache に折り返しデッドロックになる）
-    $pfwd_running_req = isset($_GET['pfwd_running']) && $_GET['pfwd_running'] === '1';
-    if ($pfwd_running_req && $pfwdavailable) {
-        $ssh_host  = $pfwdinfo->get_pfwdhost();
-        $ssh_port  = (int)$pfwdinfo->get_pfwdport();
-        $check_url = "tcp://{$ssh_host}:{$ssh_port}";
-        if ($ssh_host && $ssh_port) {
-            $fp = @fsockopen($ssh_host, $ssh_port, $sock_errno, $sock_errstr, $timeout);
-            if ($fp) {
-                fclose($fp);
-                $status = 'ok';
-                $detail = "SSH({$ssh_host}:{$ssh_port}) 到達OK (timeout:{$timeout}s)";
-            } else {
-                $status = 'ng';
-                $detail = "({$sock_errno}): {$sock_errstr} (timeout:{$timeout}s)";
-            }
-            echo json_encode(['status' => $status, 'host' => $ssh_host, 'check_url' => $check_url, 'detail' => $detail]);
-            exit;
-        }
-    }
-
-    // 通常の HTTP チェック（pfwd 停止中）
     $internet_enabled = array_key_exists('connectinternet', $config_ini) && $config_ini['connectinternet'] == 1;
     $host_configured  = array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhost']);
 
@@ -151,8 +126,12 @@ if (isset($_GET['action']) && $_GET['action'] === 'check_online_debug') {
 
     $host      = urldecode($config_ini['globalhost']);
     $check_url = 'http://' . $host;
+    $timeout   = (int)(array_key_exists('onlinechecktimeout', $config_ini) ? $config_ini['onlinechecktimeout'] : 5);
+    if ($timeout < 5) $timeout = 5;
 
-    // FOLLOWLOCATION=false: 3xx レスポンスが返った時点で到達確認済みとする
+    // ykr.moe は IPv6 のみのため IPRESOLVE_V4 を強制しない。
+    // OS に IPv4/IPv6 の選択を任せることで IPv6 only ホストにも対応する。
+    // FOLLOWLOCATION=false: 3xx が返った時点で到達確認済みとする（リダイレクト先まで追わない）
     $ch = curl_init($check_url);
     curl_setopt($ch, CURLOPT_HEADER, false);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -160,17 +139,17 @@ if (isset($_GET['action']) && $_GET['action'] === 'check_online_debug') {
     curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
     curl_setopt($ch, CURLOPT_FAILONERROR, false);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
-    curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
     curl_setopt($ch, CURLOPT_USERAGENT, 'KaraokeRequestor/1.0');
     curl_exec($ch);
-    $curl_errno = curl_errno($ch);
-    $curl_error = curl_strerror($curl_errno);
-    $http_code  = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $curl_errno  = curl_errno($ch);
+    $curl_error  = curl_strerror($curl_errno);
+    $http_code   = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $primary_ip  = curl_getinfo($ch, CURLINFO_PRIMARY_IP);
     curl_close($ch);
 
     if ($http_code > 0) {
         $status = 'ok';
-        $detail = "HTTP {$http_code} (timeout:{$timeout}s)";
+        $detail = "HTTP {$http_code} [{$primary_ip}] (timeout:{$timeout}s)";
     } else {
         $status = 'ng';
         $detail = "curl({$curl_errno}): {$curl_error} (timeout:{$timeout}s)";
@@ -434,8 +413,7 @@ function checkOnline() {
     el.textContent = '確認中...';
     el.className = 'badge bg-secondary';
     if (detailEl) detailEl.textContent = '確認中...';
-    // pfwd 起動中を渡すことで PHP 側が SSH TCP チェックに切り替える
-    fetch('autoplayctrl.php?action=check_online&pfwd_running=' + (pfwdRunning ? '1' : '0'))
+    fetch('autoplayctrl.php?action=check_online')
         .then(function(r) { return r.json(); })
         .then(function(data) {
             var urlText    = data.check_url ? '確認先: ' + data.check_url : '';

--- a/autoplayctrl.php
+++ b/autoplayctrl.php
@@ -253,24 +253,24 @@ if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhos
 
   <!-- 自動再生コントロール -->
   <div class="card mb-3">
-    <div class="card-header fw-bold">自動再生コントロール</div>
+    <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">自動再生コントロール</div>
     <div class="card-body">
-      <p class="mb-3">
-        ステータス：
+      <div class="d-flex align-items-center gap-2 mb-3">
+        <span class="text-muted small">ステータス</span>
         <?php if ($ap != 0): ?>
           <span class="badge bg-success fs-6">実行中</span>
         <?php else: ?>
           <span class="badge bg-secondary fs-6">停止中</span>
         <?php endif; ?>
-      </p>
+      </div>
       <div class="d-flex gap-2">
-        <form method="GET">
+        <form method="GET" class="flex-fill">
           <input type="hidden" name="karaokeautorunaction" value="start">
-          <button type="submit" class="btn btn-success">▶ Start</button>
+          <button type="submit" class="btn btn-success btn-lg w-100">▶ Start</button>
         </form>
-        <form method="GET">
+        <form method="GET" class="flex-fill">
           <input type="hidden" name="karaokeautorunaction" value="stop">
-          <button type="submit" class="btn btn-danger">■ Stop</button>
+          <button type="submit" class="btn btn-danger btn-lg w-100">■ Stop</button>
         </form>
       </div>
     </div>
@@ -278,7 +278,7 @@ if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhos
 
   <!-- 接続ステータス -->
   <div class="card mb-3">
-    <div class="card-header fw-bold">接続ステータス</div>
+    <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">接続ステータス</div>
     <div class="card-body">
 
       <!-- オンライン接続確認 -->
@@ -313,24 +313,24 @@ if (array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhos
   <!-- pfwd (SSH転送) -->
   <?php if ($pfwdavailable): ?>
   <div class="card mb-3">
-    <div class="card-header fw-bold">pfwd (SSH転送)</div>
+    <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">pfwd (SSH転送)</div>
     <div class="card-body">
 
       <!-- WireGuard 実行中かつ pfwd 停止中: 注意（pfwd が接続元でない可能性） -->
-      <div id="pfwd-online-alert" class="alert alert-warning py-2 <?= ($wg_running && !$pfwd_running) ? '' : 'd-none' ?>" role="alert">
-        WireGuard 実行中です。オンライン接続が確立されているため pfwd は起動しないでください。
+      <div id="pfwd-online-alert" class="alert alert-warning py-2 small <?= ($wg_running && !$pfwd_running) ? '' : 'd-none' ?>" role="alert">
+        WireGuard 実行中のためオンライン接続済みです。pfwd は起動しないでください。
       </div>
 
-      <p class="mb-3">
-        ステータス：
+      <div class="d-flex align-items-center gap-2 mb-3">
+        <span class="text-muted small">ステータス</span>
         <span id="pfwdstatus" class="badge fs-6 <?= $pfwd_running ? 'bg-success' : 'bg-secondary' ?>">
           <?= $pfwd_running ? '起動中' : '停止中' ?>
         </span>
-      </p>
+      </div>
       <div class="d-flex gap-2">
-        <button type="button" id="pfwd-start-btn" class="btn btn-success"
+        <button type="button" id="pfwd-start-btn" class="btn btn-success btn-lg flex-fill"
           <?= ($wg_running && !$pfwd_running) ? 'disabled' : '' ?> onclick="start_pfwdcmd()">起動</button>
-        <button type="button" class="btn btn-danger" onclick="stop_pfwdcmd()">停止</button>
+        <button type="button" class="btn btn-danger btn-lg flex-fill" onclick="stop_pfwdcmd()">停止</button>
       </div>
     </div>
   </div>

--- a/autoplayctrl.php
+++ b/autoplayctrl.php
@@ -22,7 +22,7 @@ if (isset($_GET['action']) && $_GET['action'] === 'check_online') {
     $host      = urldecode($config_ini['globalhost']);
     $check_url = 'http://' . $host;
     $timeout   = (int)(array_key_exists('onlinechecktimeout', $config_ini) ? $config_ini['onlinechecktimeout'] : 5);
-    if ($timeout < 1) $timeout = 5;
+    if ($timeout < 5) $timeout = 5; // SSH 逆トンネル往復を考慮し最低 5 秒確保
 
     // curl で接続確認（エラー詳細を取得するため直接実行）
     // FOLLOWLOCATION=false: リダイレクト応答(3xx)が返った時点で到達確認済みとする。

--- a/autoplayctrl.php
+++ b/autoplayctrl.php
@@ -21,18 +21,19 @@ if (isset($_GET['action']) && $_GET['action'] === 'check_online') {
 
     $host      = urldecode($config_ini['globalhost']);
     $check_url = 'http://' . $host;
-    $timeout   = (int)(array_key_exists('onlinechecktimeout', $config_ini) ? $config_ini['onlinechecktimeout'] : 2);
-    if ($timeout < 1) $timeout = 2;
+    $timeout   = (int)(array_key_exists('onlinechecktimeout', $config_ini) ? $config_ini['onlinechecktimeout'] : 5);
+    if ($timeout < 1) $timeout = 5;
 
     // curl で接続確認（エラー詳細を取得するため直接実行）
+    // FOLLOWLOCATION=false: リダイレクト応答(3xx)が返った時点で到達確認済みとする。
+    //   リダイレクトを辿ると easyauth 等でループしタイムアウトになる場合があるため。
     $ch = curl_init($check_url);
     curl_setopt($ch, CURLOPT_HEADER, false);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
     curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
-    curl_setopt($ch, CURLOPT_FAILONERROR, false); // HTTP エラーでも接続できれば OK とする
-    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-    curl_setopt($ch, CURLOPT_MAXREDIRS, 4);
+    curl_setopt($ch, CURLOPT_FAILONERROR, false);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
     curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
     curl_setopt($ch, CURLOPT_USERAGENT, 'KaraokeRequestor/1.0');
     $curl_result  = curl_exec($ch);
@@ -41,12 +42,13 @@ if (isset($_GET['action']) && $_GET['action'] === 'check_online') {
     $http_code    = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
 
-    if ($curl_result !== false || $http_code > 0) {
+    // 何らかの HTTP レスポンスが返れば（3xx/4xx/5xx 含む）到達成功と判定
+    if ($http_code > 0) {
         $status = 'ok';
-        $detail = "HTTP {$http_code}";
+        $detail = "HTTP {$http_code} (timeout:{$timeout}s)";
     } else {
         $status = 'ng';
-        $detail = "curl({$curl_errno}): {$curl_error}";
+        $detail = "curl({$curl_errno}): {$curl_error} (timeout:{$timeout}s)";
     }
 
     echo json_encode([

--- a/autoplayctrl.php
+++ b/autoplayctrl.php
@@ -102,6 +102,18 @@ if (isset($_GET['action']) && $_GET['action'] === 'check_online_debug') {
         ? "OK HTTP {$code} (接続先IP: {$ip})"
         : "NG curl({$en}): {$es2}";
 
+    // 8. ping パケットロス率 (Windows 環境)
+    $ping_cmd = 'ping -n 4 -w ' . ($timeout * 1000) . ' ' . escapeshellarg($h_host);
+    @exec($ping_cmd, $ping_output);
+    $ping_output_str = implode("\n", $ping_output);
+    // Windows ping 出力: "Packets: Sent = 4, Received = 3, Lost = 1 (25% loss)"
+    if (preg_match('/Lost = (\d+) \((\d+)%/', $ping_output_str, $m)) {
+        $loss_percent = (int)$m[2];
+        $results['ping_loss'] = "Loss {$loss_percent}% (4回送信)";
+    } else {
+        $results['ping_loss'] = "失敗または全喪失";
+    }
+
     echo json_encode(['host' => $host_raw, 'timeout' => $timeout, 'results' => $results]);
     exit;
 }
@@ -447,13 +459,14 @@ document.getElementById('check-debug-btn').addEventListener('click', function() 
                 curl_auto:    'curl (IP自動選択)',
                 curl_v4:      'curl (IPv4強制)',
                 curl_v6:      'curl (IPv6強制)',
+                ping_loss:    'ping パケットロス率',
             };
             var row = '<tr><td colspan="2" class="fw-bold">確認先: ' +
                 data.host + ' (timeout:' + data.timeout + 's)</td></tr>';
             tbody.innerHTML = row;
             Object.keys(labels).forEach(function(key) {
                 var val = data.results[key] || '—';
-                var ok  = val.startsWith('OK');
+                var ok  = val.startsWith('OK') || val.startsWith('Loss 0%');
                 tbody.innerHTML += '<tr><td>' + labels[key] + '</td>' +
                     '<td class="' + (ok ? 'text-success' : 'text-danger') + '">' +
                     val + '</td></tr>';

--- a/autoplayctrl.php
+++ b/autoplayctrl.php
@@ -102,16 +102,19 @@ if (isset($_GET['action']) && $_GET['action'] === 'check_online_debug') {
         ? "OK HTTP {$code} (接続先IP: {$ip})"
         : "NG curl({$en}): {$es2}";
 
-    // 8. ping パケットロス率 (Windows 環境)
+    // 8. ping パケットロス率 (Windows 環境、日本語ロケール対応)
     $ping_cmd = 'ping -n 4 -w ' . ($timeout * 1000) . ' ' . escapeshellarg($h_host);
     @exec($ping_cmd, $ping_output);
     $ping_output_str = implode("\n", $ping_output);
-    // Windows ping 出力: "Packets: Sent = 4, Received = 3, Lost = 1 (25% loss)"
-    if (preg_match('/Lost = (\d+) \((\d+)%/', $ping_output_str, $m)) {
-        $loss_percent = (int)$m[2];
-        $results['ping_loss'] = "Loss {$loss_percent}% (4回送信)";
+    // 送受信パケット数から計算（ロケール非依存）
+    // 英語: "Sent = 4, Received = 3"  日本語: "送信 = 4、受信 = 3"
+    if (preg_match('/(?:Sent|送信)\s*=\s*(\d+).*(?:Received|受信)\s*=\s*(\d+)/', $ping_output_str, $m)) {
+        $sent = (int)$m[1];
+        $recv = (int)$m[2];
+        $loss = $sent > 0 ? (int)(($sent - $recv) / $sent * 100) : 100;
+        $results['ping_loss'] = "Loss {$loss}% ({$sent}回送信)";
     } else {
-        $results['ping_loss'] = "失敗または全喪失";
+        $results['ping_loss'] = "実行失敗 (パース不可)";
     }
 
     echo json_encode(['host' => $host_raw, 'timeout' => $timeout, 'results' => $results]);

--- a/css/themes/player.css
+++ b/css/themes/player.css
@@ -377,7 +377,7 @@ body {
   align-items: center;
   justify-content: center;
   gap: 5px;
-  opacity: 0.65;
+  opacity: 0.85;
   font-size: 0.78rem;
   touch-action: manipulation;
 }

--- a/init.php
+++ b/init.php
@@ -290,15 +290,12 @@ print '</pre>';
      <a href="#otherroom" class="menulink" > 別部屋URL設定 </a>
     </li>
     <li class="menu">
-     <a href="#pfwd" class="menulink" > pfwd </a>
+     <a href="pfwd_settings.php" class="menulink" > pfwd・接続設定 </a>
     </li>
     <li class="menu">
      <a href="#googlesync" class="menulink" > Google同期設定 </a>
     </li>
     </ul>
-    <li class="menu">
-     <a href="#hostname" class="menulink" > 接続設定（オンライン、ホスト名） </a>
-    </li>
     <li class="menu">
      <a href="#myiplist" class="menulink" > 自IP一覧 </a>
     </li>
@@ -1456,75 +1453,11 @@ if(array_key_exists("request_automove_reset",$config_ini)) {
   </div>
 
   <div class="mb-3">
-    <h3 class="form-label"> pfwd.exeインストールフォルダ  </h3>
-    <input type="text" name="pfwdplace" class="form-control"
-<?php
-if(array_key_exists("pfwdplace",$config_ini)) {
-    print 'value="'.urldecode($config_ini["pfwdplace"]).'"';
-}else {
-    print 'value="pfwd_forykr\\"';
-    $config_ini["pfwdplace"] = "pfwd_forykr\\";
-}
-?>
-/>
-  </div>  
-  <!---- pfwd起動自動チェック ----->
-  <?php
-      $usepfwdcheck=false;
-      if(array_key_exists("usepfwdcheck",$config_ini)){
-          if($config_ini["usepfwdcheck"]==1 ){
-             $usepfwdcheck=true;
-          }
-      }
-  ?>
-
-<?php
-    $online_available_flg = false;
-    $ret = '設定無効';
-    if(array_key_exists('connectinternet',$config_ini ) && $config_ini["connectinternet"]==1 && array_key_exists('globalhost',$config_ini ) && array_key_exists('onlinechecktimeout',$config_ini ) ){
-        $ret = check_online_available($config_ini['globalhost'],$config_ini["onlinechecktimeout"]);
-       
-        if( $ret == 'OK' ){
-           $online_available_flg = true;
-        }
-    }
-?>
-  <div class="mb-3" id="usepfwdcheck" >
-    <h3 id="pfwd" class="radio form-label menulink"> pfwd 自動再起動 </h3>
-    <label class="form-label"><small>通常時オンライン版接続確認でOKになる環境で使用する</small> </label>
-<?php
-  if($online_available_flg == false) {
-      print '<div class="alert-danger" > オンライン版接続確認がNGの間は選択できません <br /> '.$ret ;
-      print '<button class="btn btn-secondary" role="button" onclick="location.reload();" >状態更新</button>'.'</div>';
-  } 
-
-?>
-    <label class="radio-inline">
-      <input type="radio" name="usepfwdcheck" value="1" <?php print ($usepfwdcheck)?'checked':' ';print ($online_available_flg == false)?' disabled':' '; ?> /> 使用する
-    </label>
-    <label class="radio-inline">
-      <input type="radio" name="usepfwdcheck" value="2" <?php print (!$usepfwdcheck)?'checked':' ';print ($online_available_flg == false)?' ':' '; ?> /> 使用しない
-    </label>
-
+    <h3 id="pfwd" class="form-label menulink">pfwd・接続設定</h3>
+    <p class="small text-muted">pfwd フォルダ設定、オンライン接続用ホスト名、自動再起動、DDNS 登録などは専用ページで管理します。</p>
+    <a href="pfwd_settings.php" class="btn btn-secondary">pfwd・接続設定ページへ</a>
   </div>
 
-  <!---- オンラインチェック、タイムアウト時間 ----->
-  <div class="mb-3">
-    <h3 class="form-label"> オンラインチェック、タイムアウト時間 </h3>
-    <label class="form-label"> <small>ブラウザではオンライン接続できるのに下の「オンライン版接続確認」がOKにならない場合この数値を増やしてください。</small> </label>
-    <input type="text" name="onlinechecktimeout" class="form-control"
-<?php
-if(array_key_exists("onlinechecktimeout",$config_ini)) {
-    print 'value="'.urldecode($config_ini["onlinechecktimeout"]).'"';
-}else {
-    print 'value="2"';
-    $config_ini["onlinechecktimeout"] = 2;
-}
-?>
-/>
-  </div>
-
-  
   <!---- 簡易認証設定 ----->
   <?php
       $useeasyauth=false;
@@ -1601,215 +1534,8 @@ if(array_key_exists("useeasyauth_word",$config_ini)) {
   </div>
 </div>
   <hr />
-<hr />
-<?php
 
-require_once 'pfwdctl.php';
-$pfwdavailable = true;
-$pfwdinfo = new pfwd();
-$pfwdinfo->pfwdpath = urldecode($config_ini["pfwdplace"]);
-$pfwdavailable = $pfwdinfo->readpfwdcfg();
-?>
-
-<div class="bg-info">
-  <h1 id="hostname" class="menulink" > ホスト名設定（オンライン接続およびDDNSの設定） </h1>
-  <h3> オンライン接続用</h3>
-
-<script>
-document.addEventListener('DOMContentLoaded', function(){
-  document.getElementById('onlinehost').addEventListener('submit', function(event) {
-    event.preventDefault();
-    fetch(this.action, { method: 'POST', body: new FormData(this) })
-      .then(function(){ window.location.href='init.php'; });
-  });
-});
-</script>
-  <h4> オンライン接続用ホスト名 </h4>
-  <form id="onlinehost" method="post"  action="toolinfo.php">
-  <div class="mb-3">
-    <label class="form-label" >ホスト名</label>
-    <input type="text" name="globalhost" class="form-control"  value="<?php
-        if(array_key_exists("globalhost",$config_ini)) {
-            print urldecode($config_ini["globalhost"]);
-        }
-        $btnvalue='更新';
-    ?>" />
-<?php
-    if(array_key_exists("globalhost",$config_ini)) {
-      if(!empty($config_ini['globalhost'])){
-        print '<dl class="dl-horizontal">';
-        print '<dt> オンライン版接続確認 </dt>';
-        $ret = check_online_available($config_ini['globalhost'],$config_ini["onlinechecktimeout"]);
-       
-        if( $ret == 'OK' ){
-           print '<dd > <div class="bg-success" >'.$ret .'</div></dd>';
-        }else {
-           print '<dd > <div class="alert-danger" > NG : '.$ret .'</div></dd>';
-        }
-        print '</dl>';
-      }
-    }
-?>
-  <input type="submit" class="btn btn-secondary" value="<?php print $btnvalue;?>" />
-  </div>
-  </form>
-<script>
-document.addEventListener('DOMContentLoaded', function(){
-  document.getElementById('pfwdconfig').addEventListener('submit', function(event) {
-    event.preventDefault();
-    fetch(this.action, { method: 'POST', body: new FormData(this) })
-      .then(function(){ window.location.href='init.php'; });
-  });
-});
-
-function createXMLHttpRequest() {
-  if (window.XMLHttpRequest) {
-    return new XMLHttpRequest();
-  } else if (window.ActiveXObject) {
-    try {
-      return new ActiveXObject("Msxml2.XMLHTTP");
-    } catch (e) {
-      try {
-        return new ActiveXObject("Microsoft.XMLHTTP");
-      } catch (e2) {
-        return null;
-      }
-    }
-  } else {
-    return null;
-  }
-}
-
-function start_pfwdcmd(){
-var request = createXMLHttpRequest();
-url="pfwd_exec.php?pfwdstart=1";
-request.open("GET", url, true);
-request.send("");
-}
-
-function stop_pfwdcmd(){
-var request = createXMLHttpRequest();
-url="pfwd_exec.php?pfwdstop=1";
-request.open("GET", url, true);
-request.send("");
-}
-
-var xmlhttp = createXMLHttpRequest();
-
-</script>
-      <h4> プライベートIPオンライン接続コマンド </h4>
-      <form id="pfwdconfig" method="post"  action="pfwd_exec.php">
-  <div class="mb-3">
-      <label class="form-label" >接続ホスト名</label>
-    <input type="text" name="pfwdserverhost" class="form-control"  value="<?php
-        if($pfwdavailable){
-            print $pfwdinfo->get_pfwdhost().':'.$pfwdinfo->get_pfwdport();
-        }
-    ?>" />
-      <label class="form-label" >ユーザー接続ポート</label>
-    <input type="text" name="pfwdserveropenport" class="form-control"  value="<?php
-        if($pfwdavailable){
-            print $pfwdinfo->get_pfwdopenport();
-        }
-    ?>" />
-    <input type="submit" class="btn btn-secondary" value="設定" />
-    </div>
-    </form>
-  <div class="mb-3">
-      <h4 class="form-label" >pfwdプログラム起動停止</h4>
-      <button type="button" class="btn btn-secondary" onClick="start_pfwdcmd()" >起動</button>
-      <button type="button" class="btn btn-secondary" onClick="stop_pfwdcmd()" >停止</button>
-      
-      <?php
-          if($pfwdavailable == false){
-              print '<span class="alert-danger" > 利用不可</span>';
-          }
-          else if($pfwdinfo->statpfwdcmd()){
-              print '<span class="bg-success" > 起動中</span>';
-          } else {
-              print '<span class="alert-danger" >停止中</span>';
-          }
-      ?>
-      
-  </div>
-  <h4> DDNS登録 </h4>
-  <label> pcgame-r18.jp (アカウントを持っている人用) </label>
-  <form id="onlinehostpcg" method="post"  action="https://pcgame-r18.jp/ddns/adddns.php">
-      <div class="mb-3">
-        <label class="form-label"> Hostname </label>
-        <div class="row">
-          <div class="col-8">
-            <input type="text" name="host" class="form-control" style=”width: 40%;” value="" />
-          </div>
-          <div class="col-4">
-          .pcgame-r18.jp
-          </div>
-        </div>
-        <label class="form-label"> IP</label>
-        <div >
-          <input type="text" name="ip" size="10" class="form-control" value="<?php echo get_globalipv4();?>" />
-        </div>
-        <input type="hidden" name="ttl" size="10" class="ttl" value="30" />
-        <input type="hidden" name="autoreturn" size="10" class="autoreturn" value="1" />
-      <input type="submit" class="btn btn-secondary" value="更新" />
-      </div>
-  </form>
-  <label> <a href="http://jpn.www.mydns.jp/" >mydns.jp </a></label>
-  <form method="post"  action="http://www.mydns.jp/directip.html">
-  <div class="mb-3">
-    <label class="form-label" >マスターID</label>
-    <input type="text" name="MID" class="form-control"  value=" " />
-
-    <label class="form-label ">パスワード</label>
-    <input type="text" name="PWD" class="form-control"  value=" " />
-
-    <label class="form-label ">IP</label>
-    <input type="text" name="IPV4ADDR" size="10" class="form-control" value="<?php echo get_globalipv4();?>" />
-  <input type="submit" class="btn btn-secondary" value="更新" />
-  </div>
-  </form>
-  <hr />
-  <h3> ローカル接続用DDNS登録 </h3>
-
-  <label> pcgame-r18.jp (アカウントを持っている人用) </label>
-  <form method="post"  action="https://pcgame-r18.jp/ddns/adddns.php">
-      <div class="mb-3">
-        <label class="form-label"> Hostname </label>
-        <div class="row">
-          <div class="col-8">
-            <input type="text" name="host" class="form-control" style=”width: 40%;” value=" " />
-          </div>
-          <div class="col-4">
-          .pcgame-r18.jp
-          </div>
-        </div>
-        <label class="form-label"> IP</label>
-        <div >
-          <input type="text" name="ip" size="10" class="form-control" value="<?php echo $_SERVER["SERVER_ADDR"];?>" />
-        </div>
-        <input type="hidden" name="ttl" size="10" class="ttl" value="30" />
-        <input type="hidden" name="autoreturn" size="10" class="autoreturn" value="1" />
-      <input type="submit" class="btn btn-secondary" value="更新" />
-      </div>
-  </form>
-
-  <label> <a href="http://jpn.www.mydns.jp/" >mydns.jp </a></label>
-  <form method="post"  action="http://www.mydns.jp/directip.html">
-  <div class="mb-3">
-    <label class="form-label" >マスターID</label>
-    <input type="text" name="MID" class="form-control"  value=" " />
-
-    <label class="form-label ">パスワード</label>
-    <input type="text" name="PWD" class="form-control"  value=" " />
-
-    <label class="form-label ">IP</label>
-    <input type="text" name="IPV4ADDR" size="10" class="form-control" value="<?php echo $_SERVER["SERVER_ADDR"];?>" />
-  <input type="submit" class="btn btn-secondary" value="更新" />
-  </div>
-  </form>
-</div>
-
-<div class="bg-info">
+<div class=”bg-info”>
   <h1 id="myiplist" class="menulink"> 自IP一覧 </h1>
   <pre>
   <?php

--- a/init.php
+++ b/init.php
@@ -290,7 +290,7 @@ print '</pre>';
      <a href="#otherroom" class="menulink" > 別部屋URL設定 </a>
     </li>
     <li class="menu">
-     <a href="pfwd_settings.php" class="menulink" > pfwd・接続設定 </a>
+     <a href="pfwd_settings.php" class="menulink" > オンライン接続設定 </a>
     </li>
     <li class="menu">
      <a href="#googlesync" class="menulink" > Google同期設定 </a>
@@ -394,6 +394,11 @@ request.send("");
   }
 print '<button type="button" class="btn btn-secondary" id="listerbt" '.$addattr.'> ゆかりすたー起動 </button>';
 ?>
+  </p>
+
+  <p>
+  <h3>オンライン接続設定</h3>
+    <a href="pfwd_settings.php" class="btn btn-secondary" > オンライン接続設定 </a>
   </p>
 
   <a href="requestlist_top.php" class="btn btn-secondary" > リクエストTOP画面に戻る　</a>
@@ -1453,9 +1458,9 @@ if(array_key_exists("request_automove_reset",$config_ini)) {
   </div>
 
   <div class="mb-3">
-    <h3 id="pfwd" class="form-label menulink">pfwd・接続設定</h3>
+    <h3 id="pfwd" class="form-label menulink">オンライン接続設定</h3>
     <p class="small text-muted">pfwd フォルダ設定、オンライン接続用ホスト名、自動再起動、DDNS 登録などは専用ページで管理します。</p>
-    <a href="pfwd_settings.php" class="btn btn-secondary">pfwd・接続設定ページへ</a>
+    <a href="pfwd_settings.php" class="btn btn-secondary">オンライン接続設定ページへ</a>
   </div>
 
   <!---- 簡易認証設定 ----->

--- a/pfwd_exec.php
+++ b/pfwd_exec.php
@@ -3,16 +3,15 @@
 require_once 'commonfunc.php';
 require_once 'pfwdctl.php';
 
-var_dump( $_REQUEST);
-var_dump( $config_ini);
-print $config_ini["pfwdplace"];
 $pfwdinfo = new pfwd();
-$pfwdinfo->readpfwdcfg();
 if(array_key_exists("pfwdplace",$config_ini)) {
-    $pfwdinfo->pfwdpath=urldecode($config_ini["pfwdplace"]);
-}else {
+    $pfwdinfo->pfwdpath = urldecode($config_ini["pfwdplace"]);
+} else {
     die();
 }
+ob_start();
+$pfwdinfo->readpfwdcfg();
+ob_end_clean();
 
 $runmode = 0;
 if(array_key_exists("pfwdstart", $_REQUEST)) {
@@ -69,7 +68,6 @@ if(array_key_exists("pfwdserverhost", $_REQUEST)) {
 }
 
 if(array_key_exists("pfwdserveropenport", $_REQUEST)) {
-print "comehere";
     $pfwdserveropenport = $_REQUEST["pfwdserveropenport"];
     if(!empty($pfwdserveropenport)){
         $pfwdinfo->set_pfwdopenport($pfwdserveropenport);
@@ -77,12 +75,10 @@ print "comehere";
         $updateflag = true;
     }
 }
-var_dump( $updateflag);
 if( $updateflag ){
     $pfwdhost = $pfwdinfo->get_pfwdhost().':'.$pfwdinfo->get_pfwdopenport();
     $config_ini_new = array_merge($config_ini,array('globalhost' => urlencode($pfwdhost)));
     writeconfig2ini($config_ini_new,$configfile);
-var_dump($config_ini_new);
 }
 
 

--- a/pfwd_settings.php
+++ b/pfwd_settings.php
@@ -144,6 +144,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_config'])) {
         if (isset($_POST[$k])) $config_ini[$k] = (int)$_POST[$k];
     }
     writeconfig2ini($config_ini, $configfile);
+
+    // globalhost のポートを pfwd.ini の openport に反映
+    if (!empty($_POST['globalhost'])) {
+        $gh       = trim($_POST['globalhost']);
+        $colonIdx = strrpos($gh, ':');
+        if ($colonIdx !== false) {
+            $newPort = substr($gh, $colonIdx + 1);
+            if (ctype_digit($newPort)) {
+                $pfwdplace_post = isset($_POST['pfwdplace']) && $_POST['pfwdplace'] !== ''
+                    ? $_POST['pfwdplace']
+                    : (array_key_exists('pfwdplace', $config_ini) ? urldecode($config_ini['pfwdplace']) : 'pfwd_forykr\\');
+                $pfwdinfo_save = new pfwd();
+                $pfwdinfo_save->pfwdpath = $pfwdplace_post;
+                ob_start();
+                $ok = $pfwdinfo_save->readpfwdcfg();
+                ob_end_clean();
+                if ($ok) {
+                    $pfwdinfo_save->set_pfwdopenport($newPort);
+                    $pfwdinfo_save->save_pfwdconfig();
+                }
+            }
+        }
+    }
+
     header('Location: pfwd_settings.php?saved=1');
     exit;
 }
@@ -170,24 +194,36 @@ $pfwdplace_val = array_key_exists('pfwdplace', $config_ini)
 $globalhost_val = array_key_exists('globalhost', $config_ini)
     ? urldecode($config_ini['globalhost']) : '';
 
-// Auto-detect local IP for DDNS（ローカル接続用）
+// globalhost からユーザー接続ポートを逆算（表示用）
+$pfwdopenport_display = '';
+if (!empty($globalhost_val)) {
+    $colonIdx = strrpos($globalhost_val, ':');
+    if ($colonIdx !== false) {
+        $pfwdopenport_display = substr($globalhost_val, $colonIdx + 1);
+    }
+}
+// globalhost にポートがない場合は pfwd.ini の値をフォールバック
+if ($pfwdopenport_display === '' && $pfwdavailable) {
+    $pfwdopenport_display = (string)$pfwdinfo->get_pfwdopenport();
+}
+
+// Auto-detect local IP for DDNS（ローカル接続用：IPv4のみ・ループバック除外）
 function get_first_non_loopback_ip() {
     require_once 'ipconfig.php';
     $iplist = getiplist();
     foreach ($iplist as $ifinfo) {
         foreach ($ifinfo as $idx => $ip) {
             if ($idx == 0) continue; // skip interface name
+            $ip = trim($ip);
             if (empty($ip)) continue;
-            // Remove IPv6 zone ID if present
-            if (strpos($ip, '%') !== false) {
-                $ip = substr($ip, 0, strpos($ip, '%'));
-            }
-            // Skip loopback addresses
-            if ($ip === '127.0.0.1' || $ip === '::1') continue;
+            // IPv6は除外（コロンを含む）
+            if (strpos($ip, ':') !== false) continue;
+            // ループバック除外
+            if ($ip === '127.0.0.1') continue;
             return $ip;
         }
     }
-    return $_SERVER['SERVER_ADDR'] ?? '';
+    return '';
 }
 $local_ip_for_ddns = get_first_non_loopback_ip();
 ?>
@@ -287,7 +323,7 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
           <div class="d-flex gap-2 align-items-end">
             <div style="flex:1;">
               <input type="text" id="pfwdserveropenport-input" class="form-control font-monospace"
-                value="<?= $pfwdavailable ? htmlspecialchars($pfwdinfo->get_pfwdopenport(), ENT_QUOTES, 'UTF-8') : '' ?>"
+                value="<?= htmlspecialchars($pfwdopenport_display, ENT_QUOTES, 'UTF-8') ?>"
                 placeholder="例: 11002" />
             </div>
             <button type="button" class="btn btn-secondary btn-sm" onclick="updateGlobalhost()">ホスト名に反映</button>

--- a/pfwd_settings.php
+++ b/pfwd_settings.php
@@ -316,7 +316,7 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
   <?php endif; ?>
 
   <!-- 設定フォーム開始 -->
-  <form method="post" id="pfwd-main-form">
+  <form method="post" id="pfwd-main-form" name="allconfig">
     <input type="hidden" name="save_config" value="1">
 
     <!-- オンライン接続設定 -->

--- a/pfwd_settings.php
+++ b/pfwd_settings.php
@@ -409,6 +409,13 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
       </div>
     </div>
 
+  <!-- 設定反映ボタン -->
+  <div class="d-grid mb-3">
+    <button type="submit" class="btn btn-primary btn-lg">設定反映</button>
+  </div>
+
+  </form><!-- /設定フォーム -->
+
   <!-- DDNS 設定 -->
   <div class="card mb-3">
     <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">DDNS 登録（オンライン用）</div>
@@ -563,13 +570,6 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
       </div>
     </div>
   </div>
-
-  <!-- 設定反映ボタン -->
-  <div class="d-grid mb-3">
-    <button type="submit" class="btn btn-primary btn-lg">設定反映</button>
-  </div>
-
-  </form><!-- /設定フォーム -->
 
 </div><!-- /container -->
 

--- a/pfwd_settings.php
+++ b/pfwd_settings.php
@@ -273,7 +273,7 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
   <?php endif; ?>
 
   <!-- 設定フォーム開始 -->
-  <form method="post">
+  <form method="post" id="pfwd-main-form">
     <input type="hidden" name="save_config" value="1">
 
     <!-- オンライン接続設定 -->
@@ -284,15 +284,15 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
         <?php if ($pfwdavailable): ?>
         <div class="mb-3">
           <label class="form-label fw-semibold">ユーザー接続ポート</label>
-          <form id="pfwdconfig-openport" method="post" action="pfwd_exec.php" class="d-flex gap-2 align-items-end">
+          <div class="d-flex gap-2 align-items-end">
             <div style="flex:1;">
-              <input type="text" name="pfwdserveropenport" class="form-control font-monospace"
+              <input type="text" id="pfwdserveropenport-input" class="form-control font-monospace"
                 value="<?= $pfwdavailable ? htmlspecialchars($pfwdinfo->get_pfwdopenport(), ENT_QUOTES, 'UTF-8') : '' ?>"
                 placeholder="例: 11002" />
             </div>
-            <button type="submit" class="btn btn-secondary btn-sm">保存</button>
-          </form>
-          <div class="form-text">外部から接続するためのポート番号です。</div>
+            <button type="button" class="btn btn-secondary btn-sm" onclick="updateGlobalhost()">ホスト名に反映</button>
+          </div>
+          <div class="form-text">外部から接続するためのポート番号です。「ホスト名に反映」で自動的にオンライン接続用ホスト名を更新します。</div>
         </div>
         <?php endif; ?>
 
@@ -461,23 +461,43 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
       <?php
       require_once 'ipconfig.php';
       $result_ipconfig = getiplist();
+      $ips_to_show = array(); // 重複排除用
+
+      // すべてのインターフェースからIPを抽出（ループバック除外）
       foreach ($result_ipconfig as $ifinfo) {
-          $count = 0;
-          foreach ($ifinfo as $ips) {
-              if ($count != 0) {
-                  if (strpos($ips, ':') !== false) {
-                      $ips = '[' . substr($ips, 0, strpos($ips, '%')) . ']';
-                  }
-                  if (!empty($ips)) {
-                      $link = 'http://' . $ips . '/';
-                      if (array_key_exists('useeasyauth_word', $config_ini) && !empty($config_ini['useeasyauth_word'])) {
-                          $link = $link . '?easypass=' . $config_ini['useeasyauth_word'];
-                      }
-                      echo '<a href="' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '" target="_blank">' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '</a>' . "\n";
-                  }
+          foreach ($ifinfo as $idx => $ip_str) {
+              if ($idx === 0) continue; // インターフェース名をスキップ
+              $ip = trim($ip_str);
+              if (empty($ip)) continue;
+
+              // IPv6 zone ID を削除
+              if (strpos($ip, '%') !== false) {
+                  $ip = substr($ip, 0, strpos($ip, '%'));
               }
-              $count++;
+
+              // ループバック判定
+              if ($ip === '127.0.0.1' || $ip === '::1') {
+                  continue;
+              }
+
+              // 重複排除
+              if (in_array($ip, $ips_to_show, true)) {
+                  continue;
+              }
+
+              $ips_to_show[] = $ip;
           }
+      }
+
+      // リンク生成
+      foreach ($ips_to_show as $ip) {
+          $is_ipv6 = (strpos($ip, ':') !== false);
+          $url_ip = $is_ipv6 ? '[' . $ip . ']' : $ip;
+          $link = 'http://' . $url_ip . '/';
+          if (array_key_exists('useeasyauth_word', $config_ini) && !empty($config_ini['useeasyauth_word'])) {
+              $link = $link . '?easypass=' . $config_ini['useeasyauth_word'];
+          }
+          echo '<a href="' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '" target="_blank">' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '</a>' . "\n";
       }
       ?>
       </div>
@@ -623,17 +643,38 @@ document.getElementById('check-debug-btn').addEventListener('click', function() 
         .finally(function() { btn.disabled = false; btn.textContent = '詳細診断'; });
 });
 
-// pfwdconfig-openport フォームの AJAX 送信（ページ遷移なし）
-var pfwdconfigOpenportForm = document.getElementById('pfwdconfig-openport');
-if (pfwdconfigOpenportForm) {
-    pfwdconfigOpenportForm.addEventListener('submit', function(event) {
-        event.preventDefault();
-        fetch(this.action, { method: 'POST', body: new FormData(this) })
-            .then(function() {
-                var btn = pfwdconfigOpenportForm.querySelector('[type=submit]');
-                if (btn) { var orig = btn.textContent; btn.textContent = '保存しました'; setTimeout(function(){ btn.textContent = orig; }, 2000); }
-            });
-    });
+// ユーザー接続ポート → グローバルホスト反映
+function updateGlobalhost() {
+    var portInput = document.getElementById('pfwdserveropenport-input');
+    var globalhostInput = document.querySelector('input[name="globalhost"]');
+    var newPort = (portInput.value || '').trim();
+
+    if (!newPort) {
+        alert('ポート番号を入力してください');
+        return;
+    }
+
+    var currentGlobalhost = (globalhostInput.value || '').trim();
+    if (!currentGlobalhost) {
+        alert('オンライン接続用ホスト名が未設定です');
+        return;
+    }
+
+    // "hostname:port" または "hostname" 形式で分割
+    var colonIdx = currentGlobalhost.lastIndexOf(':');
+    var hostname = (colonIdx > 0) ? currentGlobalhost.substring(0, colonIdx) : currentGlobalhost;
+
+    // ホスト名:ポート形式で新しい値を作成
+    var newGlobalhost = hostname + ':' + newPort;
+
+    // フィールドを更新
+    globalhostInput.value = newGlobalhost;
+
+    // メインフォームを送信
+    var mainForm = document.getElementById('pfwd-main-form');
+    if (mainForm) {
+        mainForm.submit();
+    }
 }
 
 // pfwdconfig-host フォームの AJAX 送信（ページ遷移なし）

--- a/pfwd_settings.php
+++ b/pfwd_settings.php
@@ -1,0 +1,553 @@
+<?php
+require_once 'commonfunc.php';
+require_once 'configauth_class.php';
+$configauth = new ConfigAuth();
+
+if (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] !== 'admin' || !$configauth->check_auth($_SERVER['PHP_AUTH_PW'])) {
+    header('WWW-Authenticate: Basic realm="pfwd Settings"');
+    die('管理者ログインが必要です');
+}
+
+require_once 'easyauth_class.php';
+$easyauth = new EasyAuth();
+$easyauth->do_eashauthcheck();
+
+// pfwd 初期化
+require_once 'pfwdctl.php';
+$pfwdavailable = false;
+$pfwdinfo = new pfwd();
+if (array_key_exists('pfwdplace', $config_ini) && !empty($config_ini['pfwdplace'])) {
+    $pfwdinfo->pfwdpath = urldecode($config_ini['pfwdplace']);
+    ob_start();
+    $pfwdavailable = $pfwdinfo->readpfwdcfg();
+    ob_end_clean();
+}
+
+// --- AJAX: 接続診断 ---
+if (isset($_GET['action']) && $_GET['action'] === 'check_online_debug') {
+    header('Content-Type: application/json; charset=utf-8');
+    $host_raw = array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhost'])
+        ? urldecode($config_ini['globalhost']) : '';
+    $host_parts = explode(':', $host_raw, 2);
+    $h_host = $host_parts[0];
+    $h_port = isset($host_parts[1]) ? (int)$host_parts[1] : 80;
+    $http_url = 'http://' . $host_raw;
+    $timeout  = 8;
+    $results  = [];
+
+    $ipv4 = @gethostbyname($h_host);
+    $results['dns_v4'] = ($ipv4 !== $h_host) ? $ipv4 : '解決失敗';
+
+    $aaaa = @dns_get_record($h_host, DNS_AAAA);
+    $results['dns_v6'] = (!empty($aaaa)) ? $aaaa[0]['ipv6'] : '解決失敗(またはAAAAなし)';
+
+    if ($ipv4 !== $h_host) {
+        $fp = @fsockopen($ipv4, $h_port, $e, $es, $timeout);
+        if ($fp) { fclose($fp); $results['tcp_v4_direct'] = "OK ({$ipv4}:{$h_port})"; }
+        else { $results['tcp_v4_direct'] = "NG ({$e}): {$es}"; }
+    } else {
+        $results['tcp_v4_direct'] = 'スキップ(DNS解決失敗)';
+    }
+
+    $fp = @fsockopen($h_host, $h_port, $e, $es, $timeout);
+    if ($fp) { fclose($fp); $results['tcp_hostname'] = "OK"; }
+    else { $results['tcp_hostname'] = "NG ({$e}): {$es}"; }
+
+    foreach ([null, CURL_IPRESOLVE_V4, CURL_IPRESOLVE_V6] as $resolve) {
+        $ch = curl_init($http_url);
+        $opts = [
+            CURLOPT_RETURNTRANSFER => true, CURLOPT_HEADER => false,
+            CURLOPT_CONNECTTIMEOUT => $timeout, CURLOPT_TIMEOUT => $timeout,
+            CURLOPT_FAILONERROR => false, CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_USERAGENT => 'KaraokeRequestor/1.0',
+        ];
+        if ($resolve !== null) $opts[CURLOPT_IPRESOLVE] = $resolve;
+        curl_setopt_array($ch, $opts);
+        curl_exec($ch);
+        $code = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $ip   = curl_getinfo($ch, CURLINFO_PRIMARY_IP);
+        $en   = curl_errno($ch); $es2 = curl_strerror($en);
+        curl_close($ch);
+        $val = $code > 0 ? "OK HTTP {$code} (接続先IP: {$ip})" : "NG curl({$en}): {$es2}";
+        if ($resolve === null)              $results['curl_auto'] = $val;
+        elseif ($resolve === CURL_IPRESOLVE_V4) $results['curl_v4'] = $val;
+        else                                $results['curl_v6'] = $val;
+    }
+
+    $timeout_ms = $timeout * 1000;
+    $ping_cmd = "cmd /c \"chcp 437 >nul && ping -n 4 -w {$timeout_ms} {$h_host}\"";
+    @exec($ping_cmd, $ping_output);
+    $ping_str = implode("\n", $ping_output);
+    if (preg_match('/Sent\s*=\s*(\d+).*Received\s*=\s*(\d+)/', $ping_str, $m)) {
+        $sent = (int)$m[1]; $recv = (int)$m[2];
+        $loss = $sent > 0 ? (int)(($sent - $recv) / $sent * 100) : 100;
+        $results['ping_loss'] = "Loss {$loss}% ({$sent}回送信)";
+    } else {
+        $results['ping_loss'] = "実行失敗";
+    }
+
+    echo json_encode(['host' => $host_raw, 'timeout' => $timeout, 'results' => $results]);
+    exit;
+}
+
+// --- AJAX: オンライン接続確認 ---
+if (isset($_GET['action']) && $_GET['action'] === 'check_online') {
+    header('Content-Type: application/json; charset=utf-8');
+    $internet_enabled = array_key_exists('connectinternet', $config_ini) && $config_ini['connectinternet'] == 1;
+    $host_configured  = array_key_exists('globalhost', $config_ini) && !empty($config_ini['globalhost']);
+    if (!$internet_enabled) {
+        echo json_encode(['status' => 'disabled', 'host' => '', 'check_url' => '',
+            'detail' => 'インターネット接続設定が無効 (connectinternet=0)']);
+        exit;
+    }
+    if (!$host_configured) {
+        echo json_encode(['status' => 'disabled', 'host' => '', 'check_url' => '',
+            'detail' => 'オンライン接続用ホスト (globalhost) が未設定']);
+        exit;
+    }
+    $host      = urldecode($config_ini['globalhost']);
+    $check_url = 'http://' . $host;
+    $timeout   = (int)(array_key_exists('onlinechecktimeout', $config_ini) ? $config_ini['onlinechecktimeout'] : 5);
+    if ($timeout < 5) $timeout = 5;
+    $ch = curl_init($check_url);
+    curl_setopt($ch, CURLOPT_HEADER, false);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
+    curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
+    curl_setopt($ch, CURLOPT_FAILONERROR, false);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+    curl_setopt($ch, CURLOPT_USERAGENT, 'KaraokeRequestor/1.0');
+    curl_exec($ch);
+    $curl_errno = curl_errno($ch);
+    $http_code  = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $primary_ip = curl_getinfo($ch, CURLINFO_PRIMARY_IP);
+    curl_close($ch);
+    if ($http_code > 0) {
+        $status = 'ok';
+        $detail = "HTTP {$http_code} [{$primary_ip}] (timeout:{$timeout}s)";
+    } else {
+        $status = 'ng';
+        $detail = "curl({$curl_errno}): " . curl_strerror($curl_errno) . " (timeout:{$timeout}s)";
+    }
+    echo json_encode(['status' => $status, 'host' => $host, 'check_url' => $check_url, 'detail' => $detail]);
+    exit;
+}
+
+// --- 設定保存 ---
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_config'])) {
+    $str_keys  = ['pfwdplace', 'onlinechecktimeout', 'globalhost'];
+    $int_keys  = ['usepfwdcheck'];
+    foreach ($str_keys as $k) {
+        if (isset($_POST[$k])) $config_ini[$k] = urlencode($_POST[$k]);
+    }
+    foreach ($int_keys as $k) {
+        if (isset($_POST[$k])) $config_ini[$k] = (int)$_POST[$k];
+    }
+    writeconfig2ini($config_ini, $configfile);
+    header('Location: pfwd_settings.php?saved=1');
+    exit;
+}
+
+// --- WireGuard 確認 ---
+function check_wireguard_running()
+{
+    exec('tasklist /fi "imagename eq wireguard.exe" 2>nul', $result);
+    foreach ($result as $line) {
+        if (stripos($line, 'wireguard.exe') !== false) return true;
+    }
+    return false;
+}
+
+// --- ステータス取得 ---
+$pfwd_running = $pfwdavailable ? $pfwdinfo->statpfwdcmd() : false;
+$wg_running   = check_wireguard_running();
+
+$usepfwdcheck = array_key_exists('usepfwdcheck', $config_ini) && $config_ini['usepfwdcheck'] == 1;
+$onlinechecktimeout_val = array_key_exists('onlinechecktimeout', $config_ini)
+    ? urldecode($config_ini['onlinechecktimeout']) : '2';
+$pfwdplace_val = array_key_exists('pfwdplace', $config_ini)
+    ? urldecode($config_ini['pfwdplace']) : 'pfwd_forykr\\';
+$globalhost_val = array_key_exists('globalhost', $config_ini)
+    ? urldecode($config_ini['globalhost']) : '';
+?>
+<!doctype html>
+<html lang="ja">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<title>pfwd・接続設定</title>
+<script>(function(){if(window.__ykThemeInit)return;window.__ykThemeInit=true;try{var t=localStorage.getItem("ykari-theme")||"light",f=localStorage.getItem("ykari-fontsize")||"normal";document.documentElement.setAttribute("data-theme",t);document.documentElement.setAttribute("data-fontsize",f);}catch(e){}})();</script>
+<link rel="stylesheet" href="css/bootstrap5/bootstrap.min.css">
+<link rel="stylesheet" href="css/themes/_variables.css">
+<link rel="stylesheet" href="css/themes/theme-toggle.css">
+<link rel="stylesheet" href="css/themes/player.css">
+<script src="js/jquery.js"></script>
+<script src="js/bootstrap5/bootstrap.bundle.min.js"></script>
+<script src="js/theme-toggle.js"></script>
+</head>
+<body>
+<?php shownavigatioinbar_bs5('init.php'); ?>
+
+<div class="container" style="max-width:560px; padding-bottom:32px;">
+
+  <h5 class="mb-3">pfwd・接続設定</h5>
+
+  <?php if (isset($_GET['saved'])): ?>
+  <div class="alert alert-success alert-dismissible fade show py-2" role="alert">
+    設定を保存しました。
+    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+  </div>
+  <?php endif; ?>
+
+  <!-- 接続ステータス -->
+  <div class="card mb-3">
+    <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">接続ステータス</div>
+    <div class="card-body">
+      <div class="mb-3">
+        <div class="d-flex align-items-center gap-2 flex-wrap mb-1">
+          <span class="text-nowrap">オンライン接続:</span>
+          <span id="online-status" class="badge bg-secondary">確認中...</span>
+          <button type="button" class="btn btn-sm btn-outline-secondary ms-auto text-nowrap" id="check-online-btn">再確認</button>
+        </div>
+        <div id="online-detail" class="small text-muted" style="word-break:break-all;">&nbsp;</div>
+        <button type="button" class="btn btn-sm btn-outline-secondary mt-2" id="check-debug-btn">詳細診断</button>
+        <div id="debug-result" class="mt-2 d-none">
+          <table class="table table-sm table-bordered small mb-0">
+            <tbody id="debug-tbody"></tbody>
+          </table>
+        </div>
+      </div>
+      <div class="d-flex align-items-center gap-2">
+        <span class="text-nowrap">WireGuard:</span>
+        <?php if ($wg_running): ?>
+          <span class="badge bg-success">実行中</span>
+        <?php else: ?>
+          <span class="badge bg-secondary">停止中</span>
+        <?php endif; ?>
+      </div>
+    </div>
+  </div>
+
+  <!-- pfwd 制御 -->
+  <?php if ($pfwdavailable): ?>
+  <div class="card mb-3">
+    <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">pfwd 制御</div>
+    <div class="card-body">
+      <div id="pfwd-online-alert" class="alert alert-warning py-2 small <?= ($wg_running && !$pfwd_running) ? '' : 'd-none' ?>" role="alert">
+        WireGuard 実行中のためオンライン接続済みです。pfwd は起動しないでください。
+      </div>
+      <div class="d-flex align-items-center gap-2 mb-3">
+        <span class="text-muted small">ステータス</span>
+        <span id="pfwdstatus" class="badge fs-6 <?= $pfwd_running ? 'bg-success' : 'bg-secondary' ?>">
+          <?= $pfwd_running ? '起動中' : '停止中' ?>
+        </span>
+      </div>
+      <div class="d-flex gap-2">
+        <button type="button" id="pfwd-start-btn" class="btn btn-success btn-lg flex-fill"
+          <?= ($wg_running && !$pfwd_running) ? 'disabled' : '' ?> onclick="start_pfwdcmd()">起動</button>
+        <button type="button" class="btn btn-danger btn-lg flex-fill" onclick="stop_pfwdcmd()">停止</button>
+      </div>
+    </div>
+  </div>
+  <?php endif; ?>
+
+  <!-- 接続設定 -->
+  <form method="post">
+    <input type="hidden" name="save_config" value="1">
+    <div class="card mb-3">
+      <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">オンライン接続設定</div>
+      <div class="card-body">
+        <div class="mb-3">
+          <label class="form-label fw-semibold">オンライン接続用ホスト名</label>
+          <input type="text" name="globalhost" class="form-control font-monospace"
+            value="<?= htmlspecialchars($globalhost_val, ENT_QUOTES, 'UTF-8') ?>"
+            placeholder="例: ykr.moe:11002" />
+          <div class="form-text">グローバルIPまたはDDNSホスト名。接続確認に使用します。</div>
+        </div>
+        <div class="mb-3">
+          <label class="form-label fw-semibold">接続確認タイムアウト (秒)</label>
+          <input type="number" name="onlinechecktimeout" class="form-control" style="width:120px;"
+            value="<?= htmlspecialchars($onlinechecktimeout_val, ENT_QUOTES, 'UTF-8') ?>" min="1" max="30" />
+          <div class="form-text">ブラウザでは接続できるのに確認がNGになる場合は増やしてください。</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">pfwd 設定</div>
+      <div class="card-body">
+        <div class="mb-3">
+          <label class="form-label fw-semibold">pfwd.exe インストールフォルダ</label>
+          <input type="text" name="pfwdplace" class="form-control font-monospace"
+            value="<?= htmlspecialchars($pfwdplace_val, ENT_QUOTES, 'UTF-8') ?>" />
+        </div>
+        <div class="mb-3">
+          <label class="form-label fw-semibold">pfwd 自動再起動</label>
+          <div class="form-text mb-1">通常時オンライン接続確認がOKになる環境で使用します。</div>
+          <div class="d-flex gap-3">
+            <div class="form-check">
+              <input class="form-check-input" type="radio" name="usepfwdcheck" value="1" id="pfwdcheck_yes"
+                <?= $usepfwdcheck ? 'checked' : '' ?>>
+              <label class="form-check-label" for="pfwdcheck_yes">使用する</label>
+            </div>
+            <div class="form-check">
+              <input class="form-check-input" type="radio" name="usepfwdcheck" value="2" id="pfwdcheck_no"
+                <?= !$usepfwdcheck ? 'checked' : '' ?>>
+              <label class="form-check-label" for="pfwdcheck_no">使用しない</label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="d-grid mb-3">
+      <button type="submit" class="btn btn-primary btn-lg">設定を保存</button>
+    </div>
+  </form>
+
+  <!-- pfwd サーバー設定 (pfwd_exec.php へ POST) -->
+  <?php if ($pfwdavailable): ?>
+  <div class="card mb-3">
+    <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">pfwd サーバー接続設定</div>
+    <div class="card-body">
+      <form id="pfwdconfig" method="post" action="pfwd_exec.php">
+        <div class="mb-3">
+          <label class="form-label fw-semibold">接続ホスト名:ポート</label>
+          <input type="text" name="pfwdserverhost" class="form-control font-monospace"
+            value="<?= $pfwdavailable ? htmlspecialchars($pfwdinfo->get_pfwdhost() . ':' . $pfwdinfo->get_pfwdport(), ENT_QUOTES, 'UTF-8') : '' ?>"
+            placeholder="例: ykr.moe:22" />
+        </div>
+        <div class="mb-3">
+          <label class="form-label fw-semibold">ユーザー接続ポート</label>
+          <input type="text" name="pfwdserveropenport" class="form-control font-monospace"
+            value="<?= $pfwdavailable ? htmlspecialchars($pfwdinfo->get_pfwdopenport(), ENT_QUOTES, 'UTF-8') : '' ?>"
+            placeholder="例: 11002" />
+        </div>
+        <button type="submit" class="btn btn-secondary">pfwd サーバー設定を保存</button>
+      </form>
+    </div>
+  </div>
+  <?php endif; ?>
+
+  <!-- DDNS 設定 -->
+  <div class="card mb-3">
+    <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">DDNS 登録（オンライン用）</div>
+    <div class="card-body">
+      <div class="mb-3">
+        <label class="form-label fw-semibold small">pcgame-r18.jp</label>
+        <form method="post" action="https://pcgame-r18.jp/ddns/adddns.php" class="d-flex gap-2 align-items-end flex-wrap">
+          <div>
+            <label class="form-label small">ホスト名</label>
+            <div class="input-group">
+              <input type="text" name="host" class="form-control form-control-sm font-monospace" style="width:140px;" value="" />
+              <span class="input-group-text small">.pcgame-r18.jp</span>
+            </div>
+          </div>
+          <div>
+            <label class="form-label small">IP</label>
+            <input type="text" name="ip" class="form-control form-control-sm font-monospace" style="width:130px;"
+              value="<?= htmlspecialchars(get_globalipv4(), ENT_QUOTES, 'UTF-8') ?>" />
+          </div>
+          <input type="hidden" name="ttl" value="30">
+          <input type="hidden" name="autoreturn" value="1">
+          <button type="submit" class="btn btn-sm btn-secondary mb-0">更新</button>
+        </form>
+      </div>
+      <div>
+        <label class="form-label fw-semibold small"><a href="http://jpn.www.mydns.jp/" target="_blank">mydns.jp</a></label>
+        <form method="post" action="http://www.mydns.jp/directip.html" class="d-flex gap-2 align-items-end flex-wrap">
+          <div>
+            <label class="form-label small">マスターID</label>
+            <input type="text" name="MID" class="form-control form-control-sm" style="width:110px;" value="" />
+          </div>
+          <div>
+            <label class="form-label small">パスワード</label>
+            <input type="text" name="PWD" class="form-control form-control-sm" style="width:110px;" value="" />
+          </div>
+          <div>
+            <label class="form-label small">IP</label>
+            <input type="text" name="IPV4ADDR" class="form-control form-control-sm font-monospace" style="width:120px;"
+              value="<?= htmlspecialchars(get_globalipv4(), ENT_QUOTES, 'UTF-8') ?>" />
+          </div>
+          <button type="submit" class="btn btn-sm btn-secondary mb-0">更新</button>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- DDNS 設定（ローカル用）-->
+  <div class="card mb-3">
+    <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">DDNS 登録（ローカル接続用）</div>
+    <div class="card-body">
+      <div class="mb-3">
+        <label class="form-label fw-semibold small">pcgame-r18.jp</label>
+        <form method="post" action="https://pcgame-r18.jp/ddns/adddns.php" class="d-flex gap-2 align-items-end flex-wrap">
+          <div>
+            <label class="form-label small">ホスト名</label>
+            <div class="input-group">
+              <input type="text" name="host" class="form-control form-control-sm font-monospace" style="width:140px;" value="" />
+              <span class="input-group-text small">.pcgame-r18.jp</span>
+            </div>
+          </div>
+          <div>
+            <label class="form-label small">IP</label>
+            <input type="text" name="ip" class="form-control form-control-sm font-monospace" style="width:130px;"
+              value="<?= htmlspecialchars($_SERVER['SERVER_ADDR'] ?? '', ENT_QUOTES, 'UTF-8') ?>" />
+          </div>
+          <input type="hidden" name="ttl" value="30">
+          <input type="hidden" name="autoreturn" value="1">
+          <button type="submit" class="btn btn-sm btn-secondary mb-0">更新</button>
+        </form>
+      </div>
+      <div>
+        <label class="form-label fw-semibold small"><a href="http://jpn.www.mydns.jp/" target="_blank">mydns.jp</a></label>
+        <form method="post" action="http://www.mydns.jp/directip.html" class="d-flex gap-2 align-items-end flex-wrap">
+          <div>
+            <label class="form-label small">マスターID</label>
+            <input type="text" name="MID" class="form-control form-control-sm" style="width:110px;" value="" />
+          </div>
+          <div>
+            <label class="form-label small">パスワード</label>
+            <input type="text" name="PWD" class="form-control form-control-sm" style="width:110px;" value="" />
+          </div>
+          <div>
+            <label class="form-label small">IP</label>
+            <input type="text" name="IPV4ADDR" class="form-control form-control-sm font-monospace" style="width:120px;"
+              value="<?= htmlspecialchars($_SERVER['SERVER_ADDR'] ?? '', ENT_QUOTES, 'UTF-8') ?>" />
+          </div>
+          <button type="submit" class="btn btn-sm btn-secondary mb-0">更新</button>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- 設定ページへ戻る -->
+  <div class="d-grid mt-2">
+    <a href="init.php" class="btn btn-outline-secondary btn-sm player-refresh-btn">
+      設定ページへ戻る
+    </a>
+  </div>
+
+</div><!-- /container -->
+
+<?php print_bg_style_block(true); ?>
+
+<script>
+var pfwdRunning = <?= $pfwdavailable && $pfwd_running ? 'true' : 'false' ?>;
+var wgRunning   = <?= $wg_running ? 'true' : 'false' ?>;
+
+function applyPfwdRestriction(pfwdIsRunning) {
+    var startBtn    = document.getElementById('pfwd-start-btn');
+    var onlineAlert = document.getElementById('pfwd-online-alert');
+    if (!startBtn) return;
+    if (wgRunning && !pfwdIsRunning) {
+        startBtn.disabled = true;
+        if (onlineAlert) onlineAlert.classList.remove('d-none');
+    } else {
+        startBtn.disabled = false;
+        if (onlineAlert) onlineAlert.classList.add('d-none');
+    }
+}
+
+function updatePfwdStatus(data) {
+    var el = document.getElementById('pfwdstatus');
+    if (!el) return;
+    pfwdRunning = !!data.pfwdstat;
+    el.textContent = pfwdRunning ? '起動中' : '停止中';
+    el.className   = 'badge fs-6 ' + (pfwdRunning ? 'bg-success' : 'bg-secondary');
+    applyPfwdRestriction(pfwdRunning);
+}
+
+function start_pfwdcmd() {
+    fetch('pfwd_exec.php?pfwdstart=1')
+        .then(function(r) { return r.ok ? fetch('pfwdstat.php') : null; })
+        .then(function(r) { return r ? r.json() : null; })
+        .then(function(data) { if (data) updatePfwdStatus(data); });
+}
+
+function stop_pfwdcmd() {
+    fetch('pfwd_exec.php?pfwdstop=1')
+        .then(function(r) { return r.ok ? fetch('pfwdstat.php') : null; })
+        .then(function(r) { return r ? r.json() : null; })
+        .then(function(data) { if (data) updatePfwdStatus(data); });
+}
+
+function checkOnline() {
+    var el       = document.getElementById('online-status');
+    var detailEl = document.getElementById('online-detail');
+    if (!el) return;
+    el.textContent = '確認中...';
+    el.className = 'badge bg-secondary';
+    if (detailEl) detailEl.textContent = '確認中...';
+    fetch('pfwd_settings.php?action=check_online')
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            var infoText = (data.check_url ? '確認先: ' + data.check_url : '') +
+                           (data.detail ? '  [' + data.detail + ']' : '');
+            if (data.status === 'ok') {
+                el.textContent = 'OK'; el.className = 'badge bg-success';
+            } else if (data.status === 'ng') {
+                el.textContent = 'NG'; el.className = 'badge bg-danger';
+            } else {
+                el.textContent = '無効'; el.className = 'badge bg-secondary';
+            }
+            if (detailEl) detailEl.textContent = infoText || data.detail;
+        })
+        .catch(function() {
+            el.textContent = 'エラー'; el.className = 'badge bg-danger';
+            if (detailEl) detailEl.textContent = 'AJAX通信エラー';
+        });
+}
+
+document.getElementById('check-online-btn').addEventListener('click', checkOnline);
+
+document.getElementById('check-debug-btn').addEventListener('click', function() {
+    var btn   = this;
+    var box   = document.getElementById('debug-result');
+    var tbody = document.getElementById('debug-tbody');
+    btn.disabled = true; btn.textContent = '診断中...';
+    box.classList.add('d-none'); tbody.innerHTML = '';
+    fetch('pfwd_settings.php?action=check_online_debug')
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            var labels = {
+                dns_v4: 'DNS (IPv4解決)', dns_v6: 'DNS (IPv6解決)',
+                tcp_v4_direct: 'TCP fsockopen IPv4直接', tcp_hostname: 'TCP fsockopen ホスト名',
+                curl_auto: 'curl (IP自動選択)', curl_v4: 'curl (IPv4強制)', curl_v6: 'curl (IPv6強制)',
+                ping_loss: 'ping パケットロス率',
+            };
+            tbody.innerHTML = '<tr><td colspan="2" class="fw-bold">確認先: ' +
+                data.host + ' (timeout:' + data.timeout + 's)</td></tr>';
+            Object.keys(labels).forEach(function(key) {
+                var val = data.results[key] || '—';
+                var ok  = val.startsWith('OK') || val.startsWith('Loss 0%');
+                tbody.innerHTML += '<tr><td>' + labels[key] + '</td>' +
+                    '<td class="' + (ok ? 'text-success' : 'text-danger') + '">' + val + '</td></tr>';
+            });
+            box.classList.remove('d-none');
+        })
+        .catch(function() {
+            tbody.innerHTML = '<tr><td colspan="2" class="text-danger">診断通信エラー</td></tr>';
+            box.classList.remove('d-none');
+        })
+        .finally(function() { btn.disabled = false; btn.textContent = '詳細診断'; });
+});
+
+// pfwdconfig フォームの AJAX 送信（ページ遷移なし）
+var pfwdconfigForm = document.getElementById('pfwdconfig');
+if (pfwdconfigForm) {
+    pfwdconfigForm.addEventListener('submit', function(event) {
+        event.preventDefault();
+        fetch(this.action, { method: 'POST', body: new FormData(this) })
+            .then(function() {
+                var btn = pfwdconfigForm.querySelector('[type=submit]');
+                if (btn) { var orig = btn.textContent; btn.textContent = '保存しました'; setTimeout(function(){ btn.textContent = orig; }, 2000); }
+            });
+    });
+}
+
+checkOnline();
+</script>
+
+</body>
+</html>

--- a/pfwd_settings.php
+++ b/pfwd_settings.php
@@ -367,14 +367,14 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
         <?php if ($pfwdavailable): ?>
         <div class="mb-3">
           <label class="form-label fw-semibold">接続ホスト名:ポート</label>
-          <form id="pfwdconfig-host" method="post" action="pfwd_exec.php" class="d-flex gap-2 align-items-end">
+          <div class="d-flex gap-2 align-items-end">
             <div style="flex:1;">
-              <input type="text" name="pfwdserverhost" class="form-control font-monospace"
+              <input type="text" id="pfwdserverhost-input" class="form-control font-monospace"
                 value="<?= $pfwdavailable ? htmlspecialchars($pfwdinfo->get_pfwdhost() . ':' . $pfwdinfo->get_pfwdport(), ENT_QUOTES, 'UTF-8') : '' ?>"
                 placeholder="例: ykr.moe:22" />
             </div>
-            <button type="submit" class="btn btn-secondary btn-sm">保存</button>
-          </form>
+            <button type="button" class="btn btn-secondary btn-sm" onclick="savePfwdServerHost(this)">保存</button>
+          </div>
           <div class="form-text">pfwd リレーサーバーのホスト名とSSHポート。</div>
         </div>
         <?php endif; ?>
@@ -715,17 +715,27 @@ function updateGlobalhost() {
     }
 }
 
-// pfwdconfig-host フォームの AJAX 送信（ページ遷移なし）
-var pfwdconfigHostForm = document.getElementById('pfwdconfig-host');
-if (pfwdconfigHostForm) {
-    pfwdconfigHostForm.addEventListener('submit', function(event) {
-        event.preventDefault();
-        fetch(this.action, { method: 'POST', body: new FormData(this) })
-            .then(function() {
-                var btn = pfwdconfigHostForm.querySelector('[type=submit]');
-                if (btn) { var orig = btn.textContent; btn.textContent = '保存しました'; setTimeout(function(){ btn.textContent = orig; }, 2000); }
-            });
-    });
+// 接続ホスト名:ポート 保存（form ネスト回避のため直接 fetch）
+function savePfwdServerHost(btn) {
+    var input = document.getElementById('pfwdserverhost-input');
+    if (!input) return;
+    var value = input.value.trim();
+    if (!value) return;
+    var formData = new FormData();
+    formData.append('pfwdserverhost', value);
+    if (btn) btn.disabled = true;
+    fetch('pfwd_exec.php', { method: 'POST', body: formData })
+        .then(function() {
+            if (btn) {
+                btn.disabled = false;
+                var orig = btn.textContent;
+                btn.textContent = '保存しました';
+                setTimeout(function() { btn.textContent = orig; }, 2000);
+            }
+        })
+        .catch(function() {
+            if (btn) btn.disabled = false;
+        });
 }
 
 checkOnline();

--- a/pfwd_settings.php
+++ b/pfwd_settings.php
@@ -135,7 +135,7 @@ if (isset($_GET['action']) && $_GET['action'] === 'check_online') {
 
 // --- 設定保存 ---
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_config'])) {
-    $str_keys  = ['pfwdplace', 'onlinechecktimeout', 'globalhost'];
+    $str_keys  = ['pfwdplace', 'onlinechecktimeout'];
     $int_keys  = ['usepfwdcheck'];
     foreach ($str_keys as $k) {
         if (isset($_POST[$k])) $config_ini[$k] = urlencode($_POST[$k]);
@@ -143,31 +143,39 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_config'])) {
     foreach ($int_keys as $k) {
         if (isset($_POST[$k])) $config_ini[$k] = (int)$_POST[$k];
     }
+
+    // globalhost = ホスト名:ユーザー接続ポート として組み合わせて保存
+    $post_hostname = isset($_POST['globalhost']) ? trim($_POST['globalhost']) : '';
+    $post_openport = isset($_POST['pfwdserveropenport']) ? trim($_POST['pfwdserveropenport']) : '';
+    if (!empty($post_hostname)) {
+        $config_ini['globalhost'] = urlencode(
+            !empty($post_openport) ? $post_hostname . ':' . $post_openport : $post_hostname
+        );
+    }
+
     writeconfig2ini($config_ini, $configfile);
 
-    // globalhost のホスト名とポートを pfwd.ini に反映
-    if (!empty($_POST['globalhost'])) {
-        $gh       = trim($_POST['globalhost']);
-        $colonIdx = strrpos($gh, ':');
-        if ($colonIdx !== false) {
-            $hostname = substr($gh, 0, $colonIdx);
-            $newPort  = substr($gh, $colonIdx + 1);
-            if (ctype_digit($newPort) && !empty($hostname)) {
-                $pfwdplace_post = isset($_POST['pfwdplace']) && $_POST['pfwdplace'] !== ''
-                    ? $_POST['pfwdplace']
-                    : (array_key_exists('pfwdplace', $config_ini) ? urldecode($config_ini['pfwdplace']) : 'pfwd_forykr\\');
-                $pfwdinfo_save = new pfwd();
-                $pfwdinfo_save->pfwdpath = $pfwdplace_post;
-                ob_start();
-                $ok = $pfwdinfo_save->readpfwdcfg();
-                ob_end_clean();
-                if ($ok) {
-                    $pfwdinfo_save->set_pfwdhost($hostname);
-                    $pfwdinfo_save->set_pfwdopenport($newPort);
-                    $pfwdinfo_save->save_pfwdconfig();
-                }
-            }
+    // pfwd.ini 更新：ホスト名・ユーザー接続ポート・pfwd接続ポート
+    $pfwdplace_post = isset($_POST['pfwdplace']) && $_POST['pfwdplace'] !== ''
+        ? $_POST['pfwdplace']
+        : (array_key_exists('pfwdplace', $config_ini) ? urldecode($config_ini['pfwdplace']) : 'pfwd_forykr\\');
+    $pfwdinfo_save = new pfwd();
+    $pfwdinfo_save->pfwdpath = $pfwdplace_post;
+    ob_start();
+    $ok = $pfwdinfo_save->readpfwdcfg();
+    ob_end_clean();
+    if ($ok) {
+        if (!empty($post_hostname)) {
+            $pfwdinfo_save->set_pfwdhost($post_hostname);
         }
+        if (!empty($post_openport) && ctype_digit($post_openport)) {
+            $pfwdinfo_save->set_pfwdopenport($post_openport);
+        }
+        $post_pfwdport = isset($_POST['pfwdport']) ? trim($_POST['pfwdport']) : '';
+        if (!empty($post_pfwdport) && ctype_digit($post_pfwdport)) {
+            $pfwdinfo_save->set_pfwdport($post_pfwdport);
+        }
+        $pfwdinfo_save->save_pfwdconfig();
     }
 
     header('Location: pfwd_settings.php?saved=1');
@@ -196,18 +204,15 @@ $pfwdplace_val = array_key_exists('pfwdplace', $config_ini)
 $globalhost_val = array_key_exists('globalhost', $config_ini)
     ? urldecode($config_ini['globalhost']) : '';
 
-// globalhost からユーザー接続ポートを逆算（表示用）
-$pfwdopenport_display = '';
-if (!empty($globalhost_val)) {
-    $colonIdx = strrpos($globalhost_val, ':');
-    if ($colonIdx !== false) {
-        $pfwdopenport_display = substr($globalhost_val, $colonIdx + 1);
-    }
-}
-// globalhost にポートがない場合は pfwd.ini の値をフォールバック
-if ($pfwdopenport_display === '' && $pfwdavailable) {
-    $pfwdopenport_display = (string)$pfwdinfo->get_pfwdopenport();
-}
+// globalhost のホスト名部分のみ抽出（入力欄の初期値）
+$colonIdx2 = strrpos($globalhost_val, ':');
+$globalhost_hostname = ($colonIdx2 !== false) ? substr($globalhost_val, 0, $colonIdx2) : $globalhost_val;
+
+// ユーザー接続ポート（pfwd.ini から直接取得）
+$pfwdopenport_display = $pfwdavailable ? (string)$pfwdinfo->get_pfwdopenport() : '';
+
+// pfwd接続ポート＝SSH ポート（pfwd.ini から取得）
+$pfwdport_display = $pfwdavailable ? (string)$pfwdinfo->get_pfwdport() : '10090';
 
 // Auto-detect local IP for DDNS（ローカル接続用：IPv4のみ・ループバック除外）
 function get_first_non_loopback_ip() {
@@ -318,29 +323,32 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
     <div class="card mb-3">
       <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">オンライン接続設定</div>
       <div class="card-body">
-        <!-- ユーザー接続ポート（pfwdserveropenport）-->
-        <?php if ($pfwdavailable): ?>
+        <!-- ユーザー接続ポート -->
         <div class="mb-3">
           <label class="form-label fw-semibold">ユーザー接続ポート</label>
-          <div class="d-flex gap-2 align-items-end">
-            <div style="flex:1;">
-              <input type="text" id="pfwdserveropenport-input" class="form-control font-monospace"
-                value="<?= htmlspecialchars($pfwdopenport_display, ENT_QUOTES, 'UTF-8') ?>"
-                placeholder="例: 11002" />
-            </div>
-            <button type="button" class="btn btn-secondary btn-sm" onclick="updateGlobalhost()">ホスト名に反映</button>
-          </div>
-          <div class="form-text">外部から接続するためのポート番号です。「ホスト名に反映」で自動的にオンライン接続用ホスト名を更新します。</div>
+          <input type="text" name="pfwdserveropenport" id="pfwdserveropenport-input"
+            class="form-control font-monospace" style="width:140px;"
+            value="<?= htmlspecialchars($pfwdopenport_display, ENT_QUOTES, 'UTF-8') ?>"
+            placeholder="例: 11002" oninput="updateAddressDisplay()" />
+          <div class="form-text">外部から接続するためのポート番号です。</div>
         </div>
-        <?php endif; ?>
 
-        <!-- オンライン接続用ホスト名 -->
+        <!-- オンライン接続用ホスト名（ホスト名のみ）-->
         <div class="mb-3">
           <label class="form-label fw-semibold">オンライン接続用ホスト名</label>
-          <input type="text" name="globalhost" class="form-control font-monospace"
-            value="<?= htmlspecialchars($globalhost_val, ENT_QUOTES, 'UTF-8') ?>"
-            placeholder="例: ykr.moe:11002" />
-          <div class="form-text">グローバルIPまたはDDNSホスト名。接続確認に使用します。</div>
+          <input type="text" name="globalhost" id="globalhost-input"
+            class="form-control font-monospace"
+            value="<?= htmlspecialchars($globalhost_hostname, ENT_QUOTES, 'UTF-8') ?>"
+            placeholder="例: ykr.moe" oninput="updateAddressDisplay()" />
+          <div class="form-text">グローバルIPまたはDDNSホスト名（ポートは除く）。</div>
+        </div>
+
+        <!-- オンライン接続用アドレス（表示のみ）-->
+        <div class="mb-3">
+          <label class="form-label fw-semibold text-muted small">オンライン接続用アドレス（自動生成）</label>
+          <input type="text" id="online-address-display" class="form-control font-monospace"
+            readonly tabindex="-1"
+            value="<?= htmlspecialchars($globalhost_hostname . (!empty($pfwdopenport_display) ? ':' . $pfwdopenport_display : ''), ENT_QUOTES, 'UTF-8') ?>" />
         </div>
 
         <!-- 接続確認タイムアウト -->
@@ -363,21 +371,23 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
             value="<?= htmlspecialchars($pfwdplace_val, ENT_QUOTES, 'UTF-8') ?>" />
         </div>
 
-        <!-- 接続ホスト名:ポート（統合）-->
-        <?php if ($pfwdavailable): ?>
+        <!-- pfwd接続ポート（SSH ポート）-->
         <div class="mb-3">
-          <label class="form-label fw-semibold">接続ホスト名:ポート</label>
-          <div class="d-flex gap-2 align-items-end">
-            <div style="flex:1;">
-              <input type="text" id="pfwdserverhost-input" class="form-control font-monospace"
-                value="<?= $pfwdavailable ? htmlspecialchars($pfwdinfo->get_pfwdhost() . ':' . $pfwdinfo->get_pfwdport(), ENT_QUOTES, 'UTF-8') : '' ?>"
-                placeholder="例: ykr.moe:22" />
-            </div>
-            <button type="button" class="btn btn-secondary btn-sm" onclick="savePfwdServerHost(this)">保存</button>
-          </div>
-          <div class="form-text">pfwd リレーサーバーのホスト名とSSHポート。</div>
+          <label class="form-label fw-semibold">pfwd接続ポート</label>
+          <input type="text" name="pfwdport" id="pfwdport-input"
+            class="form-control font-monospace" style="width:140px;"
+            value="<?= htmlspecialchars($pfwdport_display, ENT_QUOTES, 'UTF-8') ?>"
+            placeholder="例: 10090" oninput="updateAddressDisplay()" />
+          <div class="form-text">pfwd がリレーサーバーに接続する SSH ポート番号です。</div>
         </div>
-        <?php endif; ?>
+
+        <!-- pfwd接続アドレス（表示のみ）-->
+        <div class="mb-3">
+          <label class="form-label fw-semibold text-muted small">pfwd接続アドレス（自動生成）</label>
+          <input type="text" id="pfwd-address-display" class="form-control font-monospace"
+            readonly tabindex="-1"
+            value="<?= htmlspecialchars($globalhost_hostname . (!empty($pfwdport_display) ? ':' . $pfwdport_display : ''), ENT_QUOTES, 'UTF-8') ?>" />
+        </div>
 
         <!-- pfwd 自動再起動 -->
         <div class="mb-3">
@@ -554,9 +564,9 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
     </div>
   </div>
 
-  <!-- 設定を保存ボタン -->
+  <!-- 設定反映ボタン -->
   <div class="d-grid mb-3">
-    <button type="submit" class="btn btn-primary btn-lg">設定を保存</button>
+    <button type="submit" class="btn btn-primary btn-lg">設定反映</button>
   </div>
 
   </form><!-- /設定フォーム -->
@@ -681,61 +691,19 @@ document.getElementById('check-debug-btn').addEventListener('click', function() 
         .finally(function() { btn.disabled = false; btn.textContent = '詳細診断'; });
 });
 
-// ユーザー接続ポート → グローバルホスト反映
-function updateGlobalhost() {
-    var portInput = document.getElementById('pfwdserveropenport-input');
-    var globalhostInput = document.querySelector('input[name="globalhost"]');
-    var newPort = (portInput.value || '').trim();
+// 入力変化に合わせてアドレス表示を更新
+function updateAddressDisplay() {
+    var hostname = (document.getElementById('globalhost-input').value || '').trim();
+    var openport = (document.getElementById('pfwdserveropenport-input').value || '').trim();
+    var pfwdport = (document.getElementById('pfwdport-input').value || '').trim();
 
-    if (!newPort) {
-        alert('ポート番号を入力してください');
-        return;
-    }
+    var onlineAddr = hostname + (openport ? ':' + openport : '');
+    var pfwdAddr   = hostname + (pfwdport  ? ':' + pfwdport  : '');
 
-    var currentGlobalhost = (globalhostInput.value || '').trim();
-    if (!currentGlobalhost) {
-        alert('オンライン接続用ホスト名が未設定です');
-        return;
-    }
-
-    // "hostname:port" または "hostname" 形式で分割
-    var colonIdx = currentGlobalhost.lastIndexOf(':');
-    var hostname = (colonIdx > 0) ? currentGlobalhost.substring(0, colonIdx) : currentGlobalhost;
-
-    // ホスト名:ポート形式で新しい値を作成
-    var newGlobalhost = hostname + ':' + newPort;
-
-    // フィールドを更新
-    globalhostInput.value = newGlobalhost;
-
-    // メインフォームを送信
-    var mainForm = document.getElementById('pfwd-main-form');
-    if (mainForm) {
-        mainForm.submit();
-    }
-}
-
-// 接続ホスト名:ポート 保存（form ネスト回避のため直接 fetch）
-function savePfwdServerHost(btn) {
-    var input = document.getElementById('pfwdserverhost-input');
-    if (!input) return;
-    var value = input.value.trim();
-    if (!value) return;
-    var formData = new FormData();
-    formData.append('pfwdserverhost', value);
-    if (btn) btn.disabled = true;
-    fetch('pfwd_exec.php', { method: 'POST', body: formData })
-        .then(function() {
-            if (btn) {
-                btn.disabled = false;
-                var orig = btn.textContent;
-                btn.textContent = '保存しました';
-                setTimeout(function() { btn.textContent = orig; }, 2000);
-            }
-        })
-        .catch(function() {
-            if (btn) btn.disabled = false;
-        });
+    var onlineEl = document.getElementById('online-address-display');
+    var pfwdEl   = document.getElementById('pfwd-address-display');
+    if (onlineEl) onlineEl.value = onlineAddr;
+    if (pfwdEl)   pfwdEl.value   = pfwdAddr;
 }
 
 checkOnline();

--- a/pfwd_settings.php
+++ b/pfwd_settings.php
@@ -169,13 +169,34 @@ $pfwdplace_val = array_key_exists('pfwdplace', $config_ini)
     ? urldecode($config_ini['pfwdplace']) : 'pfwd_forykr\\';
 $globalhost_val = array_key_exists('globalhost', $config_ini)
     ? urldecode($config_ini['globalhost']) : '';
+
+// Auto-detect local IP for DDNS（ローカル接続用）
+function get_first_non_loopback_ip() {
+    require_once 'ipconfig.php';
+    $iplist = getiplist();
+    foreach ($iplist as $ifinfo) {
+        foreach ($ifinfo as $idx => $ip) {
+            if ($idx == 0) continue; // skip interface name
+            if (empty($ip)) continue;
+            // Remove IPv6 zone ID if present
+            if (strpos($ip, '%') !== false) {
+                $ip = substr($ip, 0, strpos($ip, '%'));
+            }
+            // Skip loopback addresses
+            if ($ip === '127.0.0.1' || $ip === '::1') continue;
+            return $ip;
+        }
+    }
+    return $_SERVER['SERVER_ADDR'] ?? '';
+}
+$local_ip_for_ddns = get_first_non_loopback_ip();
 ?>
 <!doctype html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
-<title>pfwd・接続設定</title>
+<title>オンライン接続設定</title>
 <script>(function(){if(window.__ykThemeInit)return;window.__ykThemeInit=true;try{var t=localStorage.getItem("ykari-theme")||"light",f=localStorage.getItem("ykari-fontsize")||"normal";document.documentElement.setAttribute("data-theme",t);document.documentElement.setAttribute("data-fontsize",f);}catch(e){}})();</script>
 <link rel="stylesheet" href="css/bootstrap5/bootstrap.min.css">
 <link rel="stylesheet" href="css/themes/_variables.css">
@@ -190,7 +211,7 @@ $globalhost_val = array_key_exists('globalhost', $config_ini)
 
 <div class="container" style="max-width:560px; padding-bottom:32px;">
 
-  <h5 class="mb-3">pfwd・接続設定</h5>
+  <h5 class="mb-3">オンライン接続設定</h5>
 
   <?php if (isset($_GET['saved'])): ?>
   <div class="alert alert-success alert-dismissible fade show py-2" role="alert">
@@ -251,12 +272,31 @@ $globalhost_val = array_key_exists('globalhost', $config_ini)
   </div>
   <?php endif; ?>
 
-  <!-- 接続設定 -->
+  <!-- 設定フォーム開始 -->
   <form method="post">
     <input type="hidden" name="save_config" value="1">
+
+    <!-- オンライン接続設定 -->
     <div class="card mb-3">
       <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">オンライン接続設定</div>
       <div class="card-body">
+        <!-- ユーザー接続ポート（pfwdserveropenport）-->
+        <?php if ($pfwdavailable): ?>
+        <div class="mb-3">
+          <label class="form-label fw-semibold">ユーザー接続ポート</label>
+          <form id="pfwdconfig-openport" method="post" action="pfwd_exec.php" class="d-flex gap-2 align-items-end">
+            <div style="flex:1;">
+              <input type="text" name="pfwdserveropenport" class="form-control font-monospace"
+                value="<?= $pfwdavailable ? htmlspecialchars($pfwdinfo->get_pfwdopenport(), ENT_QUOTES, 'UTF-8') : '' ?>"
+                placeholder="例: 11002" />
+            </div>
+            <button type="submit" class="btn btn-secondary btn-sm">保存</button>
+          </form>
+          <div class="form-text">外部から接続するためのポート番号です。</div>
+        </div>
+        <?php endif; ?>
+
+        <!-- オンライン接続用ホスト名 -->
         <div class="mb-3">
           <label class="form-label fw-semibold">オンライン接続用ホスト名</label>
           <input type="text" name="globalhost" class="form-control font-monospace"
@@ -264,6 +304,8 @@ $globalhost_val = array_key_exists('globalhost', $config_ini)
             placeholder="例: ykr.moe:11002" />
           <div class="form-text">グローバルIPまたはDDNSホスト名。接続確認に使用します。</div>
         </div>
+
+        <!-- 接続確認タイムアウト -->
         <div class="mb-3">
           <label class="form-label fw-semibold">接続確認タイムアウト (秒)</label>
           <input type="number" name="onlinechecktimeout" class="form-control" style="width:120px;"
@@ -273,6 +315,7 @@ $globalhost_val = array_key_exists('globalhost', $config_ini)
       </div>
     </div>
 
+    <!-- pfwd 設定 -->
     <div class="card mb-3">
       <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">pfwd 設定</div>
       <div class="card-body">
@@ -281,6 +324,24 @@ $globalhost_val = array_key_exists('globalhost', $config_ini)
           <input type="text" name="pfwdplace" class="form-control font-monospace"
             value="<?= htmlspecialchars($pfwdplace_val, ENT_QUOTES, 'UTF-8') ?>" />
         </div>
+
+        <!-- 接続ホスト名:ポート（統合）-->
+        <?php if ($pfwdavailable): ?>
+        <div class="mb-3">
+          <label class="form-label fw-semibold">接続ホスト名:ポート</label>
+          <form id="pfwdconfig-host" method="post" action="pfwd_exec.php" class="d-flex gap-2 align-items-end">
+            <div style="flex:1;">
+              <input type="text" name="pfwdserverhost" class="form-control font-monospace"
+                value="<?= $pfwdavailable ? htmlspecialchars($pfwdinfo->get_pfwdhost() . ':' . $pfwdinfo->get_pfwdport(), ENT_QUOTES, 'UTF-8') : '' ?>"
+                placeholder="例: ykr.moe:22" />
+            </div>
+            <button type="submit" class="btn btn-secondary btn-sm">保存</button>
+          </form>
+          <div class="form-text">pfwd リレーサーバーのホスト名とSSHポート。</div>
+        </div>
+        <?php endif; ?>
+
+        <!-- pfwd 自動再起動 -->
         <div class="mb-3">
           <label class="form-label fw-semibold">pfwd 自動再起動</label>
           <div class="form-text mb-1">通常時オンライン接続確認がOKになる環境で使用します。</div>
@@ -299,35 +360,6 @@ $globalhost_val = array_key_exists('globalhost', $config_ini)
         </div>
       </div>
     </div>
-
-    <div class="d-grid mb-3">
-      <button type="submit" class="btn btn-primary btn-lg">設定を保存</button>
-    </div>
-  </form>
-
-  <!-- pfwd サーバー設定 (pfwd_exec.php へ POST) -->
-  <?php if ($pfwdavailable): ?>
-  <div class="card mb-3">
-    <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">pfwd サーバー接続設定</div>
-    <div class="card-body">
-      <form id="pfwdconfig" method="post" action="pfwd_exec.php">
-        <div class="mb-3">
-          <label class="form-label fw-semibold">接続ホスト名:ポート</label>
-          <input type="text" name="pfwdserverhost" class="form-control font-monospace"
-            value="<?= $pfwdavailable ? htmlspecialchars($pfwdinfo->get_pfwdhost() . ':' . $pfwdinfo->get_pfwdport(), ENT_QUOTES, 'UTF-8') : '' ?>"
-            placeholder="例: ykr.moe:22" />
-        </div>
-        <div class="mb-3">
-          <label class="form-label fw-semibold">ユーザー接続ポート</label>
-          <input type="text" name="pfwdserveropenport" class="form-control font-monospace"
-            value="<?= $pfwdavailable ? htmlspecialchars($pfwdinfo->get_pfwdopenport(), ENT_QUOTES, 'UTF-8') : '' ?>"
-            placeholder="例: 11002" />
-        </div>
-        <button type="submit" class="btn btn-secondary">pfwd サーバー設定を保存</button>
-      </form>
-    </div>
-  </div>
-  <?php endif; ?>
 
   <!-- DDNS 設定 -->
   <div class="card mb-3">
@@ -392,7 +424,7 @@ $globalhost_val = array_key_exists('globalhost', $config_ini)
           <div>
             <label class="form-label small">IP</label>
             <input type="text" name="ip" class="form-control form-control-sm font-monospace" style="width:130px;"
-              value="<?= htmlspecialchars($_SERVER['SERVER_ADDR'] ?? '', ENT_QUOTES, 'UTF-8') ?>" />
+              value="<?= htmlspecialchars($local_ip_for_ddns, ENT_QUOTES, 'UTF-8') ?>" />
           </div>
           <input type="hidden" name="ttl" value="30">
           <input type="hidden" name="autoreturn" value="1">
@@ -413,7 +445,7 @@ $globalhost_val = array_key_exists('globalhost', $config_ini)
           <div>
             <label class="form-label small">IP</label>
             <input type="text" name="IPV4ADDR" class="form-control form-control-sm font-monospace" style="width:120px;"
-              value="<?= htmlspecialchars($_SERVER['SERVER_ADDR'] ?? '', ENT_QUOTES, 'UTF-8') ?>" />
+              value="<?= htmlspecialchars($local_ip_for_ddns, ENT_QUOTES, 'UTF-8') ?>" />
           </div>
           <button type="submit" class="btn btn-sm btn-secondary mb-0">更新</button>
         </form>
@@ -421,12 +453,55 @@ $globalhost_val = array_key_exists('globalhost', $config_ini)
     </div>
   </div>
 
-  <!-- 設定ページへ戻る -->
-  <div class="d-grid mt-2">
-    <a href="init.php" class="btn btn-outline-secondary btn-sm player-refresh-btn">
-      設定ページへ戻る
-    </a>
+  <!-- 自IP一覧 -->
+  <div class="card mb-3">
+    <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">自IP一覧</div>
+    <div class="card-body">
+      <div style="font-family: monospace; white-space: pre-wrap; word-break: break-all; font-size: 0.875rem;">
+      <?php
+      require_once 'ipconfig.php';
+      $result_ipconfig = getiplist();
+      foreach ($result_ipconfig as $ifinfo) {
+          $count = 0;
+          foreach ($ifinfo as $ips) {
+              if ($count != 0) {
+                  if (strpos($ips, ':') !== false) {
+                      $ips = '[' . substr($ips, 0, strpos($ips, '%')) . ']';
+                  }
+                  if (!empty($ips)) {
+                      $link = 'http://' . $ips . '/';
+                      if (array_key_exists('useeasyauth_word', $config_ini) && !empty($config_ini['useeasyauth_word'])) {
+                          $link = $link . '?easypass=' . $config_ini['useeasyauth_word'];
+                      }
+                      echo '<a href="' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '" target="_blank">' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '</a>' . "\n";
+                  }
+              }
+              $count++;
+          }
+      }
+      ?>
+      </div>
+    </div>
   </div>
+
+  <!-- 操作ボタン -->
+  <div class="card mb-3">
+    <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">操作ボタン</div>
+    <div class="card-body">
+      <div class="d-grid">
+        <a href="init.php" class="btn btn-outline-secondary">
+          設定ページへ戻る
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <!-- 設定を保存ボタン -->
+  <div class="d-grid mb-3">
+    <button type="submit" class="btn btn-primary btn-lg">設定を保存</button>
+  </div>
+
+  </form><!-- /設定フォーム -->
 
 </div><!-- /container -->
 
@@ -533,14 +608,27 @@ document.getElementById('check-debug-btn').addEventListener('click', function() 
         .finally(function() { btn.disabled = false; btn.textContent = '詳細診断'; });
 });
 
-// pfwdconfig フォームの AJAX 送信（ページ遷移なし）
-var pfwdconfigForm = document.getElementById('pfwdconfig');
-if (pfwdconfigForm) {
-    pfwdconfigForm.addEventListener('submit', function(event) {
+// pfwdconfig-openport フォームの AJAX 送信（ページ遷移なし）
+var pfwdconfigOpenportForm = document.getElementById('pfwdconfig-openport');
+if (pfwdconfigOpenportForm) {
+    pfwdconfigOpenportForm.addEventListener('submit', function(event) {
         event.preventDefault();
         fetch(this.action, { method: 'POST', body: new FormData(this) })
             .then(function() {
-                var btn = pfwdconfigForm.querySelector('[type=submit]');
+                var btn = pfwdconfigOpenportForm.querySelector('[type=submit]');
+                if (btn) { var orig = btn.textContent; btn.textContent = '保存しました'; setTimeout(function(){ btn.textContent = orig; }, 2000); }
+            });
+    });
+}
+
+// pfwdconfig-host フォームの AJAX 送信（ページ遷移なし）
+var pfwdconfigHostForm = document.getElementById('pfwdconfig-host');
+if (pfwdconfigHostForm) {
+    pfwdconfigHostForm.addEventListener('submit', function(event) {
+        event.preventDefault();
+        fetch(this.action, { method: 'POST', body: new FormData(this) })
+            .then(function() {
+                var btn = pfwdconfigHostForm.querySelector('[type=submit]');
                 if (btn) { var orig = btn.textContent; btn.textContent = '保存しました'; setTimeout(function(){ btn.textContent = orig; }, 2000); }
             });
     });

--- a/pfwd_settings.php
+++ b/pfwd_settings.php
@@ -254,7 +254,7 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
   <div class="card mb-3">
     <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">pfwd 制御</div>
     <div class="card-body">
-      <div id="pfwd-online-alert" class="alert alert-warning py-2 small <?= ($wg_running && !$pfwd_running) ? '' : 'd-none' ?>" role="alert">
+      <div id="pfwd-online-alert" class="alert alert-warning py-2 small d-none" role="alert">
         WireGuard 実行中のためオンライン接続済みです。pfwd は起動しないでください。
       </div>
       <div class="d-flex align-items-center gap-2 mb-3">
@@ -265,7 +265,7 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
       </div>
       <div class="d-flex gap-2">
         <button type="button" id="pfwd-start-btn" class="btn btn-success btn-lg flex-fill"
-          <?= ($wg_running && !$pfwd_running) ? 'disabled' : '' ?> onclick="start_pfwdcmd()">起動</button>
+          onclick="start_pfwdcmd()">起動</button>
         <button type="button" class="btn btn-danger btn-lg flex-fill" onclick="stop_pfwdcmd()">停止</button>
       </div>
     </div>
@@ -508,14 +508,23 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
 <?php print_bg_style_block(true); ?>
 
 <script>
-var pfwdRunning = <?= $pfwdavailable && $pfwd_running ? 'true' : 'false' ?>;
-var wgRunning   = <?= $wg_running ? 'true' : 'false' ?>;
+var pfwdRunning  = <?= $pfwdavailable && $pfwd_running ? 'true' : 'false' ?>;
+var wgRunning    = <?= $wg_running ? 'true' : 'false' ?>;
+var onlineStatus = 'unknown'; // 'ok' | 'ng' | 'disabled' | 'unknown'
 
 function applyPfwdRestriction(pfwdIsRunning) {
-    var startBtn    = document.getElementById('pfwd-start-btn');
-    var onlineAlert = document.getElementById('pfwd-online-alert');
+    var startBtn       = document.getElementById('pfwd-start-btn');
+    var onlineAlert    = document.getElementById('pfwd-online-alert');
+    var autoRestartYes = document.getElementById('pfwdcheck_yes');
+
+    // pfwd 自動再起動「使用する」: オンライン接続OKの時のみ有効
+    if (autoRestartYes) {
+        autoRestartYes.disabled = (onlineStatus !== 'ok');
+    }
+
     if (!startBtn) return;
-    if (wgRunning && !pfwdIsRunning) {
+    // pfwd起動制限: オンラインOK かつ WireGuard実行中 かつ pfwd停止中の場合のみ
+    if (onlineStatus === 'ok' && wgRunning && !pfwdIsRunning) {
         startBtn.disabled = true;
         if (onlineAlert) onlineAlert.classList.remove('d-none');
     } else {
@@ -560,17 +569,23 @@ function checkOnline() {
             var infoText = (data.check_url ? '確認先: ' + data.check_url : '') +
                            (data.detail ? '  [' + data.detail + ']' : '');
             if (data.status === 'ok') {
+                onlineStatus = 'ok';
                 el.textContent = 'OK'; el.className = 'badge bg-success';
             } else if (data.status === 'ng') {
+                onlineStatus = 'ng';
                 el.textContent = 'NG'; el.className = 'badge bg-danger';
             } else {
+                onlineStatus = 'disabled';
                 el.textContent = '無効'; el.className = 'badge bg-secondary';
             }
             if (detailEl) detailEl.textContent = infoText || data.detail;
+            applyPfwdRestriction(pfwdRunning);
         })
         .catch(function() {
+            onlineStatus = 'unknown';
             el.textContent = 'エラー'; el.className = 'badge bg-danger';
             if (detailEl) detailEl.textContent = 'AJAX通信エラー';
+            applyPfwdRestriction(pfwdRunning);
         });
 }
 

--- a/pfwd_settings.php
+++ b/pfwd_settings.php
@@ -145,13 +145,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_config'])) {
     }
     writeconfig2ini($config_ini, $configfile);
 
-    // globalhost のポートを pfwd.ini の openport に反映
+    // globalhost のホスト名とポートを pfwd.ini に反映
     if (!empty($_POST['globalhost'])) {
         $gh       = trim($_POST['globalhost']);
         $colonIdx = strrpos($gh, ':');
         if ($colonIdx !== false) {
-            $newPort = substr($gh, $colonIdx + 1);
-            if (ctype_digit($newPort)) {
+            $hostname = substr($gh, 0, $colonIdx);
+            $newPort  = substr($gh, $colonIdx + 1);
+            if (ctype_digit($newPort) && !empty($hostname)) {
                 $pfwdplace_post = isset($_POST['pfwdplace']) && $_POST['pfwdplace'] !== ''
                     ? $_POST['pfwdplace']
                     : (array_key_exists('pfwdplace', $config_ini) ? urldecode($config_ini['pfwdplace']) : 'pfwd_forykr\\');
@@ -161,6 +162,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_config'])) {
                 $ok = $pfwdinfo_save->readpfwdcfg();
                 ob_end_clean();
                 if ($ok) {
+                    $pfwdinfo_save->set_pfwdhost($hostname);
                     $pfwdinfo_save->set_pfwdopenport($newPort);
                     $pfwdinfo_save->save_pfwdconfig();
                 }
@@ -493,8 +495,7 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
   <div class="card mb-3">
     <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">自IP一覧</div>
     <div class="card-body">
-      <div style="font-family: monospace; white-space: pre-wrap; word-break: break-all; font-size: 0.875rem;">
-      <?php
+      <div style="font-family: monospace; white-space: pre-wrap; word-break: break-all; font-size: 0.875rem;"><?php
       require_once 'ipconfig.php';
       $result_ipconfig = getiplist();
       $ips_to_show = array(); // 重複排除用
@@ -525,7 +526,8 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
           }
       }
 
-      // リンク生成
+      // リンク生成（バッファに集める）
+      $link_output = '';
       foreach ($ips_to_show as $ip) {
           $is_ipv6 = (strpos($ip, ':') !== false);
           $url_ip = $is_ipv6 ? '[' . $ip . ']' : $ip;
@@ -533,10 +535,10 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
           if (array_key_exists('useeasyauth_word', $config_ini) && !empty($config_ini['useeasyauth_word'])) {
               $link = $link . '?easypass=' . $config_ini['useeasyauth_word'];
           }
-          echo '<a href="' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '" target="_blank">' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '</a>' . "\n";
+          $link_output .= '<a href="' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '" target="_blank">' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '</a>' . "\n";
       }
-      ?>
-      </div>
+      echo $link_output;
+      ?></div>
     </div>
   </div>
 

--- a/pfwdctl.php
+++ b/pfwdctl.php
@@ -93,36 +93,47 @@ EOT;
 
 
     public function set_pfwdhost($hoststring){
-        $replaceline = false;
+        $found = false;
         foreach($this->pfwdini as $key => $line){
             if(substr($line,0,5) === 'Host=' ) {
-                $replaceline = $line;
-                $this->pfwdini[$key] = str_replace($replaceline,'Host='.$hoststring,$line);
+                // 単純に Host= から = の後ろだけを置換
+                $this->pfwdini[$key] = 'Host='.$hoststring;
+                $found = true;
                 break;
             }
+        }
+        // Host= が見つからない場合は新規追加
+        if (!$found) {
+            $this->pfwdini[] = 'Host='.$hoststring;
         }
         return $this->pfwdini;
     }
     public function set_pfwdport($portstring){
-        $replaceline = false;
+        $found = false;
         foreach($this->pfwdini as $key => $line){
             if(substr($line,0,5) === 'Port=' ) {
-                $replaceline = $line;
-                $this->pfwdini[$key] = str_replace($replaceline,'Port='.$portstring,$line);
+                $this->pfwdini[$key] = 'Port='.$portstring;
+                $found = true;
                 break;
             }
+        }
+        if (!$found) {
+            $this->pfwdini[] = 'Port='.$portstring;
         }
         return $this->pfwdini;
     }
 
     public function set_pfwdopenport($portstring){
-        $replaceline = false;
+        $found = false;
         foreach($this->pfwdini as $key => $line){
             if(substr($line,0,4) === '01=R' ) {
-                $replaceline = $line;
-                $this->pfwdini[$key] = str_replace($replaceline,'01=R'.$portstring.':localhost:80',$line);
+                $this->pfwdini[$key] = '01=R'.$portstring.':localhost:80';
+                $found = true;
                 break;
             }
+        }
+        if (!$found) {
+            $this->pfwdini[] = '01=R'.$portstring.':localhost:80';
         }
         return $this->pfwdini;
     }

--- a/playerctrl_portal.php
+++ b/playerctrl_portal.php
@@ -59,15 +59,16 @@ if( strcmp('foobar', $playerkind) === 0 ) {
     include('mpcctrl.php');
 }
 
-if(array_key_exists("autoplay_exec",$config_ini)) {
-    if(!empty($config_ini["autoplay_exec"])){
-        if(array_key_exists("autoplay_show",$config_ini)) {
-            if($config_ini["autoplay_show"]==1){
-            print '<div align="center">';
-            print '<button type="button" class="btn btn-default btn-lg" onclick="location.href=\'autoplayctrl.php\'" >自動実行開始、停止ページへ</button>';
-            print '</div>';
-            }
-        }
+if (array_key_exists("autoplay_exec", $config_ini) && !empty($config_ini["autoplay_exec"])) {
+    $is_localhost = (isset($_SERVER['REMOTE_ADDR']) &&
+        ($_SERVER['REMOTE_ADDR'] === '127.0.0.1' || $_SERVER['REMOTE_ADDR'] === '::1'));
+    $is_admin = ($user === 'admin');
+    $autoplay_show_enabled = (array_key_exists("autoplay_show", $config_ini) && $config_ini["autoplay_show"] == 1);
+
+    if ($is_admin || $is_localhost || $autoplay_show_enabled) {
+        print '<div align="center">';
+        print '<button type="button" class="btn btn-default btn-lg" onclick="location.href=\'autoplayctrl.php\'" >自動実行開始、停止ページへ</button>';
+        print '</div>';
     }
 }
 

--- a/playerctrl_portal_bs5.php
+++ b/playerctrl_portal_bs5.php
@@ -39,13 +39,17 @@ if (strcmp('foobar', $playerkind) === 0) {
     include('mpcctrl_bs5.php');
 }
 
-if (
-    array_key_exists('autoplay_exec', $config_ini) && !empty($config_ini['autoplay_exec']) &&
-    array_key_exists('autoplay_show', $config_ini) && $config_ini['autoplay_show'] == 1
-) {
-    echo '<div class="d-grid mt-2">';
-    echo '<a href="autoplayctrl.php" class="btn btn-outline-secondary btn-lg">自動実行開始・停止ページへ</a>';
-    echo '</div>';
+if (array_key_exists('autoplay_exec', $config_ini) && !empty($config_ini['autoplay_exec'])) {
+    $is_localhost = (isset($_SERVER['REMOTE_ADDR']) &&
+        ($_SERVER['REMOTE_ADDR'] === '127.0.0.1' || $_SERVER['REMOTE_ADDR'] === '::1'));
+    $is_admin = ($user === 'admin');
+    $autoplay_show_enabled = (array_key_exists('autoplay_show', $config_ini) && $config_ini['autoplay_show'] == 1);
+
+    if ($is_admin || $is_localhost || $autoplay_show_enabled) {
+        echo '<div class="d-grid mt-2">';
+        echo '<a href="autoplayctrl.php" class="btn btn-outline-secondary btn-lg">自動実行開始・停止ページへ</a>';
+        echo '</div>';
+    }
 }
 ?>
 


### PR DESCRIPTION
## Summary

pfwd_settings.php のフォーム送信に関する2つの問題を修正しました。

### 修正内容

1. **DDNSフォームのネストによるフォーム送信失敗を修正**
   - DDNS設定の `<form>` 要素が `pfwd-main-form` の内側にネストされていたため、ブラウザが外側フォームを途中で閉じてしまう問題
   - `pfwd-main-form` をDDNSカードより前で閉じ、「設定反映」ボタンを移動してフォームが正常に送信されるよう修正

2. **ナビバーの「設定反映」ボタンが機能しない問題を修正**
   - `shownavigatioinbar_bs5('init.php')` によってナビバーに表示される「設定反映」ボタン（`document.allconfig.submit()` を実行）が、フォームに `name="allconfig"` がないため動作していなかった問題
   - フォームに `name="allconfig"` を追加して接続を修正

### 動作検証

- ユーザー接続ポート・pfwd接続ポートの設定が pfwd.ini に正常に反映される
- ナビバーおよびフォーム内の「設定反映」ボタンの両方で設定が保存される

### 関連チケット

https://claude.ai/code/session_0167CKvwMPxryxkucgZNheKi

---
_Generated by [Claude Code](https://claude.ai/code/session_0167CKvwMPxryxkucgZNheKi)_