### PR TITLE
背景画像: PC/スマホ別画像・クロップ機能・iOS固定表示・透過視認性の改善

### DIFF
--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1896,8 +1896,10 @@ function print_bg_style_block($is_bs5 = false) {
         print 'html::before{content:"";position:fixed;inset:0;z-index:-2;pointer-events:none;'
             . 'filter:none !important;'
             . 'background-image:var(--bg-page-image);background-size:cover;background-position:center;}';
-        // スマホ幅では専用画像(未設定時は PC 用にフォールバック済み)に切り替える。
-        print '@media (max-width:768px){html::before{background-image:var(--bg-page-image-mobile);}}';
+        // スマホ縦持ち(縦長表示)のときだけ専用画像に切り替える。
+        // orientation:portrait を条件に加えることで、小型端末を横持ちにした際
+        // (幅が 768px 以下のままでも)は PC 用の横長画像が使われるようにする。
+        print '@media (max-width:768px) and (orientation:portrait){html::before{background-image:var(--bg-page-image-mobile);}}';
         // body や外部 CSS (search.css / player.css / mypage インラインスタイル) が
         // body に background-image を設定すると html::before を隠してしまうため、
         // body 側の画像指定は明示的に無効化して html::before レイヤーに一本化する。

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1889,18 +1889,21 @@ function print_bg_style_block($is_bs5 = false) {
     print '<style>:root{' . implode('', $vars) . '}';
 
     if ($has_bgimage) {
-        // body 側に背景画像を貼り、body::before はオーバーレイ色のみに分離する。
-        // これによりダークモードの body::before に掛かる brightness フィルタが
-        // 背景画像を暗くするのを防ぐ(画像本体は body 直下に置くため影響を受けない)。
+        // html::before = 固定背景画像レイヤー。
+        // iOS Safari は body の background-attachment:fixed をサポートしていないため、
+        // position:fixed の疑似要素で代替することで全ブラウザ・全デバイスで背景を固定する。
         print 'html,body{background-color:transparent !important;}';
-        print 'body{background-image:var(--bg-page-image) !important;'
-            . 'background-size:cover;background-attachment:fixed;background-position:center;}';
-        // theme-toggle.css の [data-theme="dark"] body { background-image: none !important }
-        // を同一詳細度・後優先で上書きして、ダークモードでも背景画像を表示させる。
-        print '[data-theme="dark"] body{background-image:var(--bg-page-image) !important;}';
-        // スマホ(縦長)幅では専用画像に切り替える(未設定時は PC 用にフォールバック済み)。
-        print '@media (max-width:768px){'
-            . 'body,[data-theme="dark"] body{background-image:var(--bg-page-image-mobile) !important;}}';
+        print 'html::before{content:"";position:fixed;inset:0;z-index:-2;pointer-events:none;'
+            . 'filter:none !important;'
+            . 'background-image:var(--bg-page-image);background-size:cover;background-position:center;}';
+        // スマホ幅では専用画像(未設定時は PC 用にフォールバック済み)に切り替える。
+        print '@media (max-width:768px){html::before{background-image:var(--bg-page-image-mobile);}}';
+        // body や外部 CSS (search.css / player.css / mypage インラインスタイル) が
+        // body に background-image を設定すると html::before を隠してしまうため、
+        // body 側の画像指定は明示的に無効化して html::before レイヤーに一本化する。
+        print 'body{background-image:none !important;}';
+        // body::before = オーバーレイ色レイヤー。画像レイヤー(z-index:-2)の上に重ねる。
+        // ダークモードの brightness フィルタが背景画像に影響しないよう filter:none を指定。
         print 'body::before{content:"";position:fixed;inset:0;z-index:-1;pointer-events:none;'
             . 'background-image:none !important;'
             . 'background-color:rgba(var(--bg-page-rgb, 248, 236, 224), var(--bg-overlay-alpha, 1));'
@@ -1912,22 +1915,30 @@ function print_bg_style_block($is_bs5 = false) {
     }
 
     if ($has_bgimage && $card_alpha < 1.0) {
-        // カード系コンポーネントを透過させる(BS3 + BS5 + 本アプリ独自クラス)
+        // カード系コンポーネントを透過させる(BS3 + BS5 + 本アプリ独自クラス)。
         // .request-card は requestlist_swipe.php 側で per-status の rgba を持つため除外。
+        // .modal-content は別途不透明で上書きするためここには含めない。
+        // .badge は小さいステータス表示のため除外(.bg-info:not(.badge) 等で限定)。
         // フォールバック値を持たせて _variables.css 未ロード時(BS3)でも有効化。
         $card_bg = 'rgba(var(--bg-card-rgb, 255, 255, 255), var(--bg-card-alpha, 1))';
         print '.panel,.panel-default,.panel-body,.panel-heading,.panel-footer,'
-            . '.bg-info,.bg-light,.bg-white,.well,.alert,'
+            . '.bg-info:not(.badge),.bg-light:not(.badge),.bg-white,.well,.alert,'
             . '.card,.card-body,.card-header,.card-footer,'
             . '.list-group-item,.dropdown-menu,'
             . '.accordion-item,.accordion-body,.accordion-button,'
-            . '.modal-content,'
             . '.player-nowplaying,#stats-bar,'
             . '.dataTables_wrapper > .dataTable, table.dataTable tbody tr{'
             . 'background-color:' . $card_bg . ' !important;'
             . 'background-image:none !important;}';
-        // 背景色をインラインで持つ既存スタイル(bg-info の青 等)を直接上書きするための補強
-        print '.bg-info{background-color:' . $card_bg . ' !important;}';
+        // 背景色をインラインで持つ既存スタイル(bg-info の青 等)を直接上書きするための補強。
+        // バッジは除外して常に Bootstrap 本来の色を維持する。
+        print '.bg-info:not(.badge){background-color:' . $card_bg . ' !important;}';
+        // モーダル・ダイアログは透過させない。背景画像が透けると文字が読みにくくなるため、
+        // カード透過度の設定にかかわらず常に不透明な背景で表示する。
+        $card_bg_opaque = 'rgba(var(--bg-card-rgb, 255, 255, 255), 1)';
+        print '.modal-content{'
+            . 'background-color:' . $card_bg_opaque . ' !important;'
+            . 'background-image:none !important;}';
 
         // BS5 ページのみ: テーブル・フォームコントロール等の白抜き要素も透過対象に含める。
         // BS3 ページで .table や .form-control が登場するページに副作用が出るのを避けるため、

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1856,10 +1856,19 @@ function print_bg_style_block($is_bs5 = false) {
     // 背景画像機能は BS5 ページのみ対象。BS3 ページでは $has_bgimage を false のまま維持する。
     $has_bgimage = false;
     $bgimg_url = '';
+    $bgimg_mobile_url = '';
     if ($is_bs5 && array_key_exists("bgimage", $config_ini) && !empty($config_ini["bgimage"])) {
         $bgimg_url = htmlspecialchars(urldecode($config_ini["bgimage"]), ENT_QUOTES, 'UTF-8');
         $vars[] = '--bg-page-image:url(\'' . $bgimg_url . '\');';
         $has_bgimage = true;
+    }
+    if ($is_bs5 && array_key_exists("bgimage_mobile", $config_ini) && !empty($config_ini["bgimage_mobile"])) {
+        $bgimg_mobile_url = htmlspecialchars(urldecode($config_ini["bgimage_mobile"]), ENT_QUOTES, 'UTF-8');
+    }
+    // スマホ用が未設定なら PC 用画像で代替する。
+    if ($has_bgimage) {
+        $mobile_css_url = ($bgimg_mobile_url !== '') ? $bgimg_mobile_url : $bgimg_url;
+        $vars[] = '--bg-page-image-mobile:url(\'' . $mobile_css_url . '\');';
     }
 
     $overlay_alpha = 1.0;
@@ -1889,6 +1898,9 @@ function print_bg_style_block($is_bs5 = false) {
         // theme-toggle.css の [data-theme="dark"] body { background-image: none !important }
         // を同一詳細度・後優先で上書きして、ダークモードでも背景画像を表示させる。
         print '[data-theme="dark"] body{background-image:var(--bg-page-image) !important;}';
+        // スマホ(縦長)幅では専用画像に切り替える(未設定時は PC 用にフォールバック済み)。
+        print '@media (max-width:768px){'
+            . 'body,[data-theme="dark"] body{background-image:var(--bg-page-image-mobile) !important;}}';
         print 'body::before{content:"";position:fixed;inset:0;z-index:-1;pointer-events:none;'
             . 'background-image:none !important;'
             . 'background-color:rgba(var(--bg-page-rgb, 248, 236, 224), var(--bg-overlay-alpha, 1));'

--- a/init.php
+++ b/init.php
@@ -27,35 +27,57 @@ $easyauth -> do_eashauthcheck();
 $newconfig = $_REQUEST;
 
 // 背景画像のアップロード/削除処理
+// クロップ済み画像はクライアントから data URL (base64) で送信される。
 $bgimage_upload_msg = '';
-if (isset($_FILES['bgimage_upload']) && is_array($_FILES['bgimage_upload']) && $_FILES['bgimage_upload']['error'] !== UPLOAD_ERR_NO_FILE) {
-    $f = $_FILES['bgimage_upload'];
-    if ($f['error'] === UPLOAD_ERR_OK && is_uploaded_file($f['tmp_name'])) {
-        $info = @getimagesize($f['tmp_name']);
-        $allowed = [IMAGETYPE_JPEG => 'jpg', IMAGETYPE_PNG => 'png', IMAGETYPE_GIF => 'gif', IMAGETYPE_WEBP => 'webp'];
-        if ($info !== false && isset($allowed[$info[2]])) {
-            $ext = $allowed[$info[2]];
-            $bgdir = __DIR__ . '/images/bg';
-            if (!is_dir($bgdir)) { @mkdir($bgdir, 0777, true); }
-            $name = 'bg_' . date('YmdHis') . '_' . substr(bin2hex(random_bytes(4)),0,8) . '.' . $ext;
-            $dest = $bgdir . '/' . $name;
-            if (@move_uploaded_file($f['tmp_name'], $dest)) {
-                $newconfig['bgimage'] = 'images/bg/' . $name;
-                $bgimage_upload_msg = '背景画像をアップロードしました: ' . $name;
-            } else {
-                $bgimage_upload_msg = '背景画像の保存に失敗しました';
-            }
-        } else {
-            $bgimage_upload_msg = '画像ファイル (JPEG/PNG/GIF/WebP) を指定してください';
-        }
-    } else {
-        $bgimage_upload_msg = 'アップロードに失敗しました (code:' . $f['error'] . ')';
+
+// data URL を images/bg/ に保存し、相対パスを返す。失敗時は null。
+function save_bg_dataurl($dataurl, &$msg, $label) {
+    if (!is_string($dataurl) || $dataurl === '') return null;
+    if (!preg_match('#^data:image/(jpeg|png|webp|gif);base64,#', $dataurl, $m)) {
+        $msg = $label . 'の画像形式が不正です';
+        return null;
     }
+    $ext_map = ['jpeg' => 'jpg', 'png' => 'png', 'webp' => 'webp', 'gif' => 'gif'];
+    $ext = $ext_map[$m[1]];
+    $bin = base64_decode(substr($dataurl, strpos($dataurl, ',') + 1), true);
+    if ($bin === false) { $msg = $label . 'のデコードに失敗しました'; return null; }
+    if (@getimagesizefromstring($bin) === false) { $msg = $label . 'の画像を認識できませんでした'; return null; }
+    $bgdir = __DIR__ . '/images/bg';
+    if (!is_dir($bgdir)) { @mkdir($bgdir, 0777, true); }
+    $name = 'bg_' . date('YmdHis') . '_' . substr(bin2hex(random_bytes(4)), 0, 8) . '.' . $ext;
+    if (@file_put_contents($bgdir . '/' . $name, $bin) === false) {
+        $msg = $label . 'の保存に失敗しました';
+        return null;
+    }
+    return 'images/bg/' . $name;
 }
-if (isset($_REQUEST['bgimage_delete']) && $_REQUEST['bgimage_delete'] == '1') {
-    $newconfig['bgimage'] = '';
-    if (isset($newconfig['bgimage_delete'])) unset($newconfig['bgimage_delete']);
-    $bgimage_upload_msg = '背景画像をクリアしました';
+
+// PC用・スマホ用のクロップ結果を保存
+foreach ([
+    'bgimage_data'        => ['bgimage',        'PC用背景画像'],
+    'bgimage_mobile_data' => ['bgimage_mobile', 'スマホ用背景画像'],
+] as $field => $meta) {
+    if (isset($_REQUEST[$field]) && $_REQUEST[$field] !== '') {
+        $saved = save_bg_dataurl($_REQUEST[$field], $bgimage_upload_msg, $meta[1]);
+        if ($saved !== null) {
+            $newconfig[$meta[0]] = $saved;
+            $bgimage_upload_msg = $meta[1] . 'を保存しました';
+        }
+    }
+    // 一時フィールドは config.ini に書き込まない
+    unset($newconfig[$field]);
+}
+
+// 削除処理
+foreach ([
+    'bgimage_delete'        => ['bgimage',        'PC用背景画像'],
+    'bgimage_mobile_delete' => ['bgimage_mobile', 'スマホ用背景画像'],
+] as $field => $meta) {
+    if (isset($_REQUEST[$field]) && $_REQUEST[$field] == '1') {
+        $newconfig[$meta[0]] = '';
+        $bgimage_upload_msg = $meta[1] . 'をクリアしました';
+    }
+    unset($newconfig[$field]);
 }
 
 
@@ -112,6 +134,19 @@ if(array_key_exists("clearauth", $_REQUEST)) {
   font-size: 1.3rem;
   font-weight: 700;
   margin-top: 0;
+}
+/* 背景画像クロッパー */
+.bgimg-thumb { max-width: 160px; max-height: 120px; border: 1px solid #ccc; }
+.bgimg-viewport {
+  position: relative; overflow: hidden; background: #222;
+  touch-action: none; margin: 6px 0; border: 1px solid #ccc;
+  max-width: 100%;
+}
+.bgimg-block[data-target="pc"]     .bgimg-viewport { width: 320px; height: 180px; }
+.bgimg-block[data-target="mobile"] .bgimg-viewport { width: 180px; height: 320px; }
+.bgimg-cropimg {
+  position: absolute; top: 0; left: 0;
+  max-width: none; user-select: none; -webkit-user-drag: none; pointer-events: none;
 }
 </style>
 <script>
@@ -695,6 +730,10 @@ print ' value="10" ';
       if (array_key_exists("bgimage", $config_ini)) {
           $bgimage_path = urldecode($config_ini["bgimage"]);
       }
+      $bgimage_mobile_path = '';
+      if (array_key_exists("bgimage_mobile", $config_ini)) {
+          $bgimage_mobile_path = urldecode($config_ini["bgimage_mobile"]);
+      }
       $bg_card_opacity = 100;
       if (array_key_exists("bg_card_opacity", $config_ini)) {
           $bg_card_opacity = (int)$config_ini["bg_card_opacity"];
@@ -709,32 +748,67 @@ print ' value="10" ';
 <div class="card cfg-card mb-4"><div class="card-body">
   <div class="mb-3">
     <h3 id="bgimage_t" class="radio form-label menulink"> 背景画像 </h3>
-    <label><small>画面全体の背景に画像を表示します。透過度で見やすさを調整できます。</small></label>
+    <label><small>画面全体の背景に画像を表示します。PC(横長)とスマホ(縦長)で別々の画像を登録でき、アップロード時に切り抜き範囲を調整できます。スマホ用が未設定のときはPC用画像が使われます。</small></label>
     <?php if (!empty($bgimage_upload_msg)) { ?>
       <div class="alert alert-info" style="margin-top:6px;"><?php echo htmlspecialchars($bgimage_upload_msg, ENT_QUOTES, 'UTF-8'); ?></div>
     <?php } ?>
-    <?php if (!empty($bgimage_path)) { ?>
-      <div style="margin:6px 0;">
-        現在の背景画像: <code><?php echo htmlspecialchars($bgimage_path, ENT_QUOTES, 'UTF-8'); ?></code><br>
-        <img src="<?php echo htmlspecialchars($bgimage_path, ENT_QUOTES, 'UTF-8'); ?>" alt="背景画像プレビュー" style="max-width:280px; max-height:160px; border:1px solid #ccc; margin-top:4px;">
-      </div>
-    <?php } else { ?>
-      <div style="margin:6px 0;"><small>背景画像は未設定です。</small></div>
-    <?php } ?>
 
-    <div style="margin:8px 0;">
-      <label><small>背景画像ファイル(アップロード時に置き換え):</small></label>
-      <input type="file" name="bgimage_upload" accept="image/png,image/jpeg,image/gif,image/webp" />
-    </div>
-    <?php if (!empty($bgimage_path)) { ?>
-      <div style="margin:8px 0;">
-        <label class="checkbox-inline">
-          <input type="checkbox" name="bgimage_delete" value="1" /> 背景画像をクリアする (設定反映で適用)
-        </label>
+    <div class="row">
+      <?php
+        // PC用・スマホ用の2ブロックを共通テンプレートで描画
+        $bg_blocks = [
+            ['target' => 'pc',     'aspect' => 16/9, 'title' => 'PC用背景画像 (横長)',  'path' => $bgimage_path,        'field' => 'bgimage'],
+            ['target' => 'mobile', 'aspect' => 9/16, 'title' => 'スマホ用背景画像 (縦長)', 'path' => $bgimage_mobile_path, 'field' => 'bgimage_mobile'],
+        ];
+        foreach ($bg_blocks as $blk):
+          $cur = htmlspecialchars($blk['path'], ENT_QUOTES, 'UTF-8');
+      ?>
+      <div class="col-md-6 mb-3 bgimg-block" data-target="<?php echo $blk['target']; ?>" data-aspect="<?php echo round($blk['aspect'], 4); ?>">
+        <h4 style="font-size:1rem;font-weight:600;"><?php echo htmlspecialchars($blk['title'], ENT_QUOTES, 'UTF-8'); ?></h4>
+        <?php if (!empty($blk['path'])) { ?>
+          <div class="bgimg-current" style="margin:4px 0;">
+            <small>現在: <code><?php echo $cur; ?></code></small><br>
+            <img src="<?php echo $cur; ?>" alt="現在の背景画像" class="bgimg-thumb">
+          </div>
+        <?php } else { ?>
+          <div class="bgimg-current" style="margin:4px 0;"><small>未設定</small></div>
+        <?php } ?>
+
+        <div style="margin:6px 0;">
+          <input type="file" class="bgimg-file form-control form-control-sm" accept="image/png,image/jpeg,image/gif,image/webp" />
+        </div>
+
+        <div class="bgimg-cropper" hidden>
+          <div class="bgimg-viewport">
+            <img class="bgimg-cropimg" alt="" />
+          </div>
+          <div style="margin:6px 0;">
+            <label><small>拡大</small></label>
+            <input type="range" class="bgimg-zoom" min="1" max="4" step="0.01" value="1" style="width:100%;" />
+          </div>
+          <button type="button" class="btn btn-primary btn-sm bgimg-ok">この範囲で切り抜く</button>
+          <button type="button" class="btn btn-secondary btn-sm bgimg-cancel">キャンセル</button>
+          <div><small class="text-muted">画像をドラッグして位置を調整、スライダーで拡大できます。</small></div>
+        </div>
+
+        <div class="bgimg-result" style="margin:6px 0;" hidden>
+          <small class="text-success">切り抜き済み (設定反映で保存):</small><br>
+          <img alt="切り抜きプレビュー" class="bgimg-thumb" />
+        </div>
+
+        <?php if (!empty($blk['path'])) { ?>
+          <div style="margin:6px 0;">
+            <label class="checkbox-inline">
+              <input type="checkbox" class="bgimg-delete" name="<?php echo $blk['field']; ?>_delete" value="1" /> クリアする (設定反映で適用)
+            </label>
+          </div>
+        <?php } ?>
+
+        <input type="hidden" class="bgimg-data" name="<?php echo $blk['field']; ?>_data" value="" />
+        <input type="hidden" name="<?php echo $blk['field']; ?>" value="<?php echo $cur; ?>" />
       </div>
-    <?php } ?>
-    <!-- 現在のbgimage値を保持 -->
-    <input type="hidden" name="bgimage" value="<?php echo htmlspecialchars($bgimage_path, ENT_QUOTES, 'UTF-8'); ?>" />
+      <?php endforeach; ?>
+    </div>
 
     <div class="mb-3" style="margin-top:10px;">
       <label for="bg_card_opacity"><small>カード透過度: <span id="bg_card_opacity_val"><?php echo $bg_card_opacity; ?></span>%</small></label>
@@ -769,6 +843,107 @@ print ' value="10" ';
           document.getElementById(id).addEventListener('change', updateBgPreview);
       });
       updateBgPreview();
+  })();
+  </script>
+
+  <script>
+  // 背景画像クロッパー: 固定アスペクト比のビューポート内で画像をパン/ズームし、
+  // 確定時に canvas で切り抜いて data URL を hidden フィールドに格納する。
+  (function(){
+      function initCropper(block){
+          var aspect    = parseFloat(block.dataset.aspect);
+          var fileInput = block.querySelector('.bgimg-file');
+          var cropWrap  = block.querySelector('.bgimg-cropper');
+          var viewport  = block.querySelector('.bgimg-viewport');
+          var imgEl     = block.querySelector('.bgimg-cropimg');
+          var zoom      = block.querySelector('.bgimg-zoom');
+          var btnOk     = block.querySelector('.bgimg-ok');
+          var btnCancel = block.querySelector('.bgimg-cancel');
+          var dataInput = block.querySelector('.bgimg-data');
+          var resultBox = block.querySelector('.bgimg-result');
+          var resultImg = resultBox ? resultBox.querySelector('img') : null;
+          var deleteChk = block.querySelector('.bgimg-delete');
+
+          var natW = 0, natH = 0, minScale = 1, scale = 1, offX = 0, offY = 0;
+          var vw = 0, vh = 0, dragging = false, lastX = 0, lastY = 0, objUrl = null;
+
+          function clamp(){
+              var dispW = natW * scale, dispH = natH * scale;
+              if (offX > 0) offX = 0;
+              if (offX < vw - dispW) offX = vw - dispW;
+              if (offY > 0) offY = 0;
+              if (offY < vh - dispH) offY = vh - dispH;
+          }
+          function render(){
+              imgEl.style.width  = (natW * scale) + 'px';
+              imgEl.style.height = (natH * scale) + 'px';
+              imgEl.style.left   = offX + 'px';
+              imgEl.style.top    = offY + 'px';
+          }
+          fileInput.addEventListener('change', function(){
+              var f = fileInput.files && fileInput.files[0];
+              if (!f) return;
+              if (!/^image\//.test(f.type)) { alert('画像ファイルを選択してください'); return; }
+              if (objUrl) URL.revokeObjectURL(objUrl);
+              objUrl = URL.createObjectURL(f);
+              var im = new Image();
+              im.onload = function(){
+                  natW = im.naturalWidth; natH = im.naturalHeight;
+                  imgEl.src = objUrl;
+                  cropWrap.hidden = false; // 計測前に表示しないと幅が 0 になる
+                  vw = viewport.clientWidth; vh = viewport.clientHeight;
+                  minScale = Math.max(vw / natW, vh / natH);
+                  scale = minScale;
+                  zoom.value = 1;
+                  offX = (vw - natW * scale) / 2;
+                  offY = (vh - natH * scale) / 2;
+                  clamp(); render();
+              };
+              im.src = objUrl;
+          });
+          zoom.addEventListener('input', function(){
+              var cx = (vw / 2 - offX) / scale, cy = (vh / 2 - offY) / scale;
+              scale = minScale * parseFloat(zoom.value);
+              offX = vw / 2 - cx * scale;
+              offY = vh / 2 - cy * scale;
+              clamp(); render();
+          });
+          viewport.addEventListener('pointerdown', function(e){
+              dragging = true; lastX = e.clientX; lastY = e.clientY;
+              viewport.setPointerCapture(e.pointerId);
+          });
+          viewport.addEventListener('pointermove', function(e){
+              if (!dragging) return;
+              offX += e.clientX - lastX; offY += e.clientY - lastY;
+              lastX = e.clientX; lastY = e.clientY;
+              clamp(); render();
+          });
+          function endDrag(){ dragging = false; }
+          viewport.addEventListener('pointerup', endDrag);
+          viewport.addEventListener('pointercancel', endDrag);
+
+          btnCancel.addEventListener('click', function(){
+              cropWrap.hidden = true;
+              fileInput.value = '';
+              imgEl.removeAttribute('src');
+          });
+          btnOk.addEventListener('click', function(){
+              var sx = -offX / scale, sy = -offY / scale, sw = vw / scale, sh = vh / scale;
+              var outW, outH;
+              if (aspect >= 1) { outW = Math.min(1920, Math.round(sw)); outH = Math.round(outW / aspect); }
+              else             { outH = Math.min(1920, Math.round(sh)); outW = Math.round(outH * aspect); }
+              var c = document.createElement('canvas');
+              c.width = outW; c.height = outH;
+              c.getContext('2d').drawImage(imgEl, sx, sy, sw, sh, 0, 0, outW, outH);
+              var data = c.toDataURL('image/jpeg', 0.85);
+              dataInput.value = data;
+              if (resultImg) resultImg.src = data;
+              if (resultBox) resultBox.hidden = false;
+              cropWrap.hidden = true;
+              if (deleteChk) deleteChk.checked = false; // 新規画像を設定したのでクリアは解除
+          });
+      }
+      document.querySelectorAll('.bgimg-block').forEach(initCropper);
   })();
   </script>
 

--- a/init.php
+++ b/init.php
@@ -101,11 +101,14 @@ if(array_key_exists("clearauth", $_REQUEST)) {
 .cfg-card {
   margin-bottom: 1.25rem;
   border-left: 4px solid var(--bs-primary, #0d6efd);
+  background-color: rgba(var(--bg-card-rgb, 255, 255, 255), var(--bg-card-alpha, 1));
+  color: var(--color-text, #212529);
 }
 .cfg-card > .card-body { padding: 1rem 1.25rem; }
 .cfg-card .menulink { scroll-margin-top: 80px; }
-.cfg-card > .card-body > h1.menulink,
-.cfg-card > .card-body > h1:first-child {
+/* セクション見出し(h1/h3 を問わず)を統一書式に */
+.cfg-card h1.menulink,
+.cfg-card h3.menulink {
   font-size: 1.3rem;
   font-weight: 700;
   margin-top: 0;
@@ -656,9 +659,17 @@ print ' value="10" ';
 		</datalist>
   </div>
   <script>
-  document.getElementById('bgcolor').addEventListener('change', function(){
-      document.body.style.backgroundColor = this.value;
-  });
+  (function(){
+      var bgEl = document.getElementById('bgcolor');
+      function applyBgColor(){
+          // 実際のページ背景は body::before の var(--bg-page) で描画されるため
+          // body 直下の background-color ではなく CSS 変数を更新する。
+          document.documentElement.style.setProperty('--bg-page', bgEl.value);
+          document.body.style.backgroundColor = bgEl.value;
+      }
+      bgEl.addEventListener('input', applyBgColor);
+      bgEl.addEventListener('change', applyBgColor);
+  })();
   </script>
 
 <!---- 背景画像 + 透過度設定 ----->

--- a/init.php
+++ b/init.php
@@ -429,8 +429,25 @@ print '<button type="button" class="btn btn-secondary" id="listerbt" '.$addattr.
 
   <div class="mb-3">
     <h3>DBファイル名</h3>
-    <input type="text" name="dbname" id="dbname" class="form-control" value=<?php echo  urldecode($config_ini["dbname"]); ?> >
+    <div class="input-group">
+      <input type="text" name="dbname" id="dbname" class="form-control" value="<?php echo htmlspecialchars(urldecode($config_ini["dbname"]), ENT_QUOTES); ?>" >
+      <button type="button" class="btn btn-outline-secondary" id="dbname_gen">日付ファイル名を生成</button>
+    </div>
+    <div class="form-text">「request_YYYYMMDD.db」形式のファイル名を生成します。</div>
   </div>
+  <script>
+  (function(){
+    var btn = document.getElementById('dbname_gen');
+    if (!btn) return;
+    btn.addEventListener('click', function(){
+      var d = new Date();
+      var y = d.getFullYear();
+      var m = String(d.getMonth() + 1).padStart(2, '0');
+      var day = String(d.getDate()).padStart(2, '0');
+      document.getElementById('dbname').value = 'request_' + y + m + day + '.db';
+    });
+  })();
+  </script>
   
   <div class="mb-3">
     <h3 for="playmode">動作モード選択</h3>

--- a/init.php
+++ b/init.php
@@ -97,6 +97,19 @@ if(array_key_exists("clearauth", $_REQUEST)) {
   display: block;
   margin-bottom: 0.25rem;
 }
+/* 設定セクションのカード化 */
+.cfg-card {
+  margin-bottom: 1.25rem;
+  border-left: 4px solid var(--bs-primary, #0d6efd);
+}
+.cfg-card > .card-body { padding: 1rem 1.25rem; }
+.cfg-card .menulink { scroll-margin-top: 80px; }
+.cfg-card > .card-body > h1.menulink,
+.cfg-card > .card-body > h1:first-child {
+  font-size: 1.3rem;
+  font-weight: 700;
+  margin-top: 0;
+}
 </style>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
@@ -304,7 +317,7 @@ print '</pre>';
 </div>
 </div>
 <div class="col-lg-9 order-lg-first col-12 menulink">
-<div class="bg-info"  >
+<div class="card cfg-card mb-4"><div class="card-body">
   <h1 id="listctrl" class="menulink" > リクエストリスト操作 </h1>
   <h3> リストのダウンロード </h3>
   <a href ="listexport.php"  class="btn btn-secondary" > リクエストリストのダウンロード(UTF-8) </a>
@@ -340,11 +353,9 @@ print '</pre>';
   <li>
     <a href ="listtimesclear.php?times=1" class="btn btn-secondary" > 再生回数1クリア </a>【BGMモード(ジュークボックスモード)にて次から全てランダムに再生】
   </li>
-</div>
+</div></div>
 
-<hr />
-
-<div class="bg-info">
+<div class="card cfg-card mb-4"><div class="card-body">
   <p>
   <h1 id="opbuttom" class="menulink">各種操作ボタン </h1>
   <h3>ログイン情報クリア </h3>
@@ -402,14 +413,11 @@ print '<button type="button" class="btn btn-secondary" id="listerbt" '.$addattr.
   </p>
 
   <a href="requestlist_top.php" class="btn btn-secondary" > リクエストTOP画面に戻る　</a>
-</div>
+</div></div>
 
-<hr />
-
-
-<div class="bg-info">
-  <h1  id="workconfig"  class="menulink" >動作設定 </h1>
   <form name="allconfig" method="post" action="init.php" enctype="multipart/form-data">
+<div class="card cfg-card mb-4"><div class="card-body">
+  <h1  id="workconfig"  class="menulink" >動作設定 </h1>
 
   <div class="mb-3">
     <h3 title="未設定でパスワードチェックを省略">設定画面パスワード</h3>
@@ -432,6 +440,9 @@ print '<button type="button" class="btn btn-secondary" id="listerbt" '.$addattr.
     </select>
   </div>
 
+</div></div>
+
+<div class="card cfg-card mb-4"><div class="card-body">
   <h3 id="autoplay" class="menulink" >自動再生設定 </h3>
 <?php
 if(array_key_exists("autoplay_exec",$config_ini) && strlen($config_ini["autoplay_exec"]) > 0) {
@@ -480,6 +491,9 @@ print 'checked';
     </label>
   </div>
 
+</div></div>
+
+<div class="card cfg-card mb-4"><div class="card-body">
 <!---- トップ画面メッセージの設定 ----->
   <div class="mb-3">
     <h3 id="topmessage" class="menulink" >
@@ -513,6 +527,9 @@ if(array_key_exists("noticeof_searchpage",$config_ini)) {
     </div>  
   </div>  
 
+</div></div>
+
+<div class="card cfg-card mb-4"><div class="card-body">
   <!---- トップ画面即時リロードの設定 ----->
   <div class="mb-3">
   <?php
@@ -625,6 +642,9 @@ print ' value="10" ';
              $bgcolor=urldecode($config_ini["bgcolor"]);
       }
   ?>
+</div></div>
+
+<div class="card cfg-card mb-4"><div class="card-body">
   <div class="mb-3">
     <h3 id="bgcolor_t" class="radio form-label menulink"> ページ背景色  </h3>
     <input type="color" name="bgcolor" id="bgcolor" list="colors" value="<?php print $bgcolor ?>" />
@@ -656,6 +676,9 @@ print ' value="10" ';
           $bg_overlay_opacity = (int)$config_ini["bg_overlay_opacity"];
       }
   ?>
+</div></div>
+
+<div class="card cfg-card mb-4"><div class="card-body">
   <div class="mb-3">
     <h3 id="bgimage_t" class="radio form-label menulink"> 背景画像 </h3>
     <label><small>画面全体の背景に画像を表示します。透過度で見やすさを調整できます。</small></label>
@@ -737,6 +760,9 @@ print ' value="10" ';
 
 
 
+</div></div>
+
+<div class="card cfg-card mb-4"><div class="card-body">
   <div class="mb-3">
     <h3 id="movieplayer" class="menulink" > 動画プレーヤー設定 </h3>
     <h4 for="playerpath_select">MediaPlayerClassic PATH設定</h4>
@@ -1007,6 +1033,9 @@ print 'value="'.urldecode($config_ini["BGVCMDEND"]).'"';
     </div>
   </div>
 
+</div></div>
+
+<div class="card cfg-card mb-4"><div class="card-body">
 <h3 id=searchscreen class="menulink" > 検索画面設定 </h3>
   <div class="mb-3">
     <h4 for="comment"> リクエスト画面、コメント欄の説明書き </h4>
@@ -1091,6 +1120,7 @@ $si_sorted_indices = array_keys($si_order_map);
     </div>
 <?php } ?>
   </div>
+  </div>
 
   <div class="mb-3">
     <h4  > りすたーDBファイルパス  </h4>
@@ -1162,6 +1192,9 @@ $si_sorted_indices = array_keys($si_order_map);
   </div>
 
 
+</div></div>
+
+<div class="card cfg-card mb-4"><div class="card-body">
   <div class="mb-3 ">
     <h3 id="useinternet" class="radio form-label menulink"> インターネット接続  </h3>
     <label class="form-label"> <small>(使用しないにするとインターネット接続が前提の機能を無効にします)</small> </label>
@@ -1173,6 +1206,9 @@ $si_sorted_indices = array_keys($si_order_map);
     </label>
   </div>
 
+</div></div>
+
+<div class="card cfg-card mb-4"><div class="card-body">
   <div class="mb-3">
     <h3 id="commentserver" class="menulink">
     コメントサーバー設定
@@ -1245,7 +1281,8 @@ print 'value="名無しさん"';}
     </h3>
 	<label >
     <small>(ゆかりでの設定は不要になりました。MPC-BEにyoutube-dlの設定をしてください。<a href="https://github.com/bee7813993/KaraokeRequestorWeb/wiki/urlrequest"> https://github.com/bee7813993/KaraokeRequestorWeb/wiki/urlrequest </a> </small>
-	</label >    
+	</label >
+  </div>
 <!---
     <div class="mb-3">
       <h4 > ログインID(メールアドレス) </h4>
@@ -1288,6 +1325,9 @@ if(array_key_exists("downloadfolder",$config_ini)) {
     <input type="text" name="playerchecktimes" size="100" class="form-control" value="<?php echo $config_ini["playerchecktimes"]; ?>" />
   </div>
 
+</div></div>
+
+<div class="card cfg-card mb-4"><div class="card-body">
   <h3 id="otherroom" class="radio form-label menulink"> 別部屋URL設定 </h3>
   <table class="table table-striped table-bordered table-sm">
   <thead>
@@ -1457,6 +1497,9 @@ if(array_key_exists("request_automove_reset",$config_ini)) {
     </label>
   </div>
 
+</div></div>
+
+<div class="card cfg-card mb-4"><div class="card-body">
   <div class="mb-3">
     <h3 id="pfwd" class="form-label menulink">オンライン接続設定</h3>
     <p class="small text-muted">pfwd フォルダ設定、オンライン接続用ホスト名、自動再起動、DDNS 登録などは専用ページで管理します。</p>
@@ -1504,6 +1547,9 @@ if(array_key_exists("useeasyauth_word",$config_ini)) {
     </div>
   </div>
 
+</div></div>
+
+<div class="card cfg-card mb-4"><div class="card-body">
   <!---- Google同期設定 ----->
   <div class="mb-3">
     <h3 id="googlesync" class="radio form-label menulink"> Google同期設定 </h3>
@@ -1533,14 +1579,14 @@ if(array_key_exists("useeasyauth_word",$config_ini)) {
       value="<?php echo htmlspecialchars(urldecode($config_ini['google_relay_secret'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"
       placeholder="中継サーバー管理者から入手したシークレット" />
   </div>
+</div></div>
 
   <input type="submit" class="btn btn-secondary btn-lg" value="設定" />
   </form>
-  </div>
 </div>
   <hr />
 
-<div class=”bg-info”>
+<div class="card cfg-card mb-4"><div class="card-body">
   <h1 id="myiplist" class="menulink"> 自IP一覧 </h1>
   <pre>
   <?php
@@ -1572,9 +1618,8 @@ if(array_key_exists("useeasyauth_word",$config_ini)) {
   
   ?>
   </pre>
-  
-  </div>
-</div>
+
+  </div></div>
 </div><!-- row -->
 
 </div><!-- container -->

--- a/kara_config.php
+++ b/kara_config.php
@@ -174,6 +174,9 @@ function readconfig_array()
     if(!array_key_exists("bgimage", $config_ini)){
         $config_ini["bgimage"] = "";
     }
+    if(!array_key_exists("bgimage_mobile", $config_ini)){
+        $config_ini["bgimage_mobile"] = "";
+    }
     if(!array_key_exists("bg_card_opacity", $config_ini)){
         $config_ini["bg_card_opacity"] = 100;
     }


### PR DESCRIPTION
## Summary

背景画像機能の拡張と、関連する設定画面(init.php)の改善をまとめたPRです。

### 背景画像 (PC/スマホ別 + クロップ)
- PC用(横長16:9)とスマホ用(縦長9:16)で背景画像を**別々に登録**できるように
- 外部ライブラリなしの**自前canvasクロッパー**を実装(ドラッグでパン + スライダーで拡大 → 切り抜き)
- 切り抜き結果をJPEG data URLで送信し `images/bg/` に保存
- スマホ用が未設定の場合はPC用画像で自動フォールバック

### iOS背景固定の不具合修正
- iOS Safari/Chromeで `background-attachment: fixed` が効かず背景が要素と一緒にスクロールする問題を解消
- 背景画像を `html::before { position: fixed; z-index:-2 }` の固定レイヤーに変更し、全ブラウザ・全デバイスで「背景は固定・要素のみスクロール」に統一
- 向きに応じた切り替え: スマホ縦持ち=縦長画像 / 横持ち(小型端末で幅768px以下でも)=横長画像 (`orientation:portrait` を条件に追加)

### 透過度設定時の視認性改善
- `.modal-content` を透過対象から除外し常に不透明表示に。再生状況変更・コメント編集ダイアログがカード透過度設定に影響されず読みやすく
- 状態バッジ(`.bg-info` 等)を `:not(.badge)` で限定し、「再生済」などのバッジが常にBootstrap本来の色で表示されるよう修正

### 設定画面(init.php)の改善
- 各設定セクションをBS5カードレイアウト化、書式・背景色プレビューを修正
- DBファイル名に日付付きファイル名(`request_YYYYMMDD.db`)生成ボタンを追加

## 変更ファイル
- `commonfunc.php` — `print_bg_style_block` の背景レイヤー・透過CSS・メディアクエリ
- `init.php` — クロッパーUI/JS・保存処理・設定画面カード化
- `kara_config.php` — `bgimage_mobile` のデフォルト値追加

## Test plan
- [ ] init.phpでPC用/スマホ用の画像をそれぞれアップロードし、クロップ範囲を調整して保存できる
- [ ] BS5ページでPC=横長画像、スマホ縦持ち=縦長画像、スマホ横持ち=横長画像が表示される
- [ ] iPhone/iPad(Safari/Chrome)で背景が固定され要素のみスクロールする
- [ ] カード透過度を下げても再生状況変更/コメント編集ダイアログ・再生済バッジが見やすい
- [ ] スマホ用画像未設定時にPC用画像でフォールバックする

https://claude.ai/code/session_01VJXBnq4xFGdFQ5FV7SY8Fs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJXBnq4xFGdFQ5FV7SY8Fs)_