### PR TITLE
Fix HTML structure: move closing div tag in init.php

### DIFF
--- a/init.php
+++ b/init.php
@@ -1786,7 +1786,6 @@ if(array_key_exists("useeasyauth_word",$config_ini)) {
 
   <input type="submit" class="btn btn-secondary btn-lg" value="設定" />
   </form>
-</div>
   <hr />
 
 <div class="card cfg-card mb-4"><div class="card-body">
@@ -1823,6 +1822,7 @@ if(array_key_exists("useeasyauth_word",$config_ini)) {
   </pre>
 
   </div></div>
+</div><!-- col-lg-9 -->
 </div><!-- row -->
 
 </div><!-- container -->


### PR DESCRIPTION
## Summary
Corrected misplaced HTML closing `</div>` tag in `init.php` (admin settings page) to fix the Bootstrap 5 grid layout structure.

## Changes
- **Removed** stray `</div>` after the settings form (line 1789)
- **Moved** `</div><!-- col-lg-9 -->` to the correct position after all card content (line 1825)

## Details
The closing `</div>` for the `col-lg-9` column wrapper was incorrectly placed immediately after the form submission button, breaking the grid layout. This caused subsequent content (the `<hr />` and configuration cards) to render outside the intended column container.

The fix ensures proper nesting:
```
<div class="row">
  <div class="col-lg-9">
    [form content]
    [card content]
  </div><!-- col-lg-9 -->
</div><!-- row -->
```

This maintains the Bootstrap 5 responsive layout for the admin configuration interface.

https://claude.ai/code/session_01EvxkKtYptmSK5xgNAh9EFV