### PR TITLE
fix: reqorder の採番方式を統一し予約順番の崩れを修正

### DIFF
--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2569,6 +2569,36 @@ function mypage_save_keyword_link($keyword, $search_type, $search_params = '') {
 }
 
 /**
+ * requesttable の reqorder を連番（1始まり昇順）に正規化する。
+ * 現在の reqorder の大小関係を保持したまま隙間・重複を解消する。
+ * 同じ reqorder 値を持つ行は id の昇順で並べる。
+ * @param PDO $db
+ */
+function normalize_reqorder($db) {
+    $db->beginTransaction();
+    try {
+        $select = $db->query("SELECT id, reqorder FROM requesttable ORDER BY reqorder ASC, id ASC");
+        $rows = $select->fetchAll(PDO::FETCH_ASSOC);
+        $select->closeCursor();
+
+        $stmt = $db->prepare("UPDATE requesttable SET reqorder = :req WHERE id = :id");
+        $pos = 1;
+        foreach ($rows as $row) {
+            if ((int)$row['reqorder'] !== $pos) {
+                $stmt->bindValue(':req', $pos, PDO::PARAM_INT);
+                $stmt->bindValue(':id', (int)$row['id'], PDO::PARAM_INT);
+                $stmt->execute();
+            }
+            $pos++;
+        }
+        $db->commit();
+    } catch (Exception $e) {
+        $db->rollBack();
+        throw $e;
+    }
+}
+
+/**
  * マイページ用 JS (fetch + フィードバック表示) を出力する
  * <head> または <body> 内に一度だけ出力する
  */

--- a/delete.php
+++ b/delete.php
@@ -36,71 +36,53 @@ $tmpid=9999;
  */
 function dbup($id, $db)
 {
-	global $tmpid;
-// 対象のreqorderを取得
+    global $tmpid;
+    // 対象のreqorderを取得
+    $stmt = $db->prepare("SELECT * FROM requesttable WHERE id = :id");
+    $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+    $stmt->execute();
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($row === false) {
+        print("id={$id} のレコードが見つかりません。<br>");
+        return;
+    }
+    $targetorder = (int)$row['reqorder'];
 
-$stmt = $db->prepare("SELECT * FROM requesttable WHERE id = :id");
-$stmt->bindValue(':id', $id, PDO::PARAM_INT);
-$stmt->execute();
-$row = $stmt->fetch(PDO::FETCH_ASSOC);
-if ($row === false) {
-    print("id={$id} のレコードが見つかりません。<br>");
-    return;
-}
-$targetorder = $row['reqorder'];
+    // reqorder が自分より大きい（表示上ひとつ上）の行を探す
+    // ±1固定ではなく ORDER BY で隣を特定することで、10倍間隔や連番でない場合でも正しく動作する
+    $stmt = $db->prepare(
+        "SELECT * FROM requesttable WHERE reqorder > :targetorder ORDER BY reqorder ASC LIMIT 1"
+    );
+    $stmt->bindValue(':targetorder', $targetorder, PDO::PARAM_INT);
+    $stmt->execute();
+    $neighbor = $stmt->fetch(PDO::FETCH_ASSOC);
 
- $nextorder = $targetorder + 1 ;
-
-
- $stmt = $db->prepare("SELECT * FROM requesttable WHERE reqorder = :nextorder");
- $stmt->bindValue(':nextorder', $nextorder, PDO::PARAM_INT);
- $stmt->execute();
- $row = $stmt->fetch(PDO::FETCH_ASSOC);
-
- if(  $row !== false ){
- // 移動先のreqorder値の項目があったら
- $db->beginTransaction();
- $stmt = $db->prepare("UPDATE requesttable SET reqorder = :tmpid WHERE reqorder = :nextorder");
- $stmt->bindValue(':tmpid', $tmpid, PDO::PARAM_INT);
- $stmt->bindValue(':nextorder', $nextorder, PDO::PARAM_INT);
- $ret = $stmt->execute();
- if (! $ret ) {
-	$db->rollBack();
-	print("$nextorder から $tmpid への移動にしっぱいしました。<br>");
-	die();
- }
- $stmt = $db->prepare("UPDATE requesttable SET reqorder = :nextorder WHERE id = :id");
- $stmt->bindValue(':nextorder', $nextorder, PDO::PARAM_INT);
- $stmt->bindValue(':id', $id, PDO::PARAM_INT);
- $ret = $stmt->execute();
- if (! $ret ) {
-	$db->rollBack();
-	print("{$id} の $nextorder への移動にしっぱいしました。<br>");
-	die();
- }
- $stmt = $db->prepare("UPDATE requesttable SET reqorder = :targetorder WHERE reqorder = :tmpid");
- $stmt->bindValue(':targetorder', $targetorder, PDO::PARAM_INT);
- $stmt->bindValue(':tmpid', $tmpid, PDO::PARAM_INT);
- $ret = $stmt->execute();
- if (! $ret ) {
-	$db->rollBack();
-	print("$tmpid から $targetorder への移動にしっぱいしました。<br>");
-	die();
- }
- $db->commit();
- }else{
- $db->beginTransaction();
- $stmt = $db->prepare("UPDATE requesttable SET reqorder = :nextorder WHERE id = :id");
- $stmt->bindValue(':nextorder', $nextorder, PDO::PARAM_INT);
- $stmt->bindValue(':id', $id, PDO::PARAM_INT);
- $ret = $stmt->execute();
- if (! $ret ) {
-	$db->rollBack();
-	print("{$id} から $nextorder への移動にしっぱいしました。<br>");
-	die();
- }
- $db->commit();
- }
+    if ($neighbor !== false) {
+        $neighbororder = (int)$neighbor['reqorder'];
+        // 3ステップスワップ: target と neighbor の reqorder を交換
+        $db->beginTransaction();
+        // ステップ1: neighbor を一時値に退避
+        $stmt = $db->prepare("UPDATE requesttable SET reqorder = :tmpid WHERE id = :nid");
+        $stmt->bindValue(':tmpid', $tmpid, PDO::PARAM_INT);
+        $stmt->bindValue(':nid', (int)$neighbor['id'], PDO::PARAM_INT);
+        $ret = $stmt->execute();
+        if (!$ret) { $db->rollBack(); print("一時退避に失敗しました。<br>"); die(); }
+        // ステップ2: target を neighbororder へ
+        $stmt = $db->prepare("UPDATE requesttable SET reqorder = :neighbororder WHERE id = :id");
+        $stmt->bindValue(':neighbororder', $neighbororder, PDO::PARAM_INT);
+        $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+        $ret = $stmt->execute();
+        if (!$ret) { $db->rollBack(); print("{$id} の上への移動に失敗しました。<br>"); die(); }
+        // ステップ3: 一時値を targetorder へ
+        $stmt = $db->prepare("UPDATE requesttable SET reqorder = :targetorder WHERE reqorder = :tmpid");
+        $stmt->bindValue(':targetorder', $targetorder, PDO::PARAM_INT);
+        $stmt->bindValue(':tmpid', $tmpid, PDO::PARAM_INT);
+        $ret = $stmt->execute();
+        if (!$ret) { $db->rollBack(); print("復元に失敗しました。<br>"); die(); }
+        $db->commit();
+    } else {
+        print("すでに一番上です。<br>");
+    }
 }
 
 /**
@@ -110,77 +92,53 @@ $targetorder = $row['reqorder'];
  */
 function dbdown($id, $db)
 {
-	global $tmpid;
+    global $tmpid;
+    // 対象のreqorderを取得
+    $stmt = $db->prepare("SELECT * FROM requesttable WHERE id = :id");
+    $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+    $stmt->execute();
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($row === false) {
+        print("id={$id} のレコードが見つかりません。<br>");
+        return;
+    }
+    $targetorder = (int)$row['reqorder'];
 
+    // reqorder が自分より小さい（表示上ひとつ下）の行を探す
+    // ±1固定ではなく ORDER BY で隣を特定することで、10倍間隔や連番でない場合でも正しく動作する
+    $stmt = $db->prepare(
+        "SELECT * FROM requesttable WHERE reqorder < :targetorder ORDER BY reqorder DESC LIMIT 1"
+    );
+    $stmt->bindValue(':targetorder', $targetorder, PDO::PARAM_INT);
+    $stmt->execute();
+    $neighbor = $stmt->fetch(PDO::FETCH_ASSOC);
 
-// 対象のreqorderを取得
-$stmt = $db->prepare("SELECT * FROM requesttable WHERE id = :id");
-$stmt->bindValue(':id', $id, PDO::PARAM_INT);
-$stmt->execute();
-$row = $stmt->fetch(PDO::FETCH_ASSOC);
-if ($row === false) {
-    print("id={$id} のレコードが見つかりません。<br>");
-    return;
-}
-$targetorder = $row['reqorder'];
-
- $nextorder = $targetorder - 1 ;
-
- if ($targetorder <= 1 ){
-    print("すでに一番下<br>");
- }else{
-
-
- $stmt = $db->prepare("SELECT * FROM requesttable WHERE reqorder = :nextorder");
- $stmt->bindValue(':nextorder', $nextorder, PDO::PARAM_INT);
- $stmt->execute();
- $row = $stmt->fetch(PDO::FETCH_ASSOC);
-// var_dump($row);
- if(  $row !== false ){
- // 移動先のreqorder値の項目があったら
- $db->beginTransaction();
- $stmt = $db->prepare("UPDATE requesttable SET reqorder = :tmpid WHERE reqorder = :nextorder");
- $stmt->bindValue(':tmpid', $tmpid, PDO::PARAM_INT);
- $stmt->bindValue(':nextorder', $nextorder, PDO::PARAM_INT);
- $ret = $stmt->execute();
- if (! $ret ) {
-	$db->rollBack();
-	print("$targetorder から $tmpid  への移動にしっぱいしました。<br>");
-	return false;
- }
- $stmt = $db->prepare("UPDATE requesttable SET reqorder = :nextorder WHERE id = :id");
- $stmt->bindValue(':nextorder', $nextorder, PDO::PARAM_INT);
- $stmt->bindValue(':id', $id, PDO::PARAM_INT);
- $ret = $stmt->execute();
- if (! $ret ) {
-	$db->rollBack();
-	print("{$id} の $nextorder への移動にしっぱいしました。<br>");
-	return false;
- }
- $stmt = $db->prepare("UPDATE requesttable SET reqorder = :targetorder WHERE reqorder = :tmpid");
- $stmt->bindValue(':targetorder', $targetorder, PDO::PARAM_INT);
- $stmt->bindValue(':tmpid', $tmpid, PDO::PARAM_INT);
- $ret = $stmt->execute();
- if (! $ret ) {
-	$db->rollBack();
-	print("$tmpid から $targetorder への移動にしっぱいしました。<br>");
-	return false;
- }
- $db->commit();
- }else{
- $db->beginTransaction();
- $stmt = $db->prepare("UPDATE requesttable SET reqorder = :nextorder WHERE id = :id");
- $stmt->bindValue(':nextorder', $nextorder, PDO::PARAM_INT);
- $stmt->bindValue(':id', $id, PDO::PARAM_INT);
- $ret = $stmt->execute();
- if (! $ret ) {
-	$db->rollBack();
-	print("{$id} の  $nextorder への移動にしっぱいしました。<br>");
-	return false;
- }
- $db->commit();
- }
- }
+    if ($neighbor !== false) {
+        $neighbororder = (int)$neighbor['reqorder'];
+        // 3ステップスワップ: target と neighbor の reqorder を交換
+        $db->beginTransaction();
+        // ステップ1: neighbor を一時値に退避
+        $stmt = $db->prepare("UPDATE requesttable SET reqorder = :tmpid WHERE id = :nid");
+        $stmt->bindValue(':tmpid', $tmpid, PDO::PARAM_INT);
+        $stmt->bindValue(':nid', (int)$neighbor['id'], PDO::PARAM_INT);
+        $ret = $stmt->execute();
+        if (!$ret) { $db->rollBack(); print("一時退避に失敗しました。<br>"); return false; }
+        // ステップ2: target を neighbororder へ
+        $stmt = $db->prepare("UPDATE requesttable SET reqorder = :neighbororder WHERE id = :id");
+        $stmt->bindValue(':neighbororder', $neighbororder, PDO::PARAM_INT);
+        $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+        $ret = $stmt->execute();
+        if (!$ret) { $db->rollBack(); print("{$id} の下への移動に失敗しました。<br>"); return false; }
+        // ステップ3: 一時値を targetorder へ
+        $stmt = $db->prepare("UPDATE requesttable SET reqorder = :targetorder WHERE reqorder = :tmpid");
+        $stmt->bindValue(':targetorder', $targetorder, PDO::PARAM_INT);
+        $stmt->bindValue(':tmpid', $tmpid, PDO::PARAM_INT);
+        $ret = $stmt->execute();
+        if (!$ret) { $db->rollBack(); print("復元に失敗しました。<br>"); return false; }
+        $db->commit();
+    } else {
+        print("すでに一番下です。<br>");
+    }
 }
 
 /**
@@ -294,12 +252,15 @@ if( !empty($_POST['resetstatus']) ){
     if ( $l_action === 'up' )
     {
         dbup($l_id,$db);
+        normalize_reqorder($db);
     }elseif ( $l_action === 'down' )
     {
         dbdown($l_id,$db);
+        normalize_reqorder($db);
     }elseif ( $l_action === 'warikomi' )
     {
         warikomi($l_id,$db);
+        normalize_reqorder($db);
     }else {
 
         $stmt = $db->prepare("DELETE FROM requesttable WHERE id = :id");
@@ -311,6 +272,7 @@ if( !empty($_POST['resetstatus']) ){
         }
 
         print("{$l_id} を削除しました。<br>");
+        normalize_reqorder($db);
     }
 }
 print("1秒後に登録ページに移動します<br>");

--- a/exec.php
+++ b/exec.php
@@ -242,10 +242,17 @@ if (is_numeric($selectid)) {
         die();
     }
     $newid = (int)$db->lastInsertId();
-    $sql_u = 'UPDATE requesttable SET reqorder = ' . $newid . ', status = \'OK\' WHERE id = ' . $newid;
+    // reqorder は「現在の最大値+1」とし、新規予約を末尾（最後に再生）に追加する
+    $maxrow = $db->query(
+        "SELECT COALESCE(MAX(reqorder), 0) AS maxreq FROM requesttable WHERE id != " . $newid
+    )->fetch(PDO::FETCH_ASSOC);
+    $newreqorder = (int)$maxrow['maxreq'] + 1;
+    $stmt_u = $db->prepare('UPDATE requesttable SET reqorder = :reqorder, status = \'OK\' WHERE id = :id');
+    $stmt_u->bindValue(':reqorder', $newreqorder, PDO::PARAM_INT);
+    $stmt_u->bindValue(':id', $newid, PDO::PARAM_INT);
+    $stmt_u->execute();
     if (!empty($DEBUG))
-        print $sql_u . '<br />';
-    $db->exec($sql_u);
+        print "reqorder set to {$newreqorder} for id={$newid}<br />";
     if ($config_ini["request_automove"] == 1) {
         require_once('function_moveitem.php');
         $list = new MoveItem;

--- a/requestlist_reorder.php
+++ b/requestlist_reorder.php
@@ -27,8 +27,9 @@ try {
     $db->beginTransaction();
     $stmt = $db->prepare("UPDATE requesttable SET reqorder = :reqorder WHERE id = :id");
     foreach ($ids as $index => $id) {
-        // First item gets highest reqorder (displayed first, ORDER BY reqorder DESC)
-        $reqorder = ($total - $index) * 10;
+        // 先頭アイテム(index=0)が最大reqorder（ORDER BY reqorder DESC で先頭表示）
+        // 10倍間隔ではなく連番で割り当てることで他の処理との採番方式を統一する
+        $reqorder = $total - $index;
         $stmt->bindValue(':reqorder', $reqorder, PDO::PARAM_INT);
         $stmt->bindValue(':id', (int)$id, PDO::PARAM_INT);
         $stmt->execute();
@@ -40,6 +41,9 @@ try {
     echo json_encode(['status' => 'error', 'message' => 'DB error']);
     exit;
 }
+
+// ドラッグ&ドロップ対象外のレコード（再生中など）も含めて連番に正規化する
+normalize_reqorder($db);
 
 $un = new UpdateNotice();
 $un->initdb();


### PR DESCRIPTION
## 概要

予約一覧の順番が、新規予約・順番変更などの操作時に崩れる不具合を修正します。

## 原因

`reqorder`（再生順序）を操作する処理が **互換性のない3つの採番方式** を使っており、組み合わさると破綻していました。

| 処理 | 旧：採番方式 | 問題点 |
|------|------|------|
| ドラッグ&ドロップ (`requestlist_reorder.php`) | `(total−index)×10`（10倍間隔） | 10,20,30… の隙間ができる |
| 上下移動 (`delete.php` dbup/dbdown) | `reqorder±1` の行を探す | 連番前提。10倍間隔だと隣が見つからず入れ替え不能 |
| 新規予約 (`exec.php`) | `reqorder = id`（採番ID値） | 既存の採番体系と揃わず飛び値が混入 |

特に「ドラッグ&ドロップ後に上下ボタンを使う」と、上下移動が隣接行を見つけられず順位が崩れていました。

## 変更内容

**`commonfunc.php`**
- `normalize_reqorder($db)` を追加。全行を現在の reqorder の大小順に並べ直し、1始まりの連番を振り直して隙間・重複を解消する。

**`exec.php`**
- 新規予約時の reqorder 初期値を `id` から `MAX(reqorder)+1` に変更。常に末尾（最後に再生）へ追加し、採番体系を統一。

**`delete.php`**
- `dbup()` / `dbdown()` の隣接行探索を `reqorder±1`（固定値）から `ORDER BY reqorder ASC/DESC LIMIT 1`（大小で特定）に変更。間隔が連番でなくても正しく入れ替え可能に。
- up / down / warikomi / delete の各操作後に `normalize_reqorder()` を呼び出し。

**`requestlist_reorder.php`**
- reqorder の割り当てを `(total−index)×10` から `(total−index)` の連番に変更。
- 並べ替え後に `normalize_reqorder()` を呼び出してテーブル全体を正規化。

## テスト

- [x] ユーザーによる動作確認済み

https://claude.ai/code/session_01LzeggX4ETEb9YkAJZe9e7u

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzeggX4ETEb9YkAJZe9e7u)_