### PR TITLE
ゆかりすたー・ゆっこビュー2 起動ボタン実装＋モバイルナビバー UI 修正

### DIFF
--- a/css/themes/search.css
+++ b/css/themes/search.css
@@ -62,6 +62,20 @@ body {
   flex-shrink: 0;
 }
 
+/* --- ナビバー折りたたみ時：右側ボタン群を横並び・左寄せに ---
+   ms-auto による縦並び＆センター寄せを上書きする。           */
+@media (max-width: 767.98px) {
+  #gnavi .navbar-nav.ms-auto {
+    flex-direction: row !important;
+    align-items: center;
+    margin-left: 0 !important;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    padding: 0.5rem 0 0.25rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+  }
+}
+
 /* --- ナビバー折りたたみ時のドロップダウン（< md = 768px） ---
    Bootstrap デフォルトは白いフローティングボックスになるため、
    ナビバーの暗い背景に溶け込むようにリセットする。           */

--- a/css/themes/search.css
+++ b/css/themes/search.css
@@ -62,6 +62,37 @@ body {
   flex-shrink: 0;
 }
 
+/* --- ナビバー折りたたみ時のドロップダウン（< md = 768px） ---
+   Bootstrap デフォルトは白いフローティングボックスになるため、
+   ナビバーの暗い背景に溶け込むようにリセットする。           */
+@media (max-width: 767.98px) {
+  .navbar .dropdown-menu {
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+    border-radius: 0;
+    padding: 0 0 0.25rem 0.5rem;
+    margin: 0;
+  }
+  .navbar .dropdown-item {
+    color: rgba(255, 255, 255, 0.85);
+    padding: 0.4rem 1rem;
+    border-radius: 4px;
+  }
+  .navbar .dropdown-item:hover,
+  .navbar .dropdown-item:focus {
+    background-color: rgba(255, 255, 255, 0.1);
+    color: #ffffff;
+  }
+  .navbar .dropdown-divider {
+    border-color: rgba(255, 255, 255, 0.15);
+    margin: 0.25rem 0;
+  }
+  .navbar .dropdown-item-text {
+    color: rgba(255, 255, 255, 0.5);
+  }
+}
+
 /* --- 曲差し替えバナー --- */
 .swap-banner {
   background-color: var(--bg-swap-banner);

--- a/css/themes/search.css
+++ b/css/themes/search.css
@@ -74,6 +74,10 @@ body {
     padding: 0.5rem 0 0.25rem;
     border-top: 1px solid rgba(255, 255, 255, 0.1);
   }
+  /* ボタン2つを1行目に、Help等を2行目に分ける */
+  #gnavi .navbar-nav.ms-auto > li.nav-item.dropdown {
+    width: 100%;
+  }
 }
 
 /* --- ナビバー折りたたみ時のドロップダウン（< md = 768px） ---

--- a/function_search_listerdb.php
+++ b/function_search_listerdb.php
@@ -55,65 +55,56 @@ class ListerDB {
     public function isInstalledYkListerStore() {
         $output = [];
         $retval = -1;
-        exec('powershell -NoProfile -Command "if (Get-AppxPackage -Name \'*YukaLister*\') { exit 0 } else { exit 1 }" 2>NUL', $output, $retval);
+        exec('powershell -NoProfile -NonInteractive -Command "if (Get-AppxPackage -Name \'*YukaLister*\' -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }" 2>NUL', $output, $retval);
         return $retval === 0;
     }
 
     // Windows Store版ゆかりすたーを起動（Task Scheduler経由でユーザーセッションで起動）
     public function startyklistercmd_store() {
-        return $this->launchStoreApp('*YukaLister*', 'KaraokeYukaListerLaunch');
+        return $this->launchStoreApp('*YukaLister*');
     }
 
     // Windows Store版ゆっこビュー2がインストール済みか確認
     public function isInstalledYukkoView2() {
         $output = [];
         $retval = -1;
-        exec('powershell -NoProfile -Command "if (Get-AppxPackage -Name \'*YukkoView*\') { exit 0 } else { exit 1 }" 2>NUL', $output, $retval);
+        exec('powershell -NoProfile -NonInteractive -Command "if (Get-AppxPackage -Name \'*YukkoView*\' -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }" 2>NUL', $output, $retval);
         return $retval === 0;
     }
 
     // Windows Store版ゆっこビュー2を起動（Task Scheduler経由でユーザーセッションで起動）
     public function startYukkoView2cmd() {
-        return $this->launchStoreApp('*YukkoView*', 'KaraokeYukkoView2Launch');
+        return $this->launchStoreApp('*YukkoView*');
     }
 
     /**
-     * Windows Store アプリをTask Scheduler経由で対話型セッションで起動する。
-     * Apache がサービス(Session 0)で動いていても、ユーザーのデスクトップに表示される。
+     * Windows Store アプリを起動する。
+     * Apache がユーザーセッションで動作している前提で cmd /c start 経由で非同期起動。
      * @return array ['ok'=>bool, 'msg'=>string]
      */
-    private function launchStoreApp($namePattern, $taskName) {
+    private function launchStoreApp($namePattern) {
         if (!function_exists('exec')) {
             return ['ok' => false, 'msg' => 'exec() が無効です (php.ini の disable_functions を確認)'];
         }
 
         // パッケージファミリー名を取得
-        $psGetPfn = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'' . $namePattern . '\' | Select-Object -First 1).PackageFamilyName"';
-        exec($psGetPfn . ' 2>&1', $pfnOut, $pfnRet);
+        $pfnOut = [];
+        $pfnRet = -1;
+        exec(
+            'powershell -NoProfile -NonInteractive -Command "(Get-AppxPackage -Name \'' . $namePattern . '\' -ErrorAction SilentlyContinue | Select-Object -First 1).PackageFamilyName" 2>&1',
+            $pfnOut,
+            $pfnRet
+        );
         $pfn = trim(implode('', $pfnOut));
 
-        if (empty($pfn) || $pfnRet !== 0) {
-            return ['ok' => false, 'msg' => 'アプリが見つかりません (pattern: ' . $namePattern . ')'];
+        if (empty($pfn)) {
+            return ['ok' => false, 'msg' => 'アプリが見つかりません (pattern: ' . $namePattern . ', exit: ' . $pfnRet . ', out: ' . implode('|', $pfnOut) . ')'];
         }
 
-        $appUri = 'shell:AppsFolder\\' . $pfn . '!App';
-
-        // schtasks でタスクを作成して即実行（/ru "" = 現在のインタラクティブユーザーで実行）
-        $tr = 'explorer.exe "' . $appUri . '"';
-        $createCmd = 'schtasks /create /f /tn "' . $taskName . '" /tr "' . $tr . '" /sc once /st 00:00 2>&1';
-        exec($createCmd, $createOut, $createRet);
-
-        if ($createRet !== 0) {
-            // schtasks 失敗時は直接 explorer.exe で試みる（XAMPP がユーザーセッションで動いている場合に有効）
-            $direct = 'explorer.exe "' . $appUri . '"';
-            popen($direct, 'r');
-            return ['ok' => true, 'msg' => 'direct: ' . $pfn];
-        }
-
-        exec('schtasks /run /tn "' . $taskName . '" 2>&1', $runOut, $runRet);
-        if ($runRet !== 0) {
-            return ['ok' => false, 'msg' => 'schtasks /run 失敗: ' . implode(' ', $runOut)];
-        }
+        // cmd /c start で非同期起動（Apache がユーザーセッションで動作しているため直接起動可能）
+        $cmd = 'cmd /c start "" explorer.exe "shell:AppsFolder\\' . $pfn . '!App"';
+        $fp = popen($cmd, 'r');
+        if ($fp !== false) pclose($fp);
 
         return ['ok' => true, 'msg' => $pfn];
     }

--- a/function_search_listerdb.php
+++ b/function_search_listerdb.php
@@ -55,30 +55,67 @@ class ListerDB {
     public function isInstalledYkListerStore() {
         $output = [];
         $retval = -1;
-        exec('powershell -Command "if (Get-AppxPackage -Name \'*YukaLister*\') { exit 0 } else { exit 1 }" 2>NUL', $output, $retval);
+        exec('powershell -NoProfile -Command "if (Get-AppxPackage -Name \'*YukaLister*\') { exit 0 } else { exit 1 }" 2>NUL', $output, $retval);
         return $retval === 0;
     }
 
-    // Windows Store版ゆかりすたーを起動
+    // Windows Store版ゆかりすたーを起動（Task Scheduler経由でユーザーセッションで起動）
     public function startyklistercmd_store() {
-        $cmd = 'powershell -WindowStyle Hidden -Command "$p=Get-AppxPackage -Name \'*YukaLister*\' | Select-Object -First 1; if($p){Start-Process (\'shell:AppsFolder\\\' + $p.PackageFamilyName + \'!App\')}"';
-        $fp = popen($cmd, 'r');
-        pclose($fp);
+        return $this->launchStoreApp('*YukaLister*', 'KaraokeYukaListerLaunch');
     }
 
     // Windows Store版ゆっこビュー2がインストール済みか確認
     public function isInstalledYukkoView2() {
         $output = [];
         $retval = -1;
-        exec('powershell -Command "if (Get-AppxPackage -Name \'*YukkoView*\') { exit 0 } else { exit 1 }" 2>NUL', $output, $retval);
+        exec('powershell -NoProfile -Command "if (Get-AppxPackage -Name \'*YukkoView*\') { exit 0 } else { exit 1 }" 2>NUL', $output, $retval);
         return $retval === 0;
     }
 
-    // Windows Store版ゆっこビュー2を起動
+    // Windows Store版ゆっこビュー2を起動（Task Scheduler経由でユーザーセッションで起動）
     public function startYukkoView2cmd() {
-        $cmd = 'powershell -WindowStyle Hidden -Command "$p=Get-AppxPackage -Name \'*YukkoView*\' | Select-Object -First 1; if($p){Start-Process (\'shell:AppsFolder\\\' + $p.PackageFamilyName + \'!App\')}"';
-        $fp = popen($cmd, 'r');
-        pclose($fp);
+        return $this->launchStoreApp('*YukkoView*', 'KaraokeYukkoView2Launch');
+    }
+
+    /**
+     * Windows Store アプリをTask Scheduler経由で対話型セッションで起動する。
+     * Apache がサービス(Session 0)で動いていても、ユーザーのデスクトップに表示される。
+     * @return array ['ok'=>bool, 'msg'=>string]
+     */
+    private function launchStoreApp($namePattern, $taskName) {
+        if (!function_exists('exec')) {
+            return ['ok' => false, 'msg' => 'exec() が無効です (php.ini の disable_functions を確認)'];
+        }
+
+        // パッケージファミリー名を取得
+        $psGetPfn = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'' . $namePattern . '\' | Select-Object -First 1).PackageFamilyName"';
+        exec($psGetPfn . ' 2>&1', $pfnOut, $pfnRet);
+        $pfn = trim(implode('', $pfnOut));
+
+        if (empty($pfn) || $pfnRet !== 0) {
+            return ['ok' => false, 'msg' => 'アプリが見つかりません (pattern: ' . $namePattern . ')'];
+        }
+
+        $appUri = 'shell:AppsFolder\\' . $pfn . '!App';
+
+        // schtasks でタスクを作成して即実行（/ru "" = 現在のインタラクティブユーザーで実行）
+        $tr = 'explorer.exe "' . $appUri . '"';
+        $createCmd = 'schtasks /create /f /tn "' . $taskName . '" /tr "' . $tr . '" /sc once /st 00:00 2>&1';
+        exec($createCmd, $createOut, $createRet);
+
+        if ($createRet !== 0) {
+            // schtasks 失敗時は直接 explorer.exe で試みる（XAMPP がユーザーセッションで動いている場合に有効）
+            $direct = 'explorer.exe "' . $appUri . '"';
+            popen($direct, 'r');
+            return ['ok' => true, 'msg' => 'direct: ' . $pfn];
+        }
+
+        exec('schtasks /run /tn "' . $taskName . '" 2>&1', $runOut, $runRet);
+        if ($runRet !== 0) {
+            return ['ok' => false, 'msg' => 'schtasks /run 失敗: ' . implode(' ', $runOut)];
+        }
+
+        return ['ok' => true, 'msg' => $pfn];
     }
 }
 

--- a/function_search_listerdb.php
+++ b/function_search_listerdb.php
@@ -65,6 +65,21 @@ class ListerDB {
         $fp = popen($cmd, 'r');
         pclose($fp);
     }
+
+    // Windows Store版ゆっこビュー2がインストール済みか確認
+    public function isInstalledYukkoView2() {
+        $output = [];
+        $retval = -1;
+        exec('powershell -Command "if (Get-AppxPackage -Name \'*YukkoView*\') { exit 0 } else { exit 1 }" 2>NUL', $output, $retval);
+        return $retval === 0;
+    }
+
+    // Windows Store版ゆっこビュー2を起動
+    public function startYukkoView2cmd() {
+        $cmd = 'powershell -WindowStyle Hidden -Command "$p=Get-AppxPackage -Name \'*YukkoView*\' | Select-Object -First 1; if($p){Start-Process (\'shell:AppsFolder\\\' + $p.PackageFamilyName + \'!App\')}"';
+        $fp = popen($cmd, 'r');
+        pclose($fp);
+    }
 }
 
 /**

--- a/function_search_listerdb.php
+++ b/function_search_listerdb.php
@@ -101,12 +101,16 @@ class ListerDB {
             return ['ok' => false, 'msg' => 'アプリが見つかりません (pattern: ' . $namePattern . ', exit: ' . $pfnRet . ', out: ' . implode('|', $pfnOut) . ')'];
         }
 
-        // cmd /c start で非同期起動（Apache がユーザーセッションで動作しているため直接起動可能）
-        $cmd = 'cmd /c start "" explorer.exe "shell:AppsFolder\\' . $pfn . '!App"';
-        $fp = popen($cmd, 'r');
-        if ($fp !== false) pclose($fp);
+        // Start-Process で非同期起動。
+        // popen+pclose は孫プロセスのハンドル継承でブロックするため使わない。
+        // exec(PowerShell Start-Process) はPowerShell終了で即リターンする。
+        $uri = 'shell:AppsFolder\\' . $pfn . '!App';
+        $psCmd = 'powershell -NoProfile -NonInteractive -Command "Start-Process \'' . str_replace("'", "''", $uri) . '\'" 2>NUL';
+        $launchOut = [];
+        $launchRet = -1;
+        exec($psCmd, $launchOut, $launchRet);
 
-        return ['ok' => true, 'msg' => $pfn];
+        return ['ok' => true, 'msg' => $pfn, 'launch_ret' => $launchRet];
     }
 }
 

--- a/function_search_listerdb.php
+++ b/function_search_listerdb.php
@@ -50,6 +50,21 @@ class ListerDB {
         $yukalistercmd= 'YukaLister.exe';
         $cmd = 'taskkill /im "'.$yukalistercmd.'" -f';
     }
+
+    // Windows Store版ゆかりすたーがインストール済みか確認
+    public function isInstalledYkListerStore() {
+        $output = [];
+        $retval = -1;
+        exec('powershell -Command "if (Get-AppxPackage -Name \'*YukaLister*\') { exit 0 } else { exit 1 }" 2>NUL', $output, $retval);
+        return $retval === 0;
+    }
+
+    // Windows Store版ゆかりすたーを起動
+    public function startyklistercmd_store() {
+        $cmd = 'powershell -WindowStyle Hidden -Command "$p=Get-AppxPackage -Name \'*YukaLister*\' | Select-Object -First 1; if($p){Start-Process (\'shell:AppsFolder\\\' + $p.PackageFamilyName + \'!App\')}"';
+        $fp = popen($cmd, 'r');
+        pclose($fp);
+    }
 }
 
 /**

--- a/init.php
+++ b/init.php
@@ -431,29 +431,35 @@ request.onreadystatechange = function() {
 }
 request.send("");
 }
-function start_yklisterstore_cmd(){
-var request = createXMLHttpRequest();
-url="yklister_exec.php?start_store=1";
-request.open("GET", url, true);
-request.onreadystatechange = function() {
-    if(request.readyState == 4) {
-        if (request.status === 200) {
+
+function storeAppLaunch(url, btnId, label) {
+    var btn = document.getElementById(btnId);
+    if (btn) { btn.disabled = true; btn.textContent = '起動中…'; }
+    var request = createXMLHttpRequest();
+    request.open("GET", url, true);
+    request.onreadystatechange = function() {
+        if (request.readyState == 4) {
+            if (btn) { btn.disabled = false; btn.textContent = label; }
+            if (request.status === 200) {
+                try {
+                    var res = JSON.parse(request.responseText);
+                    if (!res.ok) {
+                        alert('起動に失敗しました:\n' + res.msg);
+                    }
+                } catch(e) {}
+            } else {
+                alert('通信エラー: ' + request.status);
+            }
         }
-    }
+    };
+    request.send("");
 }
-request.send("");
+
+function start_yklisterstore_cmd(){
+    storeAppLaunch("yklister_exec.php?start_store=1", "listerbt", "ゆかりすたー起動");
 }
 function start_yukkoview2_cmd(){
-var request = createXMLHttpRequest();
-url="yklister_exec.php?start_yukkoview2=1";
-request.open("GET", url, true);
-request.onreadystatechange = function() {
-    if(request.readyState == 4) {
-        if (request.status === 200) {
-        }
-    }
-}
-request.send("");
+    storeAppLaunch("yklister_exec.php?start_yukkoview2=1", "yukkoview2bt", "ゆっこビュー 2 起動");
 }
 </script>
   <p>

--- a/init.php
+++ b/init.php
@@ -443,23 +443,37 @@ request.onreadystatechange = function() {
 }
 request.send("");
 }
+function start_yukkoview2_cmd(){
+var request = createXMLHttpRequest();
+url="yklister_exec.php?start_yukkoview2=1";
+request.open("GET", url, true);
+request.onreadystatechange = function() {
+    if(request.readyState == 4) {
+        if (request.status === 200) {
+        }
+    }
+}
+request.send("");
+}
 </script>
   <p>
 <?php
   require_once 'function_search_listerdb.php';
+  $listerapi_btn = new ListerDB();
+
   $yukalisterpath= 'YukaLister\YukaLister.exe';
   $addattr = '';
   if (file_exist_check_japanese_cf($yukalisterpath) ){
     $addattr = ' onClick="start_yklistercmd()"';
+  } elseif ($listerapi_btn->isInstalledYkListerStore()) {
+    $addattr = ' onClick="start_yklisterstore_cmd()"';
   } else {
-    $listerapi_btn = new ListerDB();
-    if ($listerapi_btn->isInstalledYkListerStore()) {
-      $addattr = ' onClick="start_yklisterstore_cmd()"';
-    } else {
-      $addattr = ' disabled ';
-    }
+    $addattr = ' disabled ';
   }
 print '<button type="button" class="btn btn-secondary" id="listerbt" '.$addattr.'> ゆかりすたー起動 </button>';
+
+  $yukkoattr = $listerapi_btn->isInstalledYukkoView2() ? ' onClick="start_yukkoview2_cmd()"' : ' disabled ';
+print '<button type="button" class="btn btn-secondary" id="yukkoview2bt" '.$yukkoattr.'> ゆっこビュー 2 起動 </button>';
 ?>
   </p>
 

--- a/init.php
+++ b/init.php
@@ -420,8 +420,8 @@ print '</pre>';
   </p>
 <script type="text/javascript">
 function start_yklistercmd(){
-var request = createXMLHttpRequest();
-url="yklister_exec.php?start=1";
+var request = new XMLHttpRequest();
+var url="yklister_exec.php?start=1";
 request.open("GET", url, true);
 request.onreadystatechange = function() {
     if(request.readyState == 4) {
@@ -435,7 +435,7 @@ request.send("");
 function storeAppLaunch(url, btnId, label) {
     var btn = document.getElementById(btnId);
     if (btn) { btn.disabled = true; btn.textContent = '起動中…'; }
-    var request = createXMLHttpRequest();
+    var request = new XMLHttpRequest();
     request.open("GET", url, true);
     request.onreadystatechange = function() {
         if (request.readyState == 4) {

--- a/init.php
+++ b/init.php
@@ -431,15 +431,33 @@ request.onreadystatechange = function() {
 }
 request.send("");
 }
+function start_yklisterstore_cmd(){
+var request = createXMLHttpRequest();
+url="yklister_exec.php?start_store=1";
+request.open("GET", url, true);
+request.onreadystatechange = function() {
+    if(request.readyState == 4) {
+        if (request.status === 200) {
+        }
+    }
+}
+request.send("");
+}
 </script>
   <p>
 <?php
+  require_once 'function_search_listerdb.php';
   $yukalisterpath= 'YukaLister\YukaLister.exe';
   $addattr = '';
   if (file_exist_check_japanese_cf($yukalisterpath) ){
-  $addattr = ' onClick="start_yklistercmd()"';
-  }else {
-  $addattr = ' disabled ';
+    $addattr = ' onClick="start_yklistercmd()"';
+  } else {
+    $listerapi_btn = new ListerDB();
+    if ($listerapi_btn->isInstalledYkListerStore()) {
+      $addattr = ' onClick="start_yklisterstore_cmd()"';
+    } else {
+      $addattr = ' disabled ';
+    }
   }
 print '<button type="button" class="btn btn-secondary" id="listerbt" '.$addattr.'> ゆかりすたー起動 </button>';
 ?>

--- a/yklister_exec.php
+++ b/yklister_exec.php
@@ -26,6 +26,10 @@ if(array_key_exists("start_store", $_REQUEST)) {
     $runmode = 5;
 }
 
+if(array_key_exists("start_yukkoview2", $_REQUEST)) {
+    $runmode = 6;
+}
+
 switch($runmode) {
     case 1:
         // start
@@ -45,8 +49,12 @@ switch($runmode) {
         // check
         break;
     case 5:
-        // start Windows Store版
+        // start Windows Store版ゆかりすたー
         $listerapi->startyklistercmd_store();
+        break;
+    case 6:
+        // start Windows Store版ゆっこビュー2
+        $listerapi->startYukkoView2cmd();
         break;
 }
 

--- a/yklister_exec.php
+++ b/yklister_exec.php
@@ -22,6 +22,10 @@ if(array_key_exists("check", $_REQUEST)) {
     $runmode = 4;
 }
 
+if(array_key_exists("start_store", $_REQUEST)) {
+    $runmode = 5;
+}
+
 switch($runmode) {
     case 1:
         // start
@@ -39,6 +43,10 @@ switch($runmode) {
         break;
     case 4:
         // check
+        break;
+    case 5:
+        // start Windows Store版
+        $listerapi->startyklistercmd_store();
         break;
 }
 

--- a/yklister_exec.php
+++ b/yklister_exec.php
@@ -41,14 +41,14 @@ if (array_key_exists("debug", $_REQUEST)) {
         $steps['pkg_yukkoview'] = ['ret' => $ret, 'out' => $out];
     }
 
-    // Step 6: Start-Process で実際に起動テスト（YukaLister）
+    // Step 6: Start-Process で実際に起動テスト（YukkoView2）
     // ※ このステップで応答が止まる場合は Start-Process がブロックしている
-    if (function_exists('exec') && !empty($steps['pkg_yukalister']['out'][0])) {
-        $pfn = trim($steps['pkg_yukalister']['out'][0]);
+    if (function_exists('exec') && !empty($steps['pkg_yukkoview']['out'][0])) {
+        $pfn = trim($steps['pkg_yukkoview']['out'][0]);
         $uri = 'shell:AppsFolder\\' . $pfn . '!App';
         $out = []; $ret = -1;
         exec('powershell -NoProfile -NonInteractive -Command "Start-Process \'' . str_replace("'", "''", $uri) . '\'" 2>&1', $out, $ret);
-        $steps['launch_yukalister'] = ['ret' => $ret, 'out' => $out, 'uri' => $uri];
+        $steps['launch_yukkoview'] = ['ret' => $ret, 'out' => $out, 'uri' => $uri];
     }
 
     echo json_encode(['debug' => true, 'steps' => $steps], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);

--- a/yklister_exec.php
+++ b/yklister_exec.php
@@ -41,6 +41,16 @@ if (array_key_exists("debug", $_REQUEST)) {
         $steps['pkg_yukkoview'] = ['ret' => $ret, 'out' => $out];
     }
 
+    // Step 6: Start-Process で実際に起動テスト（YukaLister）
+    // ※ このステップで応答が止まる場合は Start-Process がブロックしている
+    if (function_exists('exec') && !empty($steps['pkg_yukalister']['out'][0])) {
+        $pfn = trim($steps['pkg_yukalister']['out'][0]);
+        $uri = 'shell:AppsFolder\\' . $pfn . '!App';
+        $out = []; $ret = -1;
+        exec('powershell -NoProfile -NonInteractive -Command "Start-Process \'' . str_replace("'", "''", $uri) . '\'" 2>&1', $out, $ret);
+        $steps['launch_yukalister'] = ['ret' => $ret, 'out' => $out, 'uri' => $uri];
+    }
+
     echo json_encode(['debug' => true, 'steps' => $steps], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
     exit;
 }

--- a/yklister_exec.php
+++ b/yklister_exec.php
@@ -2,6 +2,8 @@
 require_once 'commonfunc.php';
 require_once 'function_search_listerdb.php';
 
+header('Content-Type: application/json; charset=utf-8');
+
 $listerapi= new ListerDB();
 
 $runmode = 0;
@@ -10,7 +12,6 @@ if(array_key_exists("start", $_REQUEST)) {
 }
 
 if(array_key_exists("stop", $_REQUEST)) {
-    
     $runmode = 2;
 }
 
@@ -30,32 +31,32 @@ if(array_key_exists("start_yukkoview2", $_REQUEST)) {
     $runmode = 6;
 }
 
+$result = ['ok' => true, 'msg' => ''];
+
 switch($runmode) {
     case 1:
-        // start
         $listerapi->startyklistercmd();
         break;
     case 2:
-        // stop
         $listerapi->stopyklistercmd();
         break;
     case 3:
-        // restart
         $listerapi->stopyklistercmd();
         sleep(4);
         $listerapi->startyklistercmd();
         break;
     case 4:
-        // check
         break;
     case 5:
-        // start Windows Store版ゆかりすたー
-        $listerapi->startyklistercmd_store();
+        $result = $listerapi->startyklistercmd_store();
         break;
     case 6:
-        // start Windows Store版ゆっこビュー2
-        $listerapi->startYukkoView2cmd();
+        $result = $listerapi->startYukkoView2cmd();
+        break;
+    default:
+        $result = ['ok' => false, 'msg' => '不明なコマンドです'];
         break;
 }
 
+echo json_encode($result, JSON_UNESCAPED_UNICODE);
 ?>

--- a/yklister_exec.php
+++ b/yklister_exec.php
@@ -6,6 +6,101 @@ header('Content-Type: application/json; charset=utf-8');
 
 $listerapi= new ListerDB();
 
+// デバッグモード: yklister_exec.php?debug=1 でステップごとの動作確認
+if (array_key_exists("debug", $_REQUEST)) {
+    $steps = [];
+
+    // Step 1: exec() が使えるか
+    $steps['exec_enabled'] = function_exists('exec') ? 'yes' : 'no (disable_functions)';
+
+    // Step 2: 簡単なコマンド（echoのみ）
+    if (function_exists('exec')) {
+        $out = []; $ret = -1;
+        exec('cmd /c echo hello 2>&1', $out, $ret);
+        $steps['cmd_echo'] = ['ret' => $ret, 'out' => $out];
+    }
+
+    // Step 3: PowerShell バージョン確認（Get-AppxPackage より軽い）
+    if (function_exists('exec')) {
+        $out = []; $ret = -1;
+        exec('powershell -NoProfile -NonInteractive -Command "$PSVersionTable.PSVersion.Major" 2>&1', $out, $ret);
+        $steps['ps_version'] = ['ret' => $ret, 'out' => $out];
+    }
+
+    // Step 4: Get-AppxPackage（YukaLister）
+    if (function_exists('exec')) {
+        $out = []; $ret = -1;
+        exec('powershell -NoProfile -NonInteractive -Command "(Get-AppxPackage -Name \'*YukaLister*\' -ErrorAction SilentlyContinue | Select-Object -First 1).PackageFamilyName" 2>&1', $out, $ret);
+        $steps['pkg_yukalister'] = ['ret' => $ret, 'out' => $out];
+    }
+
+    // Step 5: Get-AppxPackage（YukkoView）
+    if (function_exists('exec')) {
+        $out = []; $ret = -1;
+        exec('powershell -NoProfile -NonInteractive -Command "(Get-AppxPackage -Name \'*YukkoView*\' -ErrorAction SilentlyContinue | Select-Object -First 1).PackageFamilyName" 2>&1', $out, $ret);
+        $steps['pkg_yukkoview'] = ['ret' => $ret, 'out' => $out];
+    }
+
+    echo json_encode(['debug' => true, 'steps' => $steps], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+    exit;
+}
+
+$runmode = 0;
+if(array_key_exists("start", $_REQUEST)) {
+    $runmode = 1;
+}
+
+if(array_key_exists("stop", $_REQUEST)) {
+    $runmode = 2;
+}
+
+if(array_key_exists("restart", $_REQUEST)) {
+    $runmode = 3;
+}
+
+if(array_key_exists("check", $_REQUEST)) {
+    $runmode = 4;
+}
+
+if(array_key_exists("start_store", $_REQUEST)) {
+    $runmode = 5;
+}
+
+if(array_key_exists("start_yukkoview2", $_REQUEST)) {
+    $runmode = 6;
+}
+
+$result = ['ok' => true, 'msg' => ''];
+
+switch($runmode) {
+    case 1:
+        $listerapi->startyklistercmd();
+        break;
+    case 2:
+        $listerapi->stopyklistercmd();
+        break;
+    case 3:
+        $listerapi->stopyklistercmd();
+        sleep(4);
+        $listerapi->startyklistercmd();
+        break;
+    case 4:
+        break;
+    case 5:
+        $result = $listerapi->startyklistercmd_store();
+        break;
+    case 6:
+        $result = $listerapi->startYukkoView2cmd();
+        break;
+    default:
+        $result = ['ok' => false, 'msg' => '不明なコマンドです'];
+        break;
+}
+
+echo json_encode($result, JSON_UNESCAPED_UNICODE);
+?>
+
+
 $runmode = 0;
 if(array_key_exists("start", $_REQUEST)) {
     $runmode = 1;


### PR DESCRIPTION
## 概要

### 1. ゆかりすたー / ゆっこビュー 2 起動ボタン実装

設定画面 (`init.php`) の「ゆかりすたー起動」ボタンを Windows Store 版に対応させ、隣に「ゆっこビュー 2 起動」ボタンを追加。

**変更ファイル**: `function_search_listerdb.php`, `yklister_exec.php`, `init.php`

- PowerShell `Get-AppxPackage` でインストール検出（ページロード時）
- `exec()` + `Start-Process` で非同期起動（`popen+pclose` はパイプハンドル継承によるブロックが発生するため不使用）
- EXE 版が存在する場合は EXE を優先、なければ Store 版を使用
- 起動中はボタンを無効化＋「起動中…」表示、失敗時は alert でエラー内容を表示
- `createXMLHttpRequest()` が `init.php` では未定義だったバグを `new XMLHttpRequest()` に修正
- デバッグ用エンドポイント `yklister_exec.php?debug=1` を追加

### 2. モバイルナビバー ドロップダウン UI 修正

**変更ファイル**: `css/themes/search.css`

- 折りたたみ時に Bootstrap デフォルトの白いフローティングボックスが表示される問題を修正 → ナビバーの暗い背景に溶け込むようリセット
- ダークモード・文字サイズボタン・Help等 がセンター寄せ＆縦並びになっていた問題を修正 → 横並び・左寄せに変更
- ダークモード・文字サイズボタンを 1 行目、Help等 を 2 行目に分離

## テスト計画

- [ ] ゆかりすたー起動ボタンを押してアプリが起動することを確認
- [ ] ゆっこビュー 2 起動ボタンを押してアプリが起動することを確認
- [ ] 未インストール時にボタンが disabled になることを確認
- [ ] モバイル幅でナビバーを開き、ドロップダウンがナビバー背景に溶け込むことを確認
- [ ] モバイル幅でボタン群が横並び・左寄せになることを確認
- [ ] デスクトップ幅で表示が変わっていないことを確認

https://claude.ai/code/session_018P6uqQhiCW92g8CeyEJYdE

---
_Generated by [Claude Code](https://claude.ai/code/session_018P6uqQhiCW92g8CeyEJYdE)_