### PR TITLE
fix: リクエスト登録・順番入れ替えの同時実行による順番表示の破損を修正

### DIFF
--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2572,10 +2572,14 @@ function mypage_save_keyword_link($keyword, $search_type, $search_params = '') {
  * requesttable の reqorder を連番（1始まり昇順）に正規化する。
  * 現在の reqorder の大小関係を保持したまま隙間・重複を解消する。
  * 同じ reqorder 値を持つ行は id の昇順で並べる。
- * @param PDO $db
+ * @param PDO  $db
+ * @param bool $in_transaction 呼び出し元が既にトランザクションを開始している場合は true。
+ *                             true の場合は BEGIN/COMMIT/ROLLBACK を行わない。
  */
-function normalize_reqorder($db) {
-    $db->beginTransaction();
+function normalize_reqorder($db, $in_transaction = false) {
+    if (!$in_transaction) {
+        $db->beginTransaction();
+    }
     try {
         $select = $db->query("SELECT id, reqorder FROM requesttable ORDER BY reqorder ASC, id ASC");
         $rows = $select->fetchAll(PDO::FETCH_ASSOC);
@@ -2591,9 +2595,13 @@ function normalize_reqorder($db) {
             }
             $pos++;
         }
-        $db->commit();
+        if (!$in_transaction) {
+            $db->commit();
+        }
     } catch (Exception $e) {
-        $db->rollBack();
+        if (!$in_transaction) {
+            $db->rollBack();
+        }
         throw $e;
     }
 }

--- a/exec.php
+++ b/exec.php
@@ -234,34 +234,37 @@ if (is_numeric($selectid)) {
     }
 } else {
     // 新規追加: BEGIN IMMEDIATEで同時アクセス競合を防ぎ、INSERT〜reqorder割り当て〜自動整列を一括処理
-    $db->exec("BEGIN IMMEDIATE;");
-    $ret = $stmt->execute($arg);
-    if (!$ret) {
+    // PDO::ERRMODE_EXCEPTION 設定により、BEGIN IMMEDIATE が SQLITE_BUSY で失敗した場合も
+    // 例外が飛ぶため、try-catch でロールバックを確実に行う
+    try {
+        $db->exec("BEGIN IMMEDIATE;");
+        $stmt->execute($arg);
+        $newid = (int)$db->lastInsertId();
+        // reqorder は「現在の最大値+1」とし、新規予約を末尾（最後に再生）に追加する
+        $maxrow = $db->query(
+            "SELECT COALESCE(MAX(reqorder), 0) AS maxreq FROM requesttable WHERE id != " . $newid
+        )->fetch(PDO::FETCH_ASSOC);
+        $newreqorder = (int)$maxrow['maxreq'] + 1;
+        $stmt_u = $db->prepare('UPDATE requesttable SET reqorder = :reqorder, status = \'OK\' WHERE id = :id');
+        $stmt_u->bindValue(':reqorder', $newreqorder, PDO::PARAM_INT);
+        $stmt_u->bindValue(':id', $newid, PDO::PARAM_INT);
+        $stmt_u->execute();
+        if (!empty($DEBUG))
+            print "reqorder set to {$newreqorder} for id={$newid}<br />";
+        if ($config_ini["request_automove"] == 1) {
+            require_once('function_moveitem.php');
+            $list = new MoveItem;
+            $list->getturnlist($db);
+            $newreq = $list->get_new_reqorder($newid);
+            $list->insertreqorder($newid, $newreq);
+            $list->save_allrequest($db);
+        }
+        $db->exec("COMMIT;");
+    } catch (Exception $e) {
         $db->exec("ROLLBACK;");
-        print(htmlspecialchars((string)$l_filename, ENT_QUOTES, 'UTF-8') . " を追加にしっぱいしました。");
+        print(htmlspecialchars((string)$l_filename, ENT_QUOTES, 'UTF-8') . " を追加に失敗しました。しばらく待ってから再試行してください。");
         die();
     }
-    $newid = (int)$db->lastInsertId();
-    // reqorder は「現在の最大値+1」とし、新規予約を末尾（最後に再生）に追加する
-    $maxrow = $db->query(
-        "SELECT COALESCE(MAX(reqorder), 0) AS maxreq FROM requesttable WHERE id != " . $newid
-    )->fetch(PDO::FETCH_ASSOC);
-    $newreqorder = (int)$maxrow['maxreq'] + 1;
-    $stmt_u = $db->prepare('UPDATE requesttable SET reqorder = :reqorder, status = \'OK\' WHERE id = :id');
-    $stmt_u->bindValue(':reqorder', $newreqorder, PDO::PARAM_INT);
-    $stmt_u->bindValue(':id', $newid, PDO::PARAM_INT);
-    $stmt_u->execute();
-    if (!empty($DEBUG))
-        print "reqorder set to {$newreqorder} for id={$newid}<br />";
-    if ($config_ini["request_automove"] == 1) {
-        require_once('function_moveitem.php');
-        $list = new MoveItem;
-        $list->getturnlist($db);
-        $newreq = $list->get_new_reqorder($newid);
-        $list->insertreqorder($newid, $newreq);
-        $list->save_allrequest($db);
-    }
-    $db->exec("COMMIT;");
 
     // ListerDB から曲情報を取得して保存
     if (!empty($l_fullpath) && array_key_exists('listerDBPATH', $config_ini)) {

--- a/kara_config.php
+++ b/kara_config.php
@@ -320,11 +320,17 @@ function initdb(&$db,$dbname)
 {
 
 try {
-	$db = new PDO('sqlite:'. $dbname);
+	$db = new PDO('sqlite:'. $dbname, null, null, [
+		PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+		PDO::ATTR_TIMEOUT => 5,
+	]);
+	// WAL モードで読み書きの並行性を向上し、busy_timeout で書き込みロック待ちを最大5秒許容する
+	$db->exec('PRAGMA journal_mode=WAL;');
+	$db->exec('PRAGMA busy_timeout=5000;');
 } catch(PDOException $e) {
 	printf("new PDO Error: %s\n", $e->getMessage());
 	die();
-} 
+}
 $sql = "create table IF NOT EXISTS requesttable (
  id INTEGER PRIMARY KEY AUTOINCREMENT, 
  songfile  varchar(1024), 

--- a/requestlist_reorder.php
+++ b/requestlist_reorder.php
@@ -24,7 +24,8 @@ if (empty($ids)) {
 
 $total = count($ids);
 try {
-    $db->beginTransaction();
+    // BEGIN IMMEDIATE で書き込みロックを先取りし、連番割り当て〜正規化を分断されずに一括処理する
+    $db->exec("BEGIN IMMEDIATE;");
     $stmt = $db->prepare("UPDATE requesttable SET reqorder = :reqorder WHERE id = :id");
     foreach ($ids as $index => $id) {
         // 先頭アイテム(index=0)が最大reqorder（ORDER BY reqorder DESC で先頭表示）
@@ -34,16 +35,17 @@ try {
         $stmt->bindValue(':id', (int)$id, PDO::PARAM_INT);
         $stmt->execute();
     }
-    $db->commit();
-} catch (PDOException $e) {
-    $db->rollBack();
+    // ドラッグ&ドロップ対象外のレコード（再生中など）も含めて連番に正規化する
+    // 同一トランザクション内で実行することで、normalize と連番割り当ての間に
+    // 別プロセスが割り込んで reqorder を変更する競合状態を防ぐ
+    normalize_reqorder($db, true);
+    $db->exec("COMMIT;");
+} catch (Exception $e) {
+    $db->exec("ROLLBACK;");
     http_response_code(500);
     echo json_encode(['status' => 'error', 'message' => 'DB error']);
     exit;
 }
-
-// ドラッグ&ドロップ対象外のレコード（再生中など）も含めて連番に正規化する
-normalize_reqorder($db);
 
 $un = new UpdateNotice();
 $un->initdb();

--- a/test_race/run_test.php
+++ b/test_race/run_test.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * 競合状態テストランナー（PHP版・バリア同期）
+ */
+
+define('PARALLEL',  20);
+define('WORKER',    __DIR__ . '/worker.php');
+define('DB_BEFORE', '/tmp/race_before.db');
+define('DB_AFTER',  '/tmp/race_after.db');
+
+function init_db(string $path): void {
+    foreach ([$path, "$path-wal", "$path-shm"] as $f) {
+        if (file_exists($f)) unlink($f);
+    }
+    $db = new PDO('sqlite:' . $path, null, null, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    ]);
+    $db->exec("CREATE TABLE IF NOT EXISTS requesttable (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        songfile TEXT,
+        singer   TEXT,
+        reqorder INTEGER DEFAULT 0
+    )");
+}
+
+function clean_barrier(string $mode): void {
+    $dir = "/tmp/race_barrier_{$mode}";
+    if (is_dir($dir)) {
+        foreach (glob("{$dir}/*") as $f) unlink($f);
+        rmdir($dir);
+    }
+}
+
+function check_result(string $path, int $fail_count): void {
+    $db = new PDO('sqlite:' . $path, null, null, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    ]);
+
+    $total     = (int)$db->query("SELECT COUNT(*) FROM requesttable")->fetchColumn();
+    $dup_rows  = $db->query(
+        "SELECT reqorder, COUNT(*) AS cnt
+           FROM requesttable
+          GROUP BY reqorder
+         HAVING cnt > 1
+          ORDER BY reqorder"
+    )->fetchAll(PDO::FETCH_ASSOC);
+    $dup_count = count($dup_rows);
+    $min_req   = $db->query("SELECT MIN(reqorder) FROM requesttable")->fetchColumn();
+    $max_req   = $db->query("SELECT MAX(reqorder) FROM requesttable")->fetchColumn();
+
+    echo "  登録件数               : {$total} / " . PARALLEL . "\n";
+    echo "  reqorder 重複グループ数: {$dup_count}  ← 0 なら正常\n";
+    echo "  reqorder 範囲          : {$min_req} 〜 {$max_req}\n";
+    echo "  プロセス失敗数         : {$fail_count}\n";
+
+    if ($dup_count > 0) {
+        echo "  ⚠ 重複詳細:\n";
+        foreach ($dup_rows as $r) {
+            echo "    reqorder={$r['reqorder']}  件数={$r['cnt']}\n";
+        }
+    }
+
+    $status = ($dup_count === 0 && $fail_count === 0) ? '✅ PASS' : '❌ FAIL（重複あり）';
+    echo "  結果: {$status}\n";
+}
+
+function run_parallel(string $mode, string $dbfile): int {
+    $procs = [];
+    for ($i = 1; $i <= PARALLEL; $i++) {
+        $cmd  = "php " . WORKER . " {$mode} {$dbfile} {$i} " . PARALLEL;
+        $desc = [['pipe','r'],['pipe','w'],['pipe','w']];
+        $procs[] = ['proc' => proc_open($cmd, $desc, $pipes), 'pipes' => $pipes];
+    }
+
+    $fail = 0;
+    foreach ($procs as &$p) {
+        $out = stream_get_contents($p['pipes'][1]);
+        fclose($p['pipes'][0]);
+        fclose($p['pipes'][1]);
+        fclose($p['pipes'][2]);
+        $code = proc_close($p['proc']);
+        echo $out;
+        if ($code !== 0) $fail++;
+    }
+    return $fail;
+}
+
+// ── メイン ──────────────────────────────────────────────────
+echo str_repeat('=', 52) . "\n";
+echo "  競合状態テスト (並列数: " . PARALLEL . ")\n";
+echo str_repeat('=', 52) . "\n\n";
+
+echo "── 修正前 (ERRMODE_SILENT / トランザクションなし) ──\n";
+init_db(DB_BEFORE);
+clean_barrier('before');
+echo "▶ 全" . PARALLEL . "プロセスが INSERT 後に一斉に MAX+1 採番...\n";
+$fail_before = run_parallel('before', DB_BEFORE);
+echo "\n";
+check_result(DB_BEFORE, $fail_before);
+
+echo "\n";
+echo "── 修正後 (ERRMODE_EXCEPTION / WAL / busy_timeout / BEGIN IMMEDIATE) ──\n";
+init_db(DB_AFTER);
+clean_barrier('after');
+echo "▶ 全" . PARALLEL . "プロセスが BEGIN IMMEDIATE 内で INSERT+採番...\n";
+$fail_after = run_parallel('after', DB_AFTER);
+echo "\n";
+check_result(DB_AFTER, $fail_after);
+
+echo "\n" . str_repeat('=', 52) . "\n";
+echo "テスト完了\n";

--- a/test_race/run_test.sh
+++ b/test_race/run_test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# 競合状態テストランナー
+# 修正前 (before) と修正後 (after) をそれぞれ PARALLEL プロセス並列で実行し、
+# reqorder の重複数を比較する
+
+PARALLEL=20       # 同時並列数
+WORKER="$(dirname "$0")/worker.php"
+DBFILE_BEFORE="/tmp/race_test_before.db"
+DBFILE_AFTER="/tmp/race_test_after.db"
+SCHEMA="CREATE TABLE IF NOT EXISTS requesttable (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  songfile TEXT,
+  singer TEXT,
+  reqorder INTEGER DEFAULT 0
+);"
+
+run_test() {
+    local mode="$1"
+    local dbfile="$2"
+
+    # DB を毎回クリーン作成
+    rm -f "$dbfile" "${dbfile}-wal" "${dbfile}-shm"
+    sqlite3 "$dbfile" "$SCHEMA"
+
+    echo "▶ [${mode}] ${PARALLEL}プロセス並列で INSERT+採番..."
+    local pids=()
+    for i in $(seq 1 $PARALLEL); do
+        php "$WORKER" "$mode" "$dbfile" "$i" &
+        pids+=($!)
+    done
+
+    # 全プロセス終了を待つ
+    local fail=0
+    for pid in "${pids[@]}"; do
+        wait "$pid" || ((fail++))
+    done
+
+    # 結果検証
+    local total dup_count min_req max_req
+    total=$(sqlite3 "$dbfile" "SELECT COUNT(*) FROM requesttable;")
+    dup_count=$(sqlite3 "$dbfile" \
+        "SELECT COUNT(*) FROM (
+           SELECT reqorder, COUNT(*) AS c
+             FROM requesttable
+            GROUP BY reqorder
+           HAVING c > 1
+         );")
+    min_req=$(sqlite3 "$dbfile" "SELECT MIN(reqorder) FROM requesttable;")
+    max_req=$(sqlite3 "$dbfile" "SELECT MAX(reqorder) FROM requesttable;")
+
+    echo ""
+    echo "  登録件数          : ${total} / ${PARALLEL}"
+    echo "  reqorder 重複グループ数: ${dup_count}  ← 0なら正常"
+    echo "  reqorder 範囲     : ${min_req} 〜 ${max_req}"
+    echo "  プロセス失敗数    : ${fail}"
+
+    if [ "$dup_count" -gt 0 ]; then
+        echo "  ⚠ 重複詳細:"
+        sqlite3 "$dbfile" \
+            "SELECT reqorder, COUNT(*) AS cnt
+               FROM requesttable
+              GROUP BY reqorder
+             HAVING cnt > 1
+             ORDER BY reqorder;"
+    fi
+    echo ""
+}
+
+echo "=========================================="
+echo "  競合状態テスト (並列数: ${PARALLEL})"
+echo "=========================================="
+echo ""
+echo "── 修正前 (ERRMODE_SILENT / busy_timeout=0) ──"
+run_test "before" "$DBFILE_BEFORE"
+
+echo "── 修正後 (ERRMODE_EXCEPTION / WAL / busy_timeout=5000) ──"
+run_test "after" "$DBFILE_AFTER"
+
+echo "=========================================="
+echo "テスト完了"

--- a/test_race/worker.php
+++ b/test_race/worker.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * 競合状態テスト用ワーカー（2段階バリア版）
+ *
+ * 2段階バリアで「全員が同じ MAX 値を読んだ後に一斉に UPDATE」する状況を作り、
+ * 修正前の reqorder 重複を確実に再現する。
+ *
+ * before: トランザクションなし + 2段階バリア
+ *   → 全員が MAX=0 を読み → 全員が reqorder=1 を設定 → 重複 20 件
+ *
+ * after : BEGIN IMMEDIATE（バリア前）+ busy_timeout
+ *   → 1 プロセスだけ lock 取得、残りは自動待機 → 重複なし
+ */
+$mode    = $argv[1] ?? 'after';
+$dbfile  = $argv[2] ?? '/tmp/race_test.db';
+$wid     = (int)($argv[3] ?? getmypid());
+$total   = (int)($argv[4] ?? 20);
+
+$bar = "/tmp/race_barrier_{$mode}";
+
+function wait_barrier(string $dir, string $tag, int $total): void {
+    $deadline = microtime(true) + 10.0;
+    while (count(glob("{$dir}/{$tag}_*")) < $total) {
+        if (microtime(true) > $deadline) break;
+        usleep(300);
+    }
+}
+
+// ════════════════════════════════════════════════════════════
+// 修正前: トランザクションなし + 2段階バリア
+//   Stage1: 全員 INSERT 完了を待つ（全員のINSERT後にMAX取得を確実に揃える）
+//   Stage2: 全員 MAX 取得完了を待つ（同じ値を読んだことを確認してから一斉UPDATE）
+// ════════════════════════════════════════════════════════════
+if ($mode === 'before') {
+
+    $db = new PDO('sqlite:' . $dbfile);
+
+    // Stage1: INSERT
+    @mkdir($bar, 0777, true);
+    $stmt = $db->prepare(
+        "INSERT INTO requesttable (songfile, singer, reqorder)
+         VALUES (:fn, :sing, 0)"
+    );
+    $stmt->execute([':fn' => "song_{$wid}", ':sing' => "worker_{$wid}"]);
+    $newid = (int)$db->lastInsertId();
+    file_put_contents("{$bar}/s1_{$wid}", '1');
+    wait_barrier($bar, 's1', $total);
+    // ここで全員の INSERT が完了している → MAX(reqorder) はまだ全員 0
+
+    // Stage2: MAX 取得（全員が同じ 0 を読む）
+    $maxrow = $db->query(
+        "SELECT COALESCE(MAX(reqorder), 0) AS maxreq
+           FROM requesttable WHERE id != " . $newid
+    )->fetch(PDO::FETCH_ASSOC);
+    $newreqorder = (int)$maxrow['maxreq'] + 1;  // 全員が 1 になる
+    file_put_contents("{$bar}/s2_{$wid}", '1');
+    wait_barrier($bar, 's2', $total);
+    // ここで全員が reqorder=1 を持っている状態で一斉に UPDATE
+
+    // Stage3: UPDATE（全員が reqorder=1 を書く → 重複確定）
+    $stmt_u = $db->prepare(
+        'UPDATE requesttable SET reqorder = :req WHERE id = :id'
+    );
+    $stmt_u->bindValue(':req', $newreqorder, PDO::PARAM_INT);
+    $stmt_u->bindValue(':id',  $newid,       PDO::PARAM_INT);
+    $stmt_u->execute();
+
+    echo "OK worker={$wid} id={$newid} reqorder={$newreqorder}\n";
+
+// ════════════════════════════════════════════════════════════
+// 修正後: BEGIN IMMEDIATE + busy_timeout=5000
+//   同じバリア後に一斉に BEGIN IMMEDIATE → 1 プロセスずつ順番待ち
+//   ロック保持中は他プロセスの MAX 取得も後になる → 重複しない
+// ════════════════════════════════════════════════════════════
+} else {
+
+    $db = new PDO('sqlite:' . $dbfile, null, null, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_TIMEOUT => 5,
+    ]);
+    $db->exec('PRAGMA journal_mode=WAL;');
+    $db->exec('PRAGMA busy_timeout=5000;');
+
+    // 修正前と同じタイミングで BEGIN IMMEDIATE を試みる
+    @mkdir($bar, 0777, true);
+    file_put_contents("{$bar}/s1_{$wid}", '1');
+    wait_barrier($bar, 's1', $total);
+
+    try {
+        // 全員が一斉に BEGIN IMMEDIATE を試みる。
+        // busy_timeout=5000ms の間 SQLite が自動リトライするため、
+        // 1 プロセスずつ順番に処理されて reqorder は重複しない。
+        $db->exec("BEGIN IMMEDIATE;");
+
+        $stmt = $db->prepare(
+            "INSERT INTO requesttable (songfile, singer, reqorder)
+             VALUES (:fn, :sing, 0)"
+        );
+        $stmt->execute([':fn' => "song_{$wid}", ':sing' => "worker_{$wid}"]);
+        $newid = (int)$db->lastInsertId();
+
+        $maxrow = $db->query(
+            "SELECT COALESCE(MAX(reqorder), 0) AS maxreq
+               FROM requesttable WHERE id != " . $newid
+        )->fetch(PDO::FETCH_ASSOC);
+        $newreqorder = (int)$maxrow['maxreq'] + 1;
+
+        $stmt_u = $db->prepare(
+            'UPDATE requesttable SET reqorder = :req WHERE id = :id'
+        );
+        $stmt_u->bindValue(':req', $newreqorder, PDO::PARAM_INT);
+        $stmt_u->bindValue(':id',  $newid,       PDO::PARAM_INT);
+        $stmt_u->execute();
+
+        $db->exec("COMMIT;");
+        echo "OK worker={$wid} id={$newid} reqorder={$newreqorder}\n";
+
+    } catch (Exception $e) {
+        try { $db->exec("ROLLBACK;"); } catch (Exception $_) {}
+        echo "FAIL worker={$wid} " . $e->getMessage() . "\n";
+        exit(1);
+    }
+}


### PR DESCRIPTION
## 概要

リクエスト登録や順番入れ替えが同時に実行されると、`reqorder`（再生順位置）が重複・破損し、順番表示が壊れる競合状態（race condition）を修正しました。

## 根本原因

SQLite の PDO 接続設定に問題がありました（`kara_config.php`）。

- **`busy_timeout` 未設定（=0）** … 別プロセスがロック中だと「待たずに即失敗」。XAMPP は各リクエストが別プロセス＝別接続のため、同時アクセス時に必ず衝突する。
- **`ERRMODE` 未設定（SILENT）** … ロック失敗時に例外が飛ばず `execute()` が `false` を返すだけ。多くの箇所が戻り値を見ないため、書き込みが黙って欠落していた。

加えて、並べ替え処理が2つの別トランザクションに分断されており、その隙間に新規登録が割り込めていました。

## 修正内容

### `kara_config.php` — 根本原因の解消（最重要）
PDO 接続に `ERRMODE_EXCEPTION` / `busy_timeout=5000` / WAL モードを設定。

### `requestlist_reorder.php` + `commonfunc.php` — 並べ替えの分断を解消
「連番割り当て」と「正規化（normalize_reqorder）」を `BEGIN IMMEDIATE` の単一トランザクションに統合。`normalize_reqorder()` に `$in_transaction` パラメータを追加し、既存トランザクション内からの呼び出しに対応。

### `exec.php` — BUSY 例外の確実なキャッチ
`BEGIN IMMEDIATE` ブロックを `try-catch` で囲み、`SQLITE_BUSY` 例外を含む全エラーを確実にロールバック・ユーザー通知するよう修正。トランザクションなしのまま二重採番が走るバグを防止。

## テスト

`test_race/` に競合状態の再現テストを追加。2段階バリア同期で「全プロセスが同じ MAX 値を読んだ後に一斉に UPDATE」する状況を再現します。

```
php test_race/run_test.php
```

**実行結果（並列20プロセス）:**

| | 修正前 | 修正後 |
|---|---|---|
| reqorder 重複グループ数 | 1（全20件が reqorder=1） | 0（1〜20、重複なし） |
| 結果 | ❌ FAIL | ✅ PASS |

修正前は全20プロセスが同時に `MAX(reqorder)=0` を読み、全員が `reqorder=1` を設定して重複。修正後は `BEGIN IMMEDIATE` + `busy_timeout` により1プロセスずつ順番に採番され、全て異なる値が振られることを確認しました。

https://claude.ai/code/session_011DB3shczZvTZfLF4azBqZ1

---
_Generated by [Claude Code](https://claude.ai/code/session_011DB3shczZvTZfLF4azBqZ1)_