### PR TITLE
検索結果のデフォルトソートを更新日順に統一＆ページネーション時のソート保持を修正

### DIFF
--- a/search_listerdb_filelist.php
+++ b/search_listerdb_filelist.php
@@ -138,6 +138,8 @@ if(!empty($select_orderby) && !empty($select_scending) ) {
    $select_orderby  = "found_last_write_time";
    $select_scending = "desc";
 }
+$myrequestarray["orderby"]  = $select_orderby;
+$myrequestarray["scending"] = $select_scending;
 
 
 $match = "";

--- a/search_listerdb_filelist_bs5.php
+++ b/search_listerdb_filelist_bs5.php
@@ -51,9 +51,9 @@ if (array_key_exists("scending", $_REQUEST) && in_array(strtoupper($_REQUEST["sc
 }
 if (empty($select_orderby))  $select_orderby  = 'found_last_write_time';
 if (empty($select_scending)) $select_scending = 'desc';
-$select_orderby_str = (!empty($select_orderby) && !empty($select_scending))
-    ? $select_orderby . ' ' . $select_scending
-    : 'found_last_write_time desc';
+$select_orderby_str = $select_orderby . ' ' . $select_scending;
+$myrequestarray["orderby"]  = $select_orderby;
+$myrequestarray["scending"] = $select_scending;
 
 $recommendation = 'on';
 if (array_key_exists("recommendation", $_REQUEST) && in_array($_REQUEST["recommendation"], ['on','off'])) {

--- a/search_listerdb_songlist.php
+++ b/search_listerdb_songlist.php
@@ -99,8 +99,6 @@ if(array_key_exists("tie_up_group_name", $_REQUEST)) {
 }
 
 
-$select_orderby_str ="song_name asc, found_file_size desc";
-
 $valid_orderby_cols = array('found_file_size', 'found_last_write_time', 'song_name', 'song_artist');
 $select_orderby = "";
 if(array_key_exists("orderby", $_REQUEST) && in_array($_REQUEST["orderby"], $valid_orderby_cols)) {
@@ -110,10 +108,11 @@ $select_scending ="";
 if(array_key_exists("scending", $_REQUEST) && in_array(strtoupper($_REQUEST["scending"]), array('ASC','DESC'))) {
     $select_scending = strtoupper($_REQUEST["scending"]);
 }
-
-if(!empty($select_orderby) && !empty($select_scending) ) {
-   $select_orderby_str = $select_orderby . ' ' . $select_scending;
-}
+if(empty($select_orderby))  $select_orderby  = "found_last_write_time";
+if(empty($select_scending)) $select_scending = "desc";
+$select_orderby_str = $select_orderby . ' ' . $select_scending;
+$myrequestarray["orderby"]  = $select_orderby;
+$myrequestarray["scending"] = $select_scending;
 
 
 $match = "";

--- a/search_listerdb_songlist_bs5.php
+++ b/search_listerdb_songlist_bs5.php
@@ -34,9 +34,11 @@ $select_orderby  = '';
 $select_scending = '';
 if (array_key_exists("orderby",   $_REQUEST) && in_array($_REQUEST["orderby"],   $valid_orderby))         $select_orderby  = $_REQUEST["orderby"];
 if (array_key_exists("scending",  $_REQUEST) && in_array(strtoupper($_REQUEST["scending"]), ['ASC','DESC'])) $select_scending = strtoupper($_REQUEST["scending"]);
-$select_orderby_str = (!empty($select_orderby) && !empty($select_scending))
-    ? $select_orderby . ' ' . $select_scending
-    : 'song_name asc, found_file_size desc';
+if (empty($select_orderby))  $select_orderby  = 'found_last_write_time';
+if (empty($select_scending)) $select_scending = 'desc';
+$select_orderby_str = $select_orderby . ' ' . $select_scending;
+$myrequestarray["orderby"]  = $select_orderby;
+$myrequestarray["scending"] = $select_scending;
 
 $selectid   = array_key_exists("selectid", $_REQUEST) ? $_REQUEST["selectid"] : '';
 $linkoption = !empty($selectid) ? '&selectid=' . rawurlencode($selectid) : '';


### PR DESCRIPTION
## 概要

ListerDB検索画面（songlist / filelist）で発生していた2つのソート関連バグを修正します。

## 修正した不具合

### ① デフォルトソートがファイルサイズ順になっていた

`search_listerdb_songlist.php` / `search_listerdb_songlist_bs5.php` でデフォルトのソート順が `song_name asc, found_file_size desc` になっており、他の画面と統一されていなかった。

→ `found_last_write_time desc`（更新日降順）に変更し、filelist と統一

### ② 「次の50件」を押すとソートがリセットされる

ユーザーがソートを変更しても、ページネーションリンクのURLにソート条件（`orderby` / `scending`）が含まれていなかったため、次のページに遷移するとデフォルト（ファイルサイズ）に戻っていた。

→ ソート確定後に必ず `$myrequestarray["orderby"]` / `$myrequestarray["scending"]` を設定し、ページネーションURLにも引き継がれるよう修正

## 修正ファイル

| ファイル | 修正内容 |
|---|---|
| `search_listerdb_songlist_bs5.php` | デフォルトを更新日降順に変更、ソートを`$myrequestarray`に保持 |
| `search_listerdb_songlist.php` | デフォルトを更新日降順に変更、ソートを`$myrequestarray`に保持 |
| `search_listerdb_filelist_bs5.php` | デフォルトソートを`$myrequestarray`に保持（ページネーション修正） |
| `search_listerdb_filelist.php` | デフォルトソートを`$myrequestarray`に保持（ページネーション修正） |

## テスト確認

- デフォルト（パラメータなし）→ `found_last_write_time desc` ✓
- 明示的にソート指定 → 指定通りに反映 ✓
- Cookie経由でソート指定 → 正しく引き継ぎ ✓
- ページネーションURL → `orderby` / `scending` が含まれ次ページでも維持 ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_012gJs3MagctyDQM7KuNrf6H)_