### PR TITLE
なんでも検索の履歴を入力文字で部分一致フィルタ表示

### DIFF
--- a/search_bs5.php
+++ b/search_bs5.php
@@ -452,6 +452,14 @@ endif;
     var dropdown = document.getElementById("search-history-dropdown");
     if (!dropdown) return;
     var hist = getHistory();
+    // 入力中の文字で履歴を部分一致フィルタ（大文字小文字を区別しない）
+    var input = document.getElementById("anyword");
+    var filter = input ? input.value.trim().toLowerCase() : "";
+    if (filter) {
+      hist = hist.filter(function (h) {
+        return h.toLowerCase().indexOf(filter) !== -1;
+      });
+    }
     if (hist.length === 0) { dropdown.hidden = true; dropdown.innerHTML = ""; return; }
 
     var html = "<ul class=\"search-history-list\">";
@@ -503,6 +511,9 @@ endif;
     });
 
     input.addEventListener("focus", function () {
+      if (getHistory().length > 0) renderDropdown();
+    });
+    input.addEventListener("input", function () {
       if (getHistory().length > 0) renderDropdown();
     });
     input.addEventListener("blur", function () {


### PR DESCRIPTION
## 概要

`search_bs5.php` のなんでも検索（ListerDB ファイル検索）において、検索履歴ドロップダウンを入力文字で部分一致フィルタ表示するよう変更しました。

## 変更内容

- `renderDropdown()` に入力欄（`#anyword`）の現在値で履歴を部分一致フィルタする処理を追加
- `input` イベントリスナーを追加し、文字入力のたびに `renderDropdown()` を再実行

## 動作

| 操作 | 変更前 | 変更後 |
|------|--------|--------|
| 入力欄にフォーカス | 全履歴を表示 | 全履歴を表示（変更なし） |
| 文字を入力 | 全履歴を表示したまま | 入力文字に部分一致する履歴のみ表示 |
| 入力欄を空にする | — | 全履歴を再表示 |
| 一致する履歴がない | — | ドロップダウンを非表示 |

- 大文字・小文字は区別しません（例: 「HELLO」→「hello kitty」にマッチ）
- 履歴の保存方式（localStorage `krw_search_history`、最大10件）は変更なし

## テスト

Playwright (Chromium) でブラウザ動作を確認済み。全7ケース PASS。

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNt7htspasaqpztDhNvnav)_