### PR TITLE
なんでも検索: 履歴フィルタ機能追加＋ファイル名タップでフルパス切り替え

### DIFF
--- a/search_listerdb_anysearch_index_bs5.php
+++ b/search_listerdb_anysearch_index_bs5.php
@@ -170,6 +170,13 @@ if (empty($includepage)) {
     var dropdown = document.getElementById("search-history-dropdown");
     if (!dropdown) return;
     var hist = getHistory();
+    var input = document.getElementById("anyword");
+    var filter = input ? input.value.trim().toLowerCase() : "";
+    if (filter) {
+      hist = hist.filter(function (h) {
+        return h.toLowerCase().indexOf(filter) !== -1;
+      });
+    }
     if (hist.length === 0) { dropdown.hidden = true; dropdown.innerHTML = ""; return; }
 
     var html = "<ul class=\"search-history-list\">";
@@ -221,6 +228,9 @@ if (empty($includepage)) {
     });
 
     input.addEventListener("focus", function () {
+      if (getHistory().length > 0) renderDropdown();
+    });
+    input.addEventListener("input", function () {
       if (getHistory().length > 0) renderDropdown();
     });
     input.addEventListener("blur", function () {

--- a/search_listerdb_filelist_bs5.php
+++ b/search_listerdb_filelist_bs5.php
@@ -187,7 +187,10 @@ function filelistfromsong_bs5($filelist, $linkoption, $listerpreviewportenable) 
         echo '<a href="' . htmlspecialchars(create_requestconfirmlink_bs5($fi, $linkoption), ENT_QUOTES, 'UTF-8') . '" class="btn-request flex-shrink-0">リクエスト</a>';
         echo '<div class="flex-grow-1" style="min-width:0;">';
         if (!empty($comment)) echo '<div class="text-secondary mb-1" style="font-size:0.8rem;">【' . htmlspecialchars($comment, ENT_QUOTES, 'UTF-8') . '】</div>';
-        echo '<div class="fw-semibold text-break mb-1">' . htmlspecialchars($fname, ENT_QUOTES, 'UTF-8') . '</div>';
+        echo '<div class="fw-semibold text-break mb-1 filename-toggle" style="cursor:pointer;" title="タップでフルパス表示"'
+           . ' data-filename="' . htmlspecialchars($fname, ENT_QUOTES, 'UTF-8') . '"'
+           . ' data-fullpath="' . htmlspecialchars($fi['found_path'], ENT_QUOTES, 'UTF-8') . '">'
+           . htmlspecialchars($fname, ENT_QUOTES, 'UTF-8') . '</div>';
         echo '<div class="d-flex flex-wrap align-items-center gap-2" style="font-size:0.78rem;color:var(--color-text-muted);">';
         if (!empty($fi['found_track'])) {
             $vocal_badges = '';
@@ -431,7 +434,10 @@ $displaylast = min($displayfrom + $displaynum, $programlist['recordsTotal']);
           <?php endif; ?>
           <?php echo mypage_action_links($program['found_path'], $display); ?>
         </div>
-        <div class="text-muted mt-1" style="font-size:0.7rem;word-break:break-all;"><?php echo htmlspecialchars(basename_jp($program['found_path']), ENT_QUOTES, 'UTF-8'); ?></div>
+        <div class="text-muted mt-1 filename-toggle" style="font-size:0.7rem;word-break:break-all;cursor:pointer;" title="タップでフルパス表示"
+             data-filename="<?php echo htmlspecialchars(basename_jp($program['found_path']), ENT_QUOTES, 'UTF-8'); ?>"
+             data-fullpath="<?php echo htmlspecialchars($program['found_path'], ENT_QUOTES, 'UTF-8'); ?>"
+        ><?php echo htmlspecialchars(basename_jp($program['found_path']), ENT_QUOTES, 'UTF-8'); ?></div>
       </div>
       <?php if ($listerpreviewportenable): ?>
         <?php $pm = make_preview_modal_bs5($program['found_path'], 'pm_m_' . $k); ?>
@@ -450,5 +456,18 @@ build_pagination_bs5($displayfrom, $displaynum, $programlist['recordsTotal'], $m
 <?php endif; ?>
 <?php endif; ?>
 </div>
+<script>
+document.addEventListener("click", function (e) {
+  var el = e.target.closest(".filename-toggle");
+  if (!el) return;
+  if (el.dataset.showing === "fullpath") {
+    el.textContent = el.dataset.filename;
+    el.dataset.showing = "filename";
+  } else {
+    el.textContent = el.dataset.fullpath;
+    el.dataset.showing = "fullpath";
+  }
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## 変更内容

### 1. なんでも検索画面での履歴フィルタ機能（`search_listerdb_anysearch_index_bs5.php`）

`search_bs5.php` に実装済みの「入力文字で部分一致フィルタ表示」を同画面にも移植しました。

- `renderDropdown()` に入力フィールドの現在値による部分一致フィルタ処理を追加
- `input` イベントリスナーを追加し、文字を打つたびにドロップダウンが即時更新されるように

### 2. 検索結果のファイル名タップでフルパス切り替え（`search_listerdb_filelist_bs5.php`）

- 検索結果のファイル名表示要素に `data-filename` / `data-fullpath` 属性を付与
- タップするたびにファイル名 ↔ フルパスをトグル表示するクリックハンドラを追加
- 対象は単曲グループ表示・複数曲リスト表示の両パス
- `cursor:pointer` + `title="タップでフルパス表示"` でタップ可能と分かるように

## テスト

- PHP構文チェック：両ファイルともエラーなし
- トグルロジック・履歴フィルタロジックをNode.jsで動作確認済み
- 手元の実機でも動作確認済み（ユーザー報告）

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6mqf6vhJYRyaNeVVPaDPq)_