### PR TITLE
perf/fix: request_confirm_bs5 の表示速度改善と getID3 関連バグ修正

### DIFF
--- a/func_audiotracklist.php
+++ b/func_audiotracklist.php
@@ -67,102 +67,98 @@ function checktracktype($trackinfo){
     return false;
 }
 
-function getaudiotracklist($filename){
-    $getID3 = new getID3();
-    $getID3->options_audiovideo_quicktime_ReturnAtomData = true;
+// --- 内部ヘルパー: analyze済み $info からオーディオトラックリストを抽出 ---
+function _audiotracklist_from_info($info) {
     $audiotracklist = array();
-    $workencode = 'UTF-8';
-    
-    if(getphpversion_fa() < 70100 ){
-       $workencode = 'SJIS-win';
-    }
-    $filename_host= mb_convert_encoding($filename, $workencode, 'UTF-8');
-    setlocale(LC_CTYPE, 'Japanese_Japan.932');
-    $res = file_exist_check_japanese($filename_host);
-    if($res){
-       //★request_confirm.phpの再生方法とキー変更の間にWarningが表示されないよう対応
-       $error_level = error_reporting();	//★エラーレベルを退避
-       error_reporting($error_level-E_WARNING);	//★エラーレベルから警告を除外
-       $info = $getID3->analyze($filename_host);
-       error_reporting($error_level);	//★エラーレベルを元に戻す
-    } else return $audiotracklist;
-
-    getid3_lib::CopyTagsToComments($info);
-    
-    if(!array_key_exists('quicktime',$info) ){
-       return $audiotracklist;
-    }
-
+    if (!array_key_exists('quicktime', $info)) return $audiotracklist;
     $tracklist = $info['quicktime']['moov']['subatoms'];
-    foreach ($tracklist as $trackinfo){
-       if($trackinfo['name'] !== 'trak' ) continue;
-       $tracktype = checktracktype($trackinfo);
-       if(($tracktype != false) && ($tracktype[0] == 2) ){
-           $audiotracklist[] = $tracktype;
-       }
+    foreach ($tracklist as $trackinfo) {
+        if ($trackinfo['name'] !== 'trak') continue;
+        $tracktype = checktracktype($trackinfo);
+        if (($tracktype != false) && ($tracktype[0] == 2)) {
+            $audiotracklist[] = $tracktype;
+        }
     }
     return $audiotracklist;
 }
 
-function getvideodetails($filename) {
-    $getID3 = new getID3();
+// --- 内部ヘルパー: analyze済み $info から動画詳細を抽出 ---
+function _videodetails_from_info($info) {
     $details = array();
-    $workencode = 'UTF-8';
-
-    if (getphpversion_fa() < 70100) {
-        $workencode = 'SJIS-win';
-    }
-    $filename_host = mb_convert_encoding($filename, $workencode, 'UTF-8');
-    setlocale(LC_CTYPE, 'Japanese_Japan.932');
-    if (!file_exist_check_japanese($filename_host)) return $details;
-
-    $error_level = error_reporting();
-    error_reporting($error_level - E_WARNING);
-    $info = $getID3->analyze($filename_host);
-    error_reporting($error_level);
-
-    getid3_lib::CopyTagsToComments($info);
-
     if (!empty($info['playtime_seconds'])) {
         $total_seconds = (int)round($info['playtime_seconds']);
         $details['duration_seconds'] = $total_seconds;
         $minutes = (int)($total_seconds / 60);
-        $secs = $total_seconds % 60;
+        $secs    = $total_seconds % 60;
         $details['duration'] = sprintf('%d:%02d', $minutes, $secs);
     }
-
     if (!empty($info['video']['frame_rate'])) {
         $details['frame_rate'] = round($info['video']['frame_rate'], 2);
     }
-
     if (!empty($info['video']['resolution_x']) && !empty($info['video']['resolution_y'])) {
         $details['resolution'] = $info['video']['resolution_x'] . 'x' . $info['video']['resolution_y'];
     }
-
     if (!empty($info['video']['codec'])) {
         $details['video_codec'] = $info['video']['codec'];
     } elseif (!empty($info['video']['fourcc_lookup'])) {
         $details['video_codec'] = $info['video']['fourcc_lookup'];
     }
-
     if (!empty($info['audio']['codec'])) {
         $details['audio_codec'] = $info['audio']['codec'];
     }
-
     if (!empty($info['audio']['channels'])) {
         $ch = (int)$info['audio']['channels'];
         $details['audio_channels'] = $ch === 1 ? 'モノラル' : ($ch === 2 ? 'ステレオ' : $ch . 'ch');
     }
-
     if (!empty($info['audio']['sample_rate'])) {
         $details['audio_sample_rate'] = number_format($info['audio']['sample_rate']) . ' Hz';
     }
-
     if (!empty($info['bitrate'])) {
         $details['bitrate'] = round($info['bitrate'] / 1000) . ' kbps';
     }
-
     return $details;
+}
+
+// --- 内部ヘルパー: ファイルパスをホストエンコーディングに変換して存在確認し analyze する ---
+// 成功時は getID3 の $info 配列を返す。失敗時は false を返す。
+function _getid3_analyze($filename) {
+    $getID3 = new getID3();
+    $getID3->options_audiovideo_quicktime_ReturnAtomData = true;
+    $workencode = (getphpversion_fa() < 70100) ? 'SJIS-win' : 'UTF-8';
+    $filename_host = mb_convert_encoding($filename, $workencode, 'UTF-8');
+    setlocale(LC_CTYPE, 'Japanese_Japan.932');
+    if (!file_exist_check_japanese($filename_host)) return false;
+    $error_level = error_reporting();
+    error_reporting($error_level - E_WARNING);
+    $info = $getID3->analyze($filename_host);
+    error_reporting($error_level);
+    getid3_lib::CopyTagsToComments($info);
+    return $info;
+}
+
+// オーディオトラックリストと動画詳細を1回の analyze で取得する（request_confirm_bs5 用）
+// 戻り値: ['audiotracklist' => array, 'videodetails' => array]
+function getfileinfo($filename) {
+    $info = _getid3_analyze($filename);
+    if ($info === false) {
+        return array('audiotracklist' => array(), 'videodetails' => array());
+    }
+    return array(
+        'audiotracklist' => _audiotracklist_from_info($info),
+        'videodetails'   => _videodetails_from_info($info),
+    );
+}
+
+function getaudiotracklist($filename){
+    $info = _getid3_analyze($filename);
+    if ($info === false) return array();
+    return _audiotracklist_from_info($info);
+}
+
+function getvideodetails($filename) {
+    $info = _getid3_analyze($filename);
+    if ($info === false) return array();
+    return _videodetails_from_info($info);
 }
 
 // function from manage-mpc.php

--- a/func_audiotracklist.php
+++ b/func_audiotracklist.php
@@ -71,6 +71,8 @@ function checktracktype($trackinfo){
 function _audiotracklist_from_info($info) {
     $audiotracklist = array();
     if (!array_key_exists('quicktime', $info)) return $audiotracklist;
+    // ④ moov がない場合（断片化MP4・破損ファイル等）は空リストを返す
+    if (!isset($info['quicktime']['moov']['subatoms'])) return $audiotracklist;
     $tracklist = $info['quicktime']['moov']['subatoms'];
     foreach ($tracklist as $trackinfo) {
         if ($trackinfo['name'] !== 'trak') continue;
@@ -132,7 +134,7 @@ function _getid3_analyze($filename, $with_atom_data = false) {
     setlocale(LC_CTYPE, 'Japanese_Japan.932');
     if (!file_exist_check_japanese($filename_host)) return false;
     $error_level = error_reporting();
-    error_reporting($error_level - E_WARNING);
+    error_reporting($error_level & ~E_WARNING); // ⑤ 算術減算ではなくビット演算で除外
     $info = $getID3->analyze($filename_host);
     error_reporting($error_level);
     getid3_lib::CopyTagsToComments($info);
@@ -151,12 +153,16 @@ function getfileinfo($filename, $need_tracklist = false) {
     $filename_host = mb_convert_encoding($filename, $workencode, 'UTF-8');
     $mtime = @filemtime($filename_host);
 
+    // ③ filemtime が失敗（false）した場合はキャッシュを使わない
+    //    空の結果を永続キャッシュしてしまうと、ファイルが復旧しても手動削除まで回復できない
+    $use_cache = ($mtime !== false);
+
     // キャッシュキー: ファイルパス + アトムデータ有無 + ファイル更新日時
-    $cache_key  = md5($filename . '|' . (int)$need_tracklist . '|' . (string)$mtime);
+    $cache_key  = md5($filename . '|' . (int)$need_tracklist . '|' . $mtime);
     $cache_file = $cache_dir . DIRECTORY_SEPARATOR . $cache_key;
 
     // キャッシュヒット確認
-    if (is_file($cache_file)) {
+    if ($use_cache && is_file($cache_file)) {
         $cached = @unserialize(file_get_contents($cache_file));
         if ($cached !== false) {
             return $cached;
@@ -170,13 +176,26 @@ function getfileinfo($filename, $need_tracklist = false) {
         'videodetails'   => ($info !== false) ? _videodetails_from_info($info) : array(),
     );
 
-    // キャッシュディレクトリ作成（初回のみ）
-    if (!is_dir($cache_dir)) {
-        @mkdir($cache_dir, 0755, true);
-        // Web からの直接アクセスを遮断
-        @file_put_contents($cache_dir . DIRECTORY_SEPARATOR . '.htaccess', "Deny from all\n");
+    // キャッシュ書き込み（filemtime が取れた場合のみ）
+    if ($use_cache) {
+        // ① キャッシュディレクトリが存在しない場合は作成
+        if (!is_dir($cache_dir)) {
+            if (!@mkdir($cache_dir, 0755, true)) {
+                // ② mkdir 失敗をログに記録してキャッシュをスキップ
+                error_log('[getfileinfo] cache dir creation failed: ' . $cache_dir);
+                return $result;
+            }
+        }
+        // ① .htaccess が存在しない場合は書き込む（再デプロイ後も確実に保護）
+        $htaccess = $cache_dir . DIRECTORY_SEPARATOR . '.htaccess';
+        if (!is_file($htaccess)) {
+            @file_put_contents($htaccess, "Deny from all\n");
+        }
+        // ② キャッシュ書き込み失敗をログに記録
+        if (@file_put_contents($cache_file, serialize($result)) === false) {
+            error_log('[getfileinfo] cache write failed: ' . $cache_file);
+        }
     }
-    @file_put_contents($cache_file, serialize($result));
 
     return $result;
 }

--- a/func_audiotracklist.php
+++ b/func_audiotracklist.php
@@ -141,16 +141,44 @@ function _getid3_analyze($filename, $with_atom_data = false) {
 
 // オーディオトラックリストと動画詳細を1回の analyze で取得する（request_confirm_bs5 用）
 // $need_tracklist=true のときだけ QuickTime アトムデータを読み込む。
+// 結果はファイル更新日時ベースでディスクキャッシュされる（2回目以降は getID3 解析不要）。
 // 戻り値: ['audiotracklist' => array, 'videodetails' => array]
 function getfileinfo($filename, $need_tracklist = false) {
-    $info = _getid3_analyze($filename, $need_tracklist);
-    if ($info === false) {
-        return array('audiotracklist' => array(), 'videodetails' => array());
+    $cache_dir = dirname(__FILE__) . DIRECTORY_SEPARATOR . '_getid3_cache';
+
+    // ファイル更新日時取得（Windows パスのエンコーディング対応）
+    $workencode = (getphpversion_fa() < 70100) ? 'SJIS-win' : 'UTF-8';
+    $filename_host = mb_convert_encoding($filename, $workencode, 'UTF-8');
+    $mtime = @filemtime($filename_host);
+
+    // キャッシュキー: ファイルパス + アトムデータ有無 + ファイル更新日時
+    $cache_key  = md5($filename . '|' . (int)$need_tracklist . '|' . (string)$mtime);
+    $cache_file = $cache_dir . DIRECTORY_SEPARATOR . $cache_key;
+
+    // キャッシュヒット確認
+    if (is_file($cache_file)) {
+        $cached = @unserialize(file_get_contents($cache_file));
+        if ($cached !== false) {
+            return $cached;
+        }
     }
-    return array(
-        'audiotracklist' => $need_tracklist ? _audiotracklist_from_info($info) : array(),
-        'videodetails'   => _videodetails_from_info($info),
+
+    // getID3 解析
+    $info = _getid3_analyze($filename, $need_tracklist);
+    $result = array(
+        'audiotracklist' => ($need_tracklist && $info !== false) ? _audiotracklist_from_info($info) : array(),
+        'videodetails'   => ($info !== false) ? _videodetails_from_info($info) : array(),
     );
+
+    // キャッシュディレクトリ作成（初回のみ）
+    if (!is_dir($cache_dir)) {
+        @mkdir($cache_dir, 0755, true);
+        // Web からの直接アクセスを遮断
+        @file_put_contents($cache_dir . DIRECTORY_SEPARATOR . '.htaccess', "Deny from all\n");
+    }
+    @file_put_contents($cache_file, serialize($result));
+
+    return $result;
 }
 
 function getaudiotracklist($filename){

--- a/func_audiotracklist.php
+++ b/func_audiotracklist.php
@@ -120,10 +120,13 @@ function _videodetails_from_info($info) {
 }
 
 // --- 内部ヘルパー: ファイルパスをホストエンコーディングに変換して存在確認し analyze する ---
+// $with_atom_data=true のときのみ QuickTime アトムデータを全量読み込む（重い）。
 // 成功時は getID3 の $info 配列を返す。失敗時は false を返す。
-function _getid3_analyze($filename) {
+function _getid3_analyze($filename, $with_atom_data = false) {
     $getID3 = new getID3();
-    $getID3->options_audiovideo_quicktime_ReturnAtomData = true;
+    if ($with_atom_data) {
+        $getID3->options_audiovideo_quicktime_ReturnAtomData = true;
+    }
     $workencode = (getphpversion_fa() < 70100) ? 'SJIS-win' : 'UTF-8';
     $filename_host = mb_convert_encoding($filename, $workencode, 'UTF-8');
     setlocale(LC_CTYPE, 'Japanese_Japan.932');
@@ -137,26 +140,27 @@ function _getid3_analyze($filename) {
 }
 
 // オーディオトラックリストと動画詳細を1回の analyze で取得する（request_confirm_bs5 用）
+// $need_tracklist=true のときだけ QuickTime アトムデータを読み込む。
 // 戻り値: ['audiotracklist' => array, 'videodetails' => array]
-function getfileinfo($filename) {
-    $info = _getid3_analyze($filename);
+function getfileinfo($filename, $need_tracklist = false) {
+    $info = _getid3_analyze($filename, $need_tracklist);
     if ($info === false) {
         return array('audiotracklist' => array(), 'videodetails' => array());
     }
     return array(
-        'audiotracklist' => _audiotracklist_from_info($info),
+        'audiotracklist' => $need_tracklist ? _audiotracklist_from_info($info) : array(),
         'videodetails'   => _videodetails_from_info($info),
     );
 }
 
 function getaudiotracklist($filename){
-    $info = _getid3_analyze($filename);
+    $info = _getid3_analyze($filename, true);
     if ($info === false) return array();
     return _audiotracklist_from_info($info);
 }
 
 function getvideodetails($filename) {
-    $info = _getid3_analyze($filename);
+    $info = _getid3_analyze($filename, false);
     if ($info === false) return array();
     return _videodetails_from_info($info);
 }

--- a/request_confirm_bs5.php
+++ b/request_confirm_bs5.php
@@ -399,9 +399,21 @@ if(is_numeric($selectid) && !empty($selectrequest) ){
 /* ファイルの存在チェック */
 $fullpath_utf8 = "";
 $audiotracklist = array();
+$videodetails = array();
+$duration_seconds = 0;
 if($shop_karaoke != 1 ){
     get_fullfilename($fullpath,$filename,$fullpath_utf8,$lister_dbpath);
     $filetype = extention_musiccheck($fullpath_utf8);
+    if(!empty($fullpath_utf8) && ($filetype == 1 || $filetype == 2)) {
+        $fileinfo = getfileinfo($fullpath_utf8);
+        $videodetails = $fileinfo['videodetails'];
+        if ($filetype == 1) {
+            $audiotracklist = $fileinfo['audiotracklist'];
+        }
+        if (isset($videodetails['duration_seconds'])) {
+            $duration_seconds = $videodetails['duration_seconds'];
+        }
+    }
 }
 
 /* キー変更が有効かどうかのチェック */
@@ -493,18 +505,6 @@ EOT;
 EOT;
 }
 
-$videodetails = array();
-$duration_seconds = 0;
-if ($shop_karaoke != 1 && !empty($fullpath_utf8) && ($filetype == 1 || $filetype == 2)) {
-    $fileinfo = getfileinfo($fullpath_utf8);
-    $videodetails = $fileinfo['videodetails'];
-    if ($filetype == 1) {
-        $audiotracklist = $fileinfo['audiotracklist'];
-    }
-    if (isset($videodetails['duration_seconds'])) {
-        $duration_seconds = $videodetails['duration_seconds'];
-    }
-}
 if ($shop_karaoke != 1 && $filetype == 1 && !empty($fullpath_utf8) && !empty($videodetails)) {
         print '<div class="card mt-2">'."\n";
         print '<div class="card-header" id="videoDetailsHeading">'."\n";

--- a/request_confirm_bs5.php
+++ b/request_confirm_bs5.php
@@ -405,7 +405,7 @@ if($shop_karaoke != 1 ){
     get_fullfilename($fullpath,$filename,$fullpath_utf8,$lister_dbpath);
     $filetype = extention_musiccheck($fullpath_utf8);
     if(!empty($fullpath_utf8) && ($filetype == 1 || $filetype == 2)) {
-        $fileinfo = getfileinfo($fullpath_utf8);
+        $fileinfo = getfileinfo($fullpath_utf8, $filetype == 1);
         $videodetails = $fileinfo['videodetails'];
         if ($filetype == 1) {
             $audiotracklist = $fileinfo['audiotracklist'];

--- a/request_confirm_bs5.php
+++ b/request_confirm_bs5.php
@@ -402,9 +402,6 @@ $audiotracklist = array();
 if($shop_karaoke != 1 ){
     get_fullfilename($fullpath,$filename,$fullpath_utf8,$lister_dbpath);
     $filetype = extention_musiccheck($fullpath_utf8);
-    if(!empty($fullpath_utf8) && $filetype == 1 ) {
-        $audiotracklist = getaudiotracklist($fullpath_utf8);
-    }
 }
 
 /* キー変更が有効かどうかのチェック */
@@ -499,7 +496,11 @@ EOT;
 $videodetails = array();
 $duration_seconds = 0;
 if ($shop_karaoke != 1 && !empty($fullpath_utf8) && ($filetype == 1 || $filetype == 2)) {
-    $videodetails = getvideodetails($fullpath_utf8);
+    $fileinfo = getfileinfo($fullpath_utf8);
+    $videodetails = $fileinfo['videodetails'];
+    if ($filetype == 1) {
+        $audiotracklist = $fileinfo['audiotracklist'];
+    }
     if (isset($videodetails['duration_seconds'])) {
         $duration_seconds = $videodetails['duration_seconds'];
     }


### PR DESCRIPTION
## 概要

`request_confirm_bs5.php?filename=XXX` を開いたときの表示速度改善と、getID3 関連の既存バグ修正をまとめたPRです。

## パフォーマンス改善

### getID3 ファイル解析を2回→1回に削減

以前は `getaudiotracklist()` と `getvideodetails()` がそれぞれ独立して `getID3->analyze()` を呼び出していたため、動画ファイルでは同じファイルを2回解析していました。

- `func_audiotracklist.php` に共通ヘルパー `_getid3_analyze()` / `_audiotracklist_from_info()` / `_videodetails_from_info()` を追加
- `getfileinfo($filename, $need_tracklist)` を新設し、1回の `analyze()` でオーディオトラックリストと動画詳細の両方を取得
- `request_confirm_bs5.php` から `getfileinfo()` を呼ぶよう変更

| ファイル種別 | 変更前 | 変更後 |
|-------------|--------|--------|
| 動画 (filetype==1) | analyze × 2回 | analyze × 1回 |
| 音楽 (filetype==2) | analyze × 1回（ReturnAtomData なし） | analyze × 1回（ReturnAtomData なし、変化なし） |

### ファイルメタデータのディスクキャッシュ

`getID3->analyze()` は大きな動画ファイルで数秒かかるため、`getfileinfo()` の結果をディスクキャッシュするよう実装しました。

- キャッシュ先: `_getid3_cache/`（Webルート内、`.htaccess` で外部アクセス遮断）
- キャッシュキー: `MD5(ファイルパス + アトムデータ有無フラグ + ファイル更新日時)`
- 初回アクセス: getID3 解析 → 結果をキャッシュ保存（従来と同じ時間）
- 2回目以降: キャッシュから即返却（ほぼ瞬時）
- キャッシュ自動無効化: ファイルが差し替えられると更新日時が変わるため自動的に再解析
- キャッシュ削除: `_getid3_cache/` フォルダの中身を削除するだけで OK

## バグ修正

| # | 種別 | 内容 |
|---|------|------|
| ① | 新規 | `.htaccess` を `is_file` で確認してから書き込むよう変更。再デプロイ後にディレクトリが既存でも確実に書き込まれる |
| ② | 新規 | `@mkdir` / `@file_put_contents` 失敗時に `error_log` へ記録。キャッシュが機能しない場合に検知可能 |
| ③ | 新規 | `@filemtime()` が `false` を返す場合（パスエンコーディング不一致等）はキャッシュをスキップ。空結果が永続キャッシュされる問題を防止 |
| ④ | 既存 | `_audiotracklist_from_info()` に `'moov'` キーの存在確認を追加。断片化MP4・破損ファイルで PHP 8 の TypeError になっていた既存バグを修正 |
| ⑤ | 既存 | `error_reporting($level - E_WARNING)` を `$level & ~E_WARNING` に修正。`E_WARNING` が未設定の環境でビットが壊れる既存バグを修正 |

## 後方互換性

- `getaudiotracklist()` / `getvideodetails()` のシグネチャ・戻り値は変更なし
- `request_confirm.php`（BS3版）・`gettracklist_json.php`・`update_duration_all.php` の既存呼び出しに影響なし

## Test plan

- [x] `request_confirm_bs5.php?filename=XXX` で動画ファイルを開き、トラック選択・動画詳細情報が正しく表示される
- [x] 同じ曲を2回開いたとき、2回目が明らかに速くなる（`_getid3_cache/` にキャッシュファイルが生成されていることを確認）
- [ ] 音楽ファイル（mp3等）でもリクエスト確認画面が正常に表示される
- [ ] `_getid3_cache/` フォルダがブラウザから直接アクセスできないこと（`.htaccess` による遮断）

https://claude.ai/code/session_01GtbKU63iyKDFLZVADtCuVL

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtbKU63iyKDFLZVADtCuVL)_