### PR TITLE
fix: URL(YouTube等)予約が再生されない不具合を修正

### DIFF
--- a/commonfunc.php
+++ b/commonfunc.php
@@ -915,9 +915,12 @@ function searchresultcount_fromkeyword($word)
 
 function selectplayerfromextension($filepath)
 {
+if( is_url($filepath) ){
+    return "mpc";
+}
 $extension = pathinfo($filepath, PATHINFO_EXTENSION);
-if( strcasecmp($extension,"mp3") == 0 
-    || strcasecmp($extension,"m4a") == 0 
+if( strcasecmp($extension,"mp3") == 0
+    || strcasecmp($extension,"m4a") == 0
     || strcasecmp($extension,"wav") == 0 ){
     $player="foobar";
 }else {
@@ -936,7 +939,13 @@ function getcurrentplayer(){
     if(count($currentsong) == 0){
         return "none";
     }else{
-        $player=selectplayerfromextension($currentsong[0]['fullpath']);
+        // kind に「URL指定」を含む場合は mpc 固定
+        if( mb_stristr($currentsong[0]['kind'], 'URL指定') !== FALSE ){
+            return "mpc";
+        }
+        // fullpath が空の場合は songfile で判定
+        $path = !empty($currentsong[0]['fullpath']) ? $currentsong[0]['fullpath'] : $currentsong[0]['songfile'];
+        $player=selectplayerfromextension($path);
     }
     return $player;
 }

--- a/manage-mpc.php
+++ b/manage-mpc.php
@@ -923,14 +923,25 @@ function start_song($db,$id,$addplaytimes = 0){
         return $row;
     }
 
-    //★ $filepath = get_fullfilename2($row["fullpath"],$row["songfile"],$filepath_utf8);
-    $filepath = get_fullfilename2_local($row["fullpath"],$row["songfile"],$filepath_utf8);  //★
-    if( $filepath === false){
-        logtocmd($word."<start_song>ファイルが見つかりませんでした、Skipします");
-        return false;
-    }
     // var_dump($row);
-    $filetype = check_filetype ($db,$id);
+    $filetype = check_filetype($db,$id);
+    if( $filetype === false ){ return false; }
+    if( $filetype == 3 ){
+        // URL指定：fullpath をそのまま使用
+        $filepath = $row["fullpath"];
+        $filepath_utf8 = $filepath;
+        if( empty($filepath) ){
+            logtocmd("<start_song>URLが空のため再生できません");
+            return false;
+        }
+    }else{
+        //★ $filepath = get_fullfilename2($row["fullpath"],$row["songfile"],$filepath_utf8);
+        $filepath = get_fullfilename2_local($row["fullpath"],$row["songfile"],$filepath_utf8);  //★
+        if( $filepath === false){
+            logtocmd($word."<start_song>ファイルが見つかりませんでした、Skipします");
+            return false;
+        }
+    }
     if( $filetype == 2 ){
         // とりあえず動画Playerを終了する。
         mpcstop();
@@ -991,11 +1002,13 @@ function start_song($db,$id,$addplaytimes = 0){
             /* key change */
             global $MPCCMDURL;
             global $MPCSTATURL;
-                    //★ 一時停止状態でファイルを開く。
+                    //★ 一時停止状態でファイルを開く。URL指定は上の filetype==3 ブロックで開済みのためスキップ。
+                    if($filetype != 3){  //★
                     global $ADDPATHCMD;  //★
                     $execcmd="$ADDPATHCMD & start  \"\" \"".$MPCPATH."\"" . " /open \"$filepath_utf8\"\n";  //★
                     $fp = popen($execcmd,'r');
                     pclose($fp);
+                    }  //★
 
             //★ MPCの再生開始時に音量を指定値に戻す（設定で有効にしている場合）
             //   制作者別音量増減（requesttable.volume != 0）が設定されている場合は


### PR DESCRIPTION
## 概要

URL指定（YouTube等の直接再生URL）で予約した曲が再生されない不具合を修正。

元の修正報告：**つぼはち** さん

---

## 原因

`manage-mpc.php` の `start_song()` が、filetype の判定より前に `get_fullfilename2_local()` でローカルファイル探索を行っていた。URLはローカルに実ファイルが存在しないため常に `false` が返り、Skipされていた。

## 変更内容

### `manage-mpc.php`
- `start_song()` で `check_filetype()` を先に呼び出すよう順序を変更
- `filetype==3`（URL指定）の場合は `fullpath` をそのまま `filepath` として使用し、ローカル探索をスキップ
- URL再生後の共通 `/open` コマンド（ローカル動画用）を `filetype != 3` の場合のみ実行するよう保護し、URLの二重openを防止

### `commonfunc.php`
- `selectplayerfromextension()` に `is_url()` 判定を追加。`.mp3` 等の拡張子を持つURLがfoobarに誤判定されるケースを防止
- `getcurrentplayer()` に `kind=URL指定` チェックと、`fullpath` が空の場合に `songfile` で判定するフォールバックを追加

## 動作確認

- YouTube URL予約がスキップされず正常に再生されることを確認（yt-dlp + MPC-BE 環境）
- 予約登録 → 自動再生ピックアップ → MPC で再生開始まで一連のフローを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)