### PR TITLE
feat: PRマージ時にDiscordへ通知するGitHub Actionsワークフローを追加

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,0 +1,41 @@
+name: Discord PR Merge Notification
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord notification
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          curl -s -X POST "$DISCORD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"embeds\": [{
+                \"title\": \"✅ PR #${{ github.event.pull_request.number }} がマージされました\",
+                \"description\": \"${{ github.event.pull_request.title }}\",
+                \"url\": \"${{ github.event.pull_request.html_url }}\",
+                \"color\": 3066993,
+                \"fields\": [
+                  {
+                    \"name\": \"マージした人\",
+                    \"value\": \"${{ github.event.pull_request.merged_by.login }}\",
+                    \"inline\": true
+                  },
+                  {
+                    \"name\": \"ブランチ\",
+                    \"value\": \"`${{ github.event.pull_request.head.ref }}` → `master`\",
+                    \"inline\": true
+                  }
+                ],
+                \"footer\": {
+                  \"text\": \"KaraokeRequestorWeb\"
+                }
+              }]
+            }"


### PR DESCRIPTION
## 概要

PR マージ時に Discord へ通知する GitHub Actions ワークフローを追加します。

## 変更内容

- `.github/workflows/discord-notify.yml` を追加
- `master` ブランチへの PR がマージされたタイミングで Discord に Embed メッセージを投稿
- Webhook URL は GitHub Secrets の `DISCORD_WEBHOOK_URL` から取得

## 通知内容

```
✅ PR #xxx がマージされました
タイトル
マージした人: xxx   ブランチ: yyy → master
                    KaraokeRequestorWeb
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)