### PR TITLE
オンラインアップデートにZIP方式を追加・Git方式を強化しBS5化

### DIFF
--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2203,7 +2203,7 @@ function get_gitbranchlist(&$errmsg = '', $do_fetch = true) {
     if ($do_fetch) {
         exec($gitcmd . ' config --global core.autoCRLF false');
         set_time_limit(900);
-        exec($gitcmd . ' fetch origin 2>&1', $out);
+        exec($gitcmd . ' fetch --prune origin 2>&1', $out);
         $out = [];
     }
 
@@ -2228,7 +2228,7 @@ function get_gittaglist(&$errmsg = 'none'){
       if(file_exists($gitcmd)){
           $execcmd = $gitcmd.' config --global core.autoCRLF false';
           exec($execcmd);
-          $execcmd = $gitcmd.' fetch origin';
+          $execcmd = $gitcmd.' fetch --prune origin';
           set_time_limit (900);
           exec($execcmd,$result_str);
           foreach($result_str as $line){
@@ -2277,7 +2277,7 @@ function update_fromgit($version_str, &$errmsg){
           $execcmd = $gitcmd.' config --global core.autoCRLF false';
           exec($execcmd);
           
-          $execcmd = $gitcmd.' fetch origin';
+          $execcmd = $gitcmd.' fetch --prune origin';
           set_time_limit (900);
           exec($execcmd,$result_str);
           foreach($result_str as $line){

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2226,17 +2226,26 @@ function get_gitbranchlist(&$errmsg = '', $do_fetch = true) {
         $out = [];
     }
 
-    // --sort=-committerdate は git 2.7+ が必要。失敗時は通常の branch -r にフォールバック
-    exec($gitcmd . ' branch -r --sort=-committerdate 2>&1', $lines, $ret);
-    if ($ret !== 0) {
+    // git for-each-ref は git 1.x から使えるため branch --sort より互換性が高い
+    exec($gitcmd . ' for-each-ref --sort=-committerdate --format=%(refname:short) refs/remotes/origin/ 2>&1', $lines, $ret);
+    if ($ret === 0 && count($lines) > 0) {
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ($line === '' || mb_strpos($line, 'origin/HEAD') !== false) continue;
+            if (mb_strpos($line, 'origin/') === 0) {
+                $branchlist[] = mb_substr($line, mb_strlen('origin/'));
+            }
+        }
+    } else {
+        // フォールバック: 古い git で for-each-ref も使えない場合
         $lines = [];
         exec($gitcmd . ' branch -r 2>&1', $lines);
-    }
-    foreach ($lines as $line) {
-        $line = trim($line);
-        if (mb_strpos($line, '->') !== false) continue;  // HEAD -> origin/master 等をスキップ
-        if (mb_strpos($line, 'origin/') === 0) {
-            $branchlist[] = mb_substr($line, mb_strlen('origin/'));
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if (mb_strpos($line, '->') !== false) continue;
+            if (mb_strpos($line, 'origin/') === 0) {
+                $branchlist[] = mb_substr($line, mb_strlen('origin/'));
+            }
         }
     }
     return $branchlist;

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2394,9 +2394,19 @@ function check_zip_update_available() {
     return true;
 }
 
+// アップデート取得元リポジトリ（owner/repo）を config から取得。未設定時は既定値。
+function get_update_repo() {
+    global $config_ini;
+    if (array_key_exists('update_repo', $config_ini)) {
+        $repo = trim(urldecode($config_ini['update_repo']));
+        if ($repo !== '') return $repo;
+    }
+    return 'bee7813993/KaraokeRequestorWeb';
+}
+
 function get_archive_taglist(&$errmsg = '') {
     $taglist = [];
-    $url = 'https://api.github.com/repos/bee7813993/KaraokeRequestorWeb/tags';
+    $url = 'https://api.github.com/repos/' . get_update_repo() . '/tags';
     $data = _kara_http_get($url, $errmsg);
     if ($data === false) {
         return $taglist;
@@ -2461,12 +2471,13 @@ function update_fromarchive($version_str, &$errmsg) {
         return false;
     }
 
+    $repo = get_update_repo();
     $vs = trim($version_str);
     if ($vs === 'master' || $vs === 'origin/master') {
-        $zip_url = 'https://github.com/bee7813993/KaraokeRequestorWeb/archive/refs/heads/master.zip';
+        $zip_url = 'https://github.com/' . $repo . '/archive/refs/heads/master.zip';
     } else {
         $tag = ltrim($vs, 'refs/tags/');
-        $zip_url = 'https://github.com/bee7813993/KaraokeRequestorWeb/archive/refs/tags/' . rawurlencode($tag) . '.zip';
+        $zip_url = 'https://github.com/' . $repo . '/archive/refs/tags/' . rawurlencode($tag) . '.zip';
     }
 
     $app_root = realpath(__DIR__);
@@ -2605,7 +2616,7 @@ function init_git_repo(&$errmsg) {
     }
 
     set_time_limit(900);
-    $origin = 'https://github.com/bee7813993/KaraokeRequestorWeb.git';
+    $origin = 'https://github.com/' . get_update_repo() . '.git';
 
     $steps = [
         $gitcmd . ' init',

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2613,6 +2613,8 @@ function init_git_repo(&$errmsg) {
         $gitcmd . ' config --global core.autoCRLF false',
         $gitcmd . ' fetch --depth=1 origin master',
         $gitcmd . ' reset --hard FETCH_HEAD',
+        // タグ情報だけ取得（コミット本体なし）→ git describe --tags が動作するようになる
+        $gitcmd . ' fetch --tags origin',
     ];
 
     foreach ($steps as $cmd) {

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2476,8 +2476,15 @@ function update_fromarchive($version_str, &$errmsg) {
     if ($vs === 'master' || $vs === 'origin/master') {
         $zip_url = 'https://github.com/' . $repo . '/archive/refs/heads/master.zip';
     } else {
-        $tag = ltrim($vs, 'refs/tags/');
-        $zip_url = 'https://github.com/' . $repo . '/archive/refs/tags/' . rawurlencode($tag) . '.zip';
+        // origin/ プレフィックスは除去（ブランチ指定との統一）
+        if (strpos($vs, 'origin/') === 0) {
+            $vs = substr($vs, strlen('origin/'));
+        }
+        $vs = ltrim($vs, '/');
+        // archive/<ref>.zip は ref にタグ・ブランチ・コミットハッシュのいずれも指定可。
+        // ブランチ名のスラッシュ(feature/x 等)は保持しつつ各セグメントをエンコード。
+        $encoded_ref = implode('/', array_map('rawurlencode', explode('/', $vs)));
+        $zip_url = 'https://github.com/' . $repo . '/archive/' . $encoded_ref . '.zip';
     }
 
     $app_root = realpath(__DIR__);
@@ -2492,9 +2499,14 @@ function update_fromarchive($version_str, &$errmsg) {
     set_time_limit(900);
 
     $data = _kara_http_get($zip_url, $errmsg);
-    if ($data === false || strlen($data) === 0) {
+    if ($data === false) {
+        // errmsg は _kara_http_get が設定済み（存在しないタグ/ブランチ/ハッシュなら HTTP 404）
         _kara_update_cleanup($tmp_dir);
-        if (strlen($data) === 0) $errmsg = 'ダウンロードしたファイルが空です';
+        return false;
+    }
+    if (strlen($data) === 0) {
+        _kara_update_cleanup($tmp_dir);
+        $errmsg = 'ダウンロードしたファイルが空です';
         return false;
     }
     file_put_contents($zip_file, $data);

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2481,6 +2481,94 @@ function update_fromarchive($version_str, &$errmsg) {
 
 // ---- ZIPアーカイブ方式ここまで ----
 
+// ---- Git メンテナンス / 初期化 ----
+
+function format_filesize($bytes) {
+    if ($bytes >= 1048576) return round($bytes / 1048576, 1) . ' MB';
+    if ($bytes >= 1024)    return round($bytes / 1024, 0) . ' KB';
+    return $bytes . ' B';
+}
+
+function get_git_dir_size() {
+    $git_dir = realpath(__DIR__) . DIRECTORY_SEPARATOR . '.git';
+    if (!is_dir($git_dir)) return null;
+    $size = 0;
+    try {
+        $iter = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($git_dir, RecursiveDirectoryIterator::SKIP_DOTS)
+        );
+        foreach ($iter as $file) {
+            if ($file->isFile()) $size += $file->getSize();
+        }
+    } catch (Exception $e) {
+        return null;
+    }
+    return $size;
+}
+
+function run_git_gc(&$errmsg, $aggressive = false) {
+    global $config_ini;
+    if (!array_key_exists('gitcommandpath', $config_ini)) {
+        $errmsg = 'gitcommandpath が設定されていません';
+        return false;
+    }
+    $gitcmd = urldecode($config_ini['gitcommandpath']);
+    if (!file_exists($gitcmd)) {
+        $errmsg = 'git コマンドが見つかりません: ' . $gitcmd;
+        return false;
+    }
+    set_time_limit(600);
+    $flag = $aggressive ? ' --aggressive' : '';
+    exec($gitcmd . ' gc' . $flag . ' --prune=all 2>&1', $out, $ret);
+    if ($ret !== 0) {
+        $errmsg = 'git gc 失敗: ' . implode(' / ', $out);
+        return false;
+    }
+    return true;
+}
+
+function init_git_repo(&$errmsg) {
+    global $config_ini;
+    $app_root = realpath(__DIR__);
+
+    if (!array_key_exists('gitcommandpath', $config_ini)) {
+        $errmsg = 'gitcommandpath が設定されていません';
+        return false;
+    }
+    $gitcmd = urldecode($config_ini['gitcommandpath']);
+    if (!file_exists($gitcmd)) {
+        $errmsg = 'git コマンドが見つかりません: ' . $gitcmd;
+        return false;
+    }
+    if (is_dir($app_root . DIRECTORY_SEPARATOR . '.git')) {
+        $errmsg = '.git フォルダが既に存在します';
+        return false;
+    }
+
+    set_time_limit(900);
+    $origin = 'https://github.com/bee7813993/KaraokeRequestorWeb.git';
+
+    $steps = [
+        $gitcmd . ' init',
+        $gitcmd . ' remote add origin ' . $origin,
+        $gitcmd . ' config --global core.autoCRLF false',
+        $gitcmd . ' fetch --depth=1 origin master',
+        $gitcmd . ' reset --hard FETCH_HEAD',
+    ];
+
+    foreach ($steps as $cmd) {
+        exec($cmd . ' 2>&1', $out, $ret);
+        if ($ret !== 0) {
+            $errmsg = 'コマンド失敗 [' . $cmd . ']: ' . implode(' / ', $out);
+            return false;
+        }
+        $out = [];
+    }
+    return true;
+}
+
+// ---- Git メンテナンス / 初期化ここまで ----
+
 function make_preview_modal($filepath, $modalid) {
   global $everythinghost;
   

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2192,6 +2192,32 @@ function get_version(){
     }
 }
 
+// $do_fetch=false を指定すると fetch をスキップ（get_gittaglist の直後に呼ぶ場合など）
+function get_gitbranchlist(&$errmsg = '', $do_fetch = true) {
+    global $config_ini;
+    $branchlist = [];
+    if (!array_key_exists('gitcommandpath', $config_ini)) return $branchlist;
+    $gitcmd = urldecode($config_ini['gitcommandpath']);
+    if (!file_exists($gitcmd)) return $branchlist;
+
+    if ($do_fetch) {
+        exec($gitcmd . ' config --global core.autoCRLF false');
+        set_time_limit(900);
+        exec($gitcmd . ' fetch origin 2>&1', $out);
+        $out = [];
+    }
+
+    exec($gitcmd . ' branch -r 2>&1', $lines);
+    foreach ($lines as $line) {
+        $line = trim($line);
+        if (mb_strpos($line, '->') !== false) continue;  // HEAD -> origin/master 等をスキップ
+        if (mb_strpos($line, 'origin/') === 0) {
+            $branchlist[] = mb_substr($line, mb_strlen('origin/'));
+        }
+    }
+    return $branchlist;
+}
+
 function get_gittaglist(&$errmsg = 'none'){
 
     global $config_ini;

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2192,6 +2192,15 @@ function get_version(){
     }
 }
 
+function get_git_command_version() {
+    global $config_ini;
+    if (!array_key_exists('gitcommandpath', $config_ini)) return null;
+    $gitcmd = urldecode($config_ini['gitcommandpath']);
+    if (!file_exists($gitcmd)) return null;
+    $ver = trim(exec($gitcmd . ' --version 2>&1'));
+    return ($ver !== '') ? $ver : null;
+}
+
 function get_current_git_branch() {
     global $config_ini;
     if (!array_key_exists('gitcommandpath', $config_ini)) return null;

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2217,7 +2217,7 @@ function get_gitbranchlist(&$errmsg = '', $do_fetch = true) {
         $out = [];
     }
 
-    exec($gitcmd . ' branch -r 2>&1', $lines);
+    exec($gitcmd . ' branch -r --sort=-committerdate 2>&1', $lines);
     foreach ($lines as $line) {
         $line = trim($line);
         if (mb_strpos($line, '->') !== false) continue;  // HEAD -> origin/master 等をスキップ

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2217,7 +2217,12 @@ function get_gitbranchlist(&$errmsg = '', $do_fetch = true) {
         $out = [];
     }
 
-    exec($gitcmd . ' branch -r --sort=-committerdate 2>&1', $lines);
+    // --sort=-committerdate は git 2.7+ が必要。失敗時は通常の branch -r にフォールバック
+    exec($gitcmd . ' branch -r --sort=-committerdate 2>&1', $lines, $ret);
+    if ($ret !== 0) {
+        $lines = [];
+        exec($gitcmd . ' branch -r 2>&1', $lines);
+    }
     foreach ($lines as $line) {
         $line = trim($line);
         if (mb_strpos($line, '->') !== false) continue;  // HEAD -> origin/master 等をスキップ

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2192,6 +2192,16 @@ function get_version(){
     }
 }
 
+function get_current_git_branch() {
+    global $config_ini;
+    if (!array_key_exists('gitcommandpath', $config_ini)) return null;
+    $gitcmd = urldecode($config_ini['gitcommandpath']);
+    if (!file_exists($gitcmd)) return null;
+    $branch = trim(exec($gitcmd . ' rev-parse --abbrev-ref HEAD 2>&1'));
+    if ($branch === '' || $branch === 'HEAD' || mb_strpos($branch, 'fatal') !== false) return null;
+    return $branch;
+}
+
 // $do_fetch=false を指定すると fetch をスキップ（get_gittaglist の直後に呼ぶ場合など）
 function get_gitbranchlist(&$errmsg = '', $do_fetch = true) {
     global $config_ini;

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2286,9 +2286,200 @@ function update_fromgit($version_str, &$errmsg){
     if($errorcnt > 0) {
         return false;
     }
-    
+
     return true;
 }
+
+// ---- ZIPアーカイブ方式アップデート ----
+
+function _kara_http_get($url, &$errmsg) {
+    if (function_exists('curl_init')) {
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_USERAGENT, 'KaraokeRequestorWeb-Updater');
+        curl_setopt($ch, CURLOPT_TIMEOUT, 300);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        $data = curl_exec($ch);
+        $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+        if ($data === false || $httpcode !== 200) {
+            $errmsg = 'HTTP取得失敗 (HTTP ' . $httpcode . '): ' . $url;
+            return false;
+        }
+        return $data;
+    } elseif (ini_get('allow_url_fopen')) {
+        $context = stream_context_create(['http' => [
+            'method'  => 'GET',
+            'header'  => "User-Agent: KaraokeRequestorWeb-Updater\r\n",
+            'timeout' => 300,
+        ]]);
+        $data = @file_get_contents($url, false, $context);
+        if ($data === false) {
+            $errmsg = 'HTTP取得失敗: ' . $url;
+            return false;
+        }
+        return $data;
+    }
+    $errmsg = 'curl または allow_url_fopen が有効である必要があります';
+    return false;
+}
+
+function check_zip_update_available() {
+    if (!class_exists('ZipArchive')) {
+        return 'PHP の ZipArchive 拡張が無効です (php.ini で extension=zip を有効化してください)';
+    }
+    if (!function_exists('curl_init') && !ini_get('allow_url_fopen')) {
+        return 'curl または allow_url_fopen が必要です';
+    }
+    return true;
+}
+
+function get_archive_taglist(&$errmsg = '') {
+    $taglist = [];
+    $url = 'https://api.github.com/repos/bee7813993/KaraokeRequestorWeb/tags';
+    $data = _kara_http_get($url, $errmsg);
+    if ($data === false) {
+        return $taglist;
+    }
+    $items = json_decode($data, true);
+    if (!is_array($items)) {
+        $errmsg = 'GitHub API レスポンスの解析失敗';
+        return $taglist;
+    }
+    foreach ($items as $item) {
+        $name = $item['name'] ?? '';
+        if (mb_substr($name, 0, 1) === 'v' && is_numeric(mb_substr($name, 1, 1))) {
+            $taglist[] = $name;
+        }
+    }
+    return $taglist;
+}
+
+function _kara_update_copy_recursive($src, $dst, $exclude_list, $relative = '') {
+    $entries = scandir($src);
+    foreach ($entries as $entry) {
+        if ($entry === '.' || $entry === '..') continue;
+
+        $rel = $relative === '' ? $entry : $relative . '/' . $entry;
+
+        foreach ($exclude_list as $excl) {
+            if ($rel === $excl || strpos($rel, $excl . '/') === 0) {
+                continue 2;
+            }
+        }
+
+        $src_path = $src . DIRECTORY_SEPARATOR . $entry;
+        $dst_path = $dst . DIRECTORY_SEPARATOR . $entry;
+
+        if (is_dir($src_path)) {
+            if (!is_dir($dst_path)) {
+                mkdir($dst_path, 0755, true);
+            }
+            _kara_update_copy_recursive($src_path, $dst_path, $exclude_list, $rel);
+        } else {
+            copy($src_path, $dst_path);
+        }
+    }
+}
+
+function _kara_update_cleanup($dir) {
+    if (!is_dir($dir)) return;
+    foreach (scandir($dir) as $entry) {
+        if ($entry === '.' || $entry === '..') continue;
+        $path = $dir . DIRECTORY_SEPARATOR . $entry;
+        is_dir($path) ? _kara_update_cleanup($path) : unlink($path);
+    }
+    rmdir($dir);
+}
+
+function update_fromarchive($version_str, &$errmsg) {
+    global $config_ini;
+
+    $check = check_zip_update_available();
+    if ($check !== true) {
+        $errmsg = $check;
+        return false;
+    }
+
+    $vs = trim($version_str);
+    if ($vs === 'master' || $vs === 'origin/master') {
+        $zip_url = 'https://github.com/bee7813993/KaraokeRequestorWeb/archive/refs/heads/master.zip';
+    } else {
+        $tag = ltrim($vs, 'refs/tags/');
+        $zip_url = 'https://github.com/bee7813993/KaraokeRequestorWeb/archive/refs/tags/' . rawurlencode($tag) . '.zip';
+    }
+
+    $app_root = realpath(__DIR__);
+    $tmp_dir  = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'kara_update_' . bin2hex(random_bytes(8));
+
+    if (!mkdir($tmp_dir, 0700, true)) {
+        $errmsg = '一時ディレクトリの作成に失敗しました';
+        return false;
+    }
+
+    $zip_file = $tmp_dir . DIRECTORY_SEPARATOR . 'update.zip';
+    set_time_limit(900);
+
+    $data = _kara_http_get($zip_url, $errmsg);
+    if ($data === false || strlen($data) === 0) {
+        _kara_update_cleanup($tmp_dir);
+        if (strlen($data) === 0) $errmsg = 'ダウンロードしたファイルが空です';
+        return false;
+    }
+    file_put_contents($zip_file, $data);
+    unset($data);
+
+    $zip = new ZipArchive();
+    if ($zip->open($zip_file) !== true) {
+        _kara_update_cleanup($tmp_dir);
+        $errmsg = 'ZIP の展開に失敗しました';
+        return false;
+    }
+    $extract_dir = $tmp_dir . DIRECTORY_SEPARATOR . 'extracted';
+    mkdir($extract_dir, 0700, true);
+    $zip->extractTo($extract_dir);
+    $zip->close();
+
+    // アーカイブ内のトップレベルディレクトリを探す
+    $source_dir = null;
+    foreach (scandir($extract_dir) as $entry) {
+        if ($entry !== '.' && $entry !== '..' && is_dir($extract_dir . DIRECTORY_SEPARATOR . $entry)) {
+            $source_dir = $extract_dir . DIRECTORY_SEPARATOR . $entry;
+            break;
+        }
+    }
+
+    if ($source_dir === null ||
+        !file_exists($source_dir . DIRECTORY_SEPARATOR . 'commonfunc.php') ||
+        !file_exists($source_dir . DIRECTORY_SEPARATOR . 'kara_config.php')) {
+        _kara_update_cleanup($tmp_dir);
+        $errmsg = 'アーカイブの構造が不正です (commonfunc.php / kara_config.php が見つかりません)';
+        return false;
+    }
+
+    // ユーザーデータ保護: 上書き除外リスト (相対パス, / 区切り)
+    $exclude_list = ['config.ini', '.git', 'version'];
+    if (array_key_exists('dbname', $config_ini)) {
+        $dbname = basename(urldecode($config_ini['dbname']));
+        if ($dbname !== '' && !in_array($dbname, $exclude_list)) {
+            $exclude_list[] = $dbname;
+        }
+    } else {
+        $exclude_list[] = 'request.db';
+    }
+    $exclude_list[] = 'images/bg';
+
+    _kara_update_copy_recursive($source_dir, $app_root, $exclude_list);
+
+    // バージョンファイルを更新
+    file_put_contents($app_root . DIRECTORY_SEPARATOR . 'version', $version_str);
+
+    _kara_update_cleanup($tmp_dir);
+    return true;
+}
+
+// ---- ZIPアーカイブ方式ここまで ----
 
 function make_preview_modal($filepath, $modalid) {
   global $everythinghost;

--- a/kara_config.php
+++ b/kara_config.php
@@ -184,6 +184,14 @@ function readconfig_array()
         $config_ini["bg_overlay_opacity"] = 100;
     }
 
+    // アップデート取得元リポジトリ（owner/repo 形式）。
+    // 開発移譲などで取得元が変わった場合、config.ini でこの値を書き換えれば
+    // ZIP / git アップデート先を切り替えられる。
+    if(!array_key_exists("update_repo", $config_ini)){
+        $update_repo = 'bee7813993/KaraokeRequestorWeb';
+        $config_ini = array_merge($config_ini,array("update_repo" => urlencode($update_repo)));
+    }
+
     if($config_ini["playerpath_select"] == urlencode("その他PATH指定" )) {
         $config_ini = array_merge($config_ini,array("playerpath" => ($config_ini["playerpath_any"])));
     }else{

--- a/online_update.php
+++ b/online_update.php
@@ -147,12 +147,12 @@ if ($zip_check !== true):
   </div>
 
   <div class="card mb-3">
-    <div class="card-header fw-bold">任意タグ / コミットハッシュ</div>
+    <div class="card-header fw-bold">任意タグ / ブランチ / コミットハッシュ</div>
     <div class="card-body">
       <form method="GET" class="d-flex gap-2 align-items-center">
         <input type="hidden" name="METHOD" value="zip" />
         <input type="text" name="UPDATEVERSION" class="form-control form-control-sm" style="max-width:280px;"
-               placeholder="例: v0.09.9-alpha" />
+               placeholder="例: v0.09.9-alpha / 3a4b5c6" />
         <button type="submit" class="btn btn-warning btn-sm"
                 onclick="return confirm('指定バージョンで更新します。よろしいですか？');">実行</button>
       </form>

--- a/online_update.php
+++ b/online_update.php
@@ -169,6 +169,12 @@ if ($zip_check !== true):
     $git_errmsg   = '';
     $git_taglist  = get_gittaglist($git_errmsg);           // fetch もここで実行（--prune付き）
     $git_branches = get_gitbranchlist($git_errmsg, false); // fetch 済みなのでスキップ
+    // master を先頭に並び替え
+    usort($git_branches, function($a, $b) {
+        if ($a === 'master') return -1;
+        if ($b === 'master') return 1;
+        return strcmp($a, $b);
+    });
     $fetch_failed = !empty($git_errmsg) && $git_errmsg !== 'none';
     $current_branch = get_current_git_branch();
 ?>

--- a/online_update.php
+++ b/online_update.php
@@ -1,89 +1,204 @@
-<html>
-<head>
-<?php 
-// 処理記述部
+<?php
 require_once 'commonfunc.php';
 print_meta_header();
-$res = 2;
-if(array_key_exists("UPDATEVERSION", $_REQUEST)) {
-  $res = update_fromgit(urldecode($_REQUEST["UPDATEVERSION"]),$errmsg);
+
+$res    = 2;    // 2=何もしていない, true=成功, false=失敗
+$errmsg = '';
+
+$req_version = array_key_exists('UPDATEVERSION', $_REQUEST) ? urldecode($_REQUEST['UPDATEVERSION']) : null;
+$req_method  = (array_key_exists('METHOD', $_REQUEST) && $_REQUEST['METHOD'] === 'git') ? 'git' : 'zip';
+
+if ($req_version !== null && $req_version !== '') {
+    if ($req_method === 'git') {
+        $res = update_fromgit($req_version, $errmsg);
+    } else {
+        $res = update_fromarchive($req_version, $errmsg);
+    }
 }
 
+// git が利用可能か判定
+$git_available = false;
+if (array_key_exists('gitcommandpath', $config_ini)) {
+    $gitcmd = urldecode($config_ini['gitcommandpath']);
+    $git_available = file_exists($gitcmd);
+}
+
+$active_tab = $git_available ? $req_method : 'zip';
 ?>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta http-equiv="Content-Script-Type" content="text/javascript" />
 
     <!-- Bootstrap -->
     <link href="css/bootstrap.min.css" rel="stylesheet">
 
-
-    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
-
-  <script type="text/javascript">
-
-    // ここに処理を記述します。
-  </script>
   <title>オンラインアップデート</title>
   <link type="text/css" rel="stylesheet" href="css/style.css" />
   <script type="text/javascript" charset="utf8" src="js/jquery.js"></script>
   <script src="js/bootstrap.min.js"></script>
 </head>
 <body>
-<?php
-shownavigatioinbar();
-?>
+<?php shownavigatioinbar(); ?>
+
+<div class="container" style="margin-top:20px;">
+  <h3>オンラインアップデート</h3>
 
 <?php
-if($res === false){
-   print "<p> $errmsg </p>" ;
-} else if($res === true){
-   print '<p>アップデートに成功しました</p>';
+// 更新結果表示
+if ($res === false) {
+    echo '<div class="alert alert-danger">' . htmlspecialchars($errmsg) . '</div>';
+} elseif ($res === true) {
+    echo '<div class="alert alert-success">アップデートに成功しました</div>';
 }
 
-$curver = get_git_version();
-if(!is_null($curver)) {
-print "<p> 現在のバージョン $curver </p>";
+// 現在バージョン表示
+$curver = get_version();
+if (!empty($curver)) {
+    echo '<p><strong>現在のバージョン:</strong> ' . htmlspecialchars($curver) . '</p>';
 }
-
-$taglist = get_gittaglist();
-if(count($taglist) > 0){
-  print '<dl class="dl-horizontal">';
-    print '<dt > 最新版(リリース前) </dt>';
-    print '<dd > <a href=online_update.php?UPDATEVERSION='.urlencode("origin/master").' class="btn btn-primary" > 更新 </a></dd> ';
-  foreach(array_reverse($taglist) as $tag){
-    if(strcmp($tag,'v0.09.5-alpha') == 0 ){
-      print '<dt > '.$tag.' </dt>';
-      print '<dd > これ以前のバージョンはコマンドプロンプトでのコマンド実行が必要です </dd> ';
-      break;
-    }
-    print '<dt > '.$tag.' </dt>';
-    print '<dd > <a href=online_update.php?UPDATEVERSION='.urlencode($tag).' class="btn btn-primary" > 更新 </a></dd> ';
-  }
-  print '</dl >';
-    print '  <div class="container">';
-    print '<div class="form-group">';
-    print '<form method="GET" class="form-inline">';
-    print '<label> 任意バージョンハッシュ </label>';
-    print '<input type="text" name="UPDATEVERSION" class="form-control toolinfo" />';
-    print '<input type="submit" value="実行" class="btn btn-primary "/>';
-    print '</form>';
-    print '  </div>';
-    print '  </div>';
-  
-
-}else {
-  print "Now no tag\n";
-}
-
 ?>
 
-<p> バージョン情報 <a href="https://github.com/bee7813993/KaraokeRequestorWeb/commits/master" target="_blank" > https://github.com/bee7813993/KaraokeRequestorWeb/commits/master </a>
+<?php if ($git_available): ?>
+<!-- タブ（git が設定されている場合のみ表示） -->
+<ul class="nav nav-tabs" id="updateTabs">
+  <li role="presentation" <?php if ($active_tab === 'zip') echo 'class="active"'; ?>>
+    <a href="#tab-zip" data-toggle="tab">ZIP方式（推奨）</a>
+  </li>
+  <li role="presentation" <?php if ($active_tab === 'git') echo 'class="active"'; ?>>
+    <a href="#tab-git" data-toggle="tab">Git方式</a>
+  </li>
+</ul>
+<div class="tab-content" style="margin-top:15px;">
+
+  <!-- ZIP 方式タブ -->
+  <div role="tabpanel" class="tab-pane <?php echo ($active_tab === 'zip') ? 'active' : ''; ?>" id="tab-zip">
+<?php else: ?>
+<!-- git 未設定: ZIP方式のみ -->
+<div>
+  <div>
+<?php endif; ?>
+
+<?php
+$zip_check = check_zip_update_available();
+if ($zip_check !== true):
+?>
+    <div class="alert alert-warning">
+      ZIP方式は現在利用できません: <?php echo htmlspecialchars($zip_check); ?>
+    </div>
+<?php else:
+    $zip_errmsg = '';
+    $zip_taglist = get_archive_taglist($zip_errmsg);
+    if (!empty($zip_errmsg)):
+?>
+    <div class="alert alert-warning">タグ一覧の取得に失敗しました: <?php echo htmlspecialchars($zip_errmsg); ?></div>
+<?php elseif (count($zip_taglist) === 0): ?>
+    <div class="alert alert-info">タグ情報を取得できませんでした（ネットワークを確認してください）</div>
+<?php else: ?>
+    <dl class="dl-horizontal">
+      <dt>最新版 (master)</dt>
+      <dd>
+        <a href="online_update.php?UPDATEVERSION=<?php echo urlencode('master'); ?>&METHOD=zip"
+           class="btn btn-primary btn-sm"
+           onclick="return confirm('master ブランチの最新版に更新します。よろしいですか？');">更新</a>
+      </dd>
+<?php   foreach ($zip_taglist as $tag):
+          if (strcmp($tag, 'v0.09.5-alpha') === 0): ?>
+      <dt><?php echo htmlspecialchars($tag); ?></dt>
+      <dd>これ以前のバージョンはコマンドプロンプトでのコマンド実行が必要です</dd>
+<?php       break;
+          endif; ?>
+      <dt><?php echo htmlspecialchars($tag); ?></dt>
+      <dd>
+        <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($tag); ?>&METHOD=zip"
+           class="btn btn-default btn-sm"
+           onclick="return confirm('<?php echo htmlspecialchars($tag, ENT_QUOTES); ?> に更新します。よろしいですか？');">更新</a>
+      </dd>
+<?php   endforeach; ?>
+    </dl>
+
+    <div class="panel panel-default" style="margin-top:10px;">
+      <div class="panel-body">
+        <form method="GET" class="form-inline">
+          <input type="hidden" name="METHOD" value="zip" />
+          <div class="form-group">
+            <label>任意タグ/コミットハッシュ&nbsp;</label>
+            <input type="text" name="UPDATEVERSION" class="form-control" placeholder="例: v0.09.9-alpha" />
+          </div>
+          &nbsp;<input type="submit" value="実行" class="btn btn-warning"
+                        onclick="return confirm('指定バージョンで更新します。よろしいですか？');" />
+        </form>
+      </div>
+    </div>
+<?php endif; endif; // zip_check / taglist ?>
+
+  </div><!-- /zip tab pane -->
+
+<?php if ($git_available): ?>
+
+  <!-- Git 方式タブ -->
+  <div role="tabpanel" class="tab-pane <?php echo ($active_tab === 'git') ? 'active' : ''; ?>" id="tab-git">
+    <div class="alert alert-info">
+      Git 方式: <code>git fetch</code> + <code>git reset --hard</code> でアップデートします。
+      <code>.git</code> フォルダを保持するためディスク容量が多くなります。
+    </div>
+<?php
+    $git_errmsg  = '';
+    $git_taglist = get_gittaglist($git_errmsg);
+    if (!empty($git_errmsg) && $git_errmsg !== 'none'):
+?>
+    <div class="alert alert-warning">タグ一覧の取得に失敗しました: <?php echo htmlspecialchars($git_errmsg); ?></div>
+<?php elseif (count($git_taglist) === 0): ?>
+    <div class="alert alert-info">タグが見つかりませんでした</div>
+<?php else: ?>
+    <dl class="dl-horizontal">
+      <dt>最新版 (リリース前)</dt>
+      <dd>
+        <a href="online_update.php?UPDATEVERSION=<?php echo urlencode('origin/master'); ?>&METHOD=git"
+           class="btn btn-primary btn-sm"
+           onclick="return confirm('origin/master の最新版に更新します。よろしいですか？');">更新</a>
+      </dd>
+<?php   foreach (array_reverse($git_taglist) as $tag):
+          if (strcmp($tag, 'v0.09.5-alpha') === 0): ?>
+      <dt><?php echo htmlspecialchars($tag); ?></dt>
+      <dd>これ以前のバージョンはコマンドプロンプトでのコマンド実行が必要です</dd>
+<?php       break;
+          endif; ?>
+      <dt><?php echo htmlspecialchars($tag); ?></dt>
+      <dd>
+        <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($tag); ?>&METHOD=git"
+           class="btn btn-default btn-sm"
+           onclick="return confirm('<?php echo htmlspecialchars($tag, ENT_QUOTES); ?> に更新します。よろしいですか？');">更新</a>
+      </dd>
+<?php   endforeach; ?>
+    </dl>
+
+    <div class="panel panel-default" style="margin-top:10px;">
+      <div class="panel-body">
+        <form method="GET" class="form-inline">
+          <input type="hidden" name="METHOD" value="git" />
+          <div class="form-group">
+            <label>任意バージョンハッシュ&nbsp;</label>
+            <input type="text" name="UPDATEVERSION" class="form-control" />
+          </div>
+          &nbsp;<input type="submit" value="実行" class="btn btn-warning" />
+        </form>
+      </div>
+    </div>
+<?php endif; ?>
+  </div><!-- /git tab pane -->
+
+</div><!-- /tab-content -->
+<?php else: ?>
+  </div>
+<?php endif; ?>
+
+<hr/>
+<p class="text-muted small">
+  バージョン情報:
+  <a href="https://github.com/bee7813993/KaraokeRequestorWeb/commits/master" target="_blank">
+    GitHub コミット履歴
+  </a>
+</p>
+</div><!-- /container -->
 
 </body>
 </html>

--- a/online_update.php
+++ b/online_update.php
@@ -197,21 +197,38 @@ if ($zip_check !== true):
       Git 方式: <code>git fetch</code> + <code>git reset --hard</code> でアップデートします。
     </div>
 <?php
-    $git_errmsg  = '';
-    $git_taglist = get_gittaglist($git_errmsg);
-    if (!empty($git_errmsg) && $git_errmsg !== 'none'):
+    $git_errmsg   = '';
+    $git_taglist  = get_gittaglist($git_errmsg);               // fetch もここで実行
+    $git_branches = get_gitbranchlist($git_errmsg, false);     // fetch 済みなのでスキップ
+    $fetch_failed = !empty($git_errmsg) && $git_errmsg !== 'none';
 ?>
-    <div class="alert alert-warning">タグ一覧の取得に失敗しました: <?php echo htmlspecialchars($git_errmsg); ?></div>
-<?php elseif (count($git_taglist) === 0): ?>
+<?php if ($fetch_failed): ?>
+    <div class="alert alert-warning">取得に失敗しました: <?php echo htmlspecialchars($git_errmsg); ?></div>
+<?php else: ?>
+
+    <!-- ブランチ一覧 -->
+<?php if (count($git_branches) > 0): ?>
+    <h5><strong>ブランチ</strong></h5>
+    <dl class="dl-horizontal">
+<?php   foreach ($git_branches as $branch):
+          $ver = 'origin/' . $branch; ?>
+      <dt style="overflow:hidden; text-overflow:ellipsis;"><?php echo htmlspecialchars($branch); ?></dt>
+      <dd>
+        <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($ver); ?>&METHOD=git"
+           class="btn btn-<?php echo ($branch === 'master') ? 'primary' : 'default'; ?> btn-sm"
+           onclick="return confirm('<?php echo htmlspecialchars($branch, ENT_QUOTES); ?> ブランチに切り替えます。よろしいですか？');">更新</a>
+      </dd>
+<?php   endforeach; ?>
+    </dl>
+    <hr/>
+<?php endif; ?>
+
+    <!-- タグ一覧 -->
+<?php if (count($git_taglist) === 0): ?>
     <div class="alert alert-info">タグが見つかりませんでした</div>
 <?php else: ?>
+    <h5><strong>タグ（リリース版）</strong></h5>
     <dl class="dl-horizontal">
-      <dt>最新版 (リリース前)</dt>
-      <dd>
-        <a href="online_update.php?UPDATEVERSION=<?php echo urlencode('origin/master'); ?>&METHOD=git"
-           class="btn btn-primary btn-sm"
-           onclick="return confirm('origin/master の最新版に更新します。よろしいですか？');">更新</a>
-      </dd>
 <?php   foreach (array_reverse($git_taglist) as $tag):
           if (strcmp($tag, 'v0.09.5-alpha') === 0): ?>
       <dt><?php echo htmlspecialchars($tag); ?></dt>
@@ -225,20 +242,22 @@ if ($zip_check !== true):
       </dd>
 <?php   endforeach; ?>
     </dl>
+<?php endif; // git_taglist ?>
 
     <div class="panel panel-default" style="margin-top:10px;">
       <div class="panel-body">
         <form method="GET" class="form-inline">
           <input type="hidden" name="METHOD" value="git" />
           <div class="form-group">
-            <label>任意バージョンハッシュ&nbsp;</label>
-            <input type="text" name="UPDATEVERSION" class="form-control" />
+            <label>任意ブランチ / タグ / ハッシュ&nbsp;</label>
+            <input type="text" name="UPDATEVERSION" class="form-control" placeholder="例: origin/my-branch" />
           </div>
           &nbsp;<input type="submit" value="実行" class="btn btn-warning" />
         </form>
       </div>
     </div>
-<?php endif; // git_taglist ?>
+
+<?php endif; // fetch_failed ?>
 <?php endif; // git_repo_exists ?>
 
   </div><!-- /git tab pane -->

--- a/online_update.php
+++ b/online_update.php
@@ -214,7 +214,7 @@ if ($zip_check !== true):
 <?php if (count($git_branches) > 0): ?>
   <div class="card mb-3">
     <div class="card-header p-0">
-      <button class="btn btn-link text-decoration-none text-start w-100 px-3 py-2 fw-bold"
+      <button class="btn btn-link text-decoration-none text-start text-body w-100 px-3 py-2 fw-bold"
               type="button" data-bs-toggle="collapse" data-bs-target="#branchList">
         ブランチ選択
         <span class="badge bg-secondary ms-1"><?php echo count($git_branches); ?></span>
@@ -253,7 +253,7 @@ if ($zip_check !== true):
 <?php if (count($git_taglist) > 0): ?>
   <div class="card mb-3">
     <div class="card-header p-0">
-      <button class="btn btn-link text-decoration-none text-start w-100 px-3 py-2 fw-bold"
+      <button class="btn btn-link text-decoration-none text-start text-body w-100 px-3 py-2 fw-bold"
               type="button" data-bs-toggle="collapse" data-bs-target="#tagList">
         タグ一覧（リリース版）
         <span class="badge bg-secondary ms-1"><?php echo count($git_taglist); ?></span>

--- a/online_update.php
+++ b/online_update.php
@@ -57,11 +57,13 @@ $active_tab = $git_available ? $req_method : 'zip';
 if ($res === false) {
     echo '<div class="alert alert-danger">' . htmlspecialchars($errmsg) . '</div>';
 } elseif ($res === true) {
-    $action_label = match($req_action) {
-        'git_gc', 'git_gc_aggressive' => 'リポジトリの最適化',
-        'git_init'                    => 'Git リポジトリの初期化',
-        default                       => 'アップデート',
-    };
+    if ($req_action === 'git_gc' || $req_action === 'git_gc_aggressive') {
+        $action_label = 'リポジトリの最適化';
+    } elseif ($req_action === 'git_init') {
+        $action_label = 'Git リポジトリの初期化';
+    } else {
+        $action_label = 'アップデート';
+    }
     echo '<div class="alert alert-success">' . htmlspecialchars($action_label) . 'に成功しました</div>';
 }
 

--- a/online_update.php
+++ b/online_update.php
@@ -135,7 +135,7 @@ if ($zip_check !== true):
             <td class="text-end">
               <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($tag); ?>&METHOD=zip"
                  class="btn btn-outline-secondary btn-sm"
-                 onclick="return confirm('<?php echo htmlspecialchars($tag, ENT_QUOTES); ?> に更新します。よろしいですか？');">更新</a>
+                 onclick="return confirm('<?php echo htmlspecialchars($tag, ENT_QUOTES); ?> を反映します。よろしいですか？');">反映</a>
             </td>
           </tr>
 <?php   endforeach; ?>
@@ -202,7 +202,7 @@ if ($zip_check !== true):
       <a href="online_update.php?UPDATEVERSION=<?php echo urlencode('origin/' . $current_branch); ?>&METHOD=git"
          class="btn btn-primary"
          onclick="return confirm('<?php echo htmlspecialchars($current_branch, ENT_QUOTES); ?> ブランチを最新に更新します。よろしいですか？');">
-        このブランチを最新に更新
+        このブランチの最新に更新
       </a>
 <?php else: ?>
       <p class="text-muted mb-0">ブランチ情報を取得できませんでした</p>
@@ -278,7 +278,7 @@ if ($zip_check !== true):
               <td class="text-end align-middle">
                 <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($tag); ?>&METHOD=git"
                    class="btn btn-outline-secondary btn-sm"
-                   onclick="return confirm('<?php echo htmlspecialchars($tag, ENT_QUOTES); ?> に更新します。よろしいですか？');">更新</a>
+                   onclick="return confirm('<?php echo htmlspecialchars($tag, ENT_QUOTES); ?> を反映します。よろしいですか？');">反映</a>
               </td>
             </tr>
 <?php   endforeach; ?>

--- a/online_update.php
+++ b/online_update.php
@@ -40,6 +40,10 @@ $active_tab = $git_available ? $req_method : 'zip';
 <?php print_meta_header(); ?>
 <title>オンラインアップデート</title>
 <?php print_bs5_head_core(); ?>
+<style>
+/* 非アクティブのタブ文字色をテーマカラーに合わせる */
+#updateTabs .nav-link:not(.active) { color: var(--color-text); }
+</style>
 </head>
 <body>
 <?php shownavigatioinbar_bs5('online_update.php'); ?>
@@ -214,7 +218,7 @@ if ($zip_check !== true):
 <?php if (count($git_branches) > 0): ?>
   <div class="card mb-3">
     <div class="card-header p-0">
-      <button class="btn btn-link text-decoration-none text-start text-body w-100 px-3 py-2 fw-bold"
+      <button class="btn btn-link text-decoration-none text-start w-100 px-3 py-2 fw-bold" style="color: var(--color-text);"
               type="button" data-bs-toggle="collapse" data-bs-target="#branchList">
         ブランチ選択
         <span class="badge bg-secondary ms-1"><?php echo count($git_branches); ?></span>
@@ -253,7 +257,7 @@ if ($zip_check !== true):
 <?php if (count($git_taglist) > 0): ?>
   <div class="card mb-3">
     <div class="card-header p-0">
-      <button class="btn btn-link text-decoration-none text-start text-body w-100 px-3 py-2 fw-bold"
+      <button class="btn btn-link text-decoration-none text-start w-100 px-3 py-2 fw-bold" style="color: var(--color-text);"
               type="button" data-bs-toggle="collapse" data-bs-target="#tagList">
         タグ一覧（リリース版）
         <span class="badge bg-secondary ms-1"><?php echo count($git_taglist); ?></span>

--- a/online_update.php
+++ b/online_update.php
@@ -1,15 +1,13 @@
 <?php
 require_once 'commonfunc.php';
-print_meta_header();
 
-$res    = 2;   // 2=何もしていない, true=成功, false=失敗
+$res    = 2;
 $errmsg = '';
 
 $req_version = isset($_REQUEST['UPDATEVERSION']) ? urldecode($_REQUEST['UPDATEVERSION']) : null;
 $req_method  = (isset($_REQUEST['METHOD']) && $_REQUEST['METHOD'] === 'git') ? 'git' : 'zip';
 $req_action  = isset($_REQUEST['ACTION']) ? $_REQUEST['ACTION'] : '';
 
-// アクション処理
 if ($req_action === 'git_gc') {
     $res = run_git_gc($errmsg, false);
 } elseif ($req_action === 'git_gc_aggressive') {
@@ -24,7 +22,6 @@ if ($req_action === 'git_gc') {
     }
 }
 
-// git 状態判定
 $git_configured  = false;
 $git_available   = false;
 $git_repo_exists = is_dir(realpath(__DIR__) . DIRECTORY_SEPARATOR . '.git');
@@ -37,378 +34,376 @@ if (array_key_exists('gitcommandpath', $config_ini)) {
 
 $active_tab = $git_available ? $req_method : 'zip';
 ?>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-    <!-- Bootstrap -->
-    <link href="css/bootstrap.min.css" rel="stylesheet">
-  <title>オンラインアップデート</title>
-  <link type="text/css" rel="stylesheet" href="css/style.css" />
-  <script type="text/javascript" charset="utf8" src="js/jquery.js"></script>
-  <script src="js/bootstrap.min.js"></script>
+<!doctype html>
+<html lang="ja">
+<head>
+<?php print_meta_header(); ?>
+<title>オンラインアップデート</title>
+<?php print_bs5_head_core(); ?>
 </head>
 <body>
-<?php shownavigatioinbar(); ?>
+<?php shownavigatioinbar_bs5('online_update.php'); ?>
 
-<div class="container" style="margin-top:20px;">
-  <h3>オンラインアップデート</h3>
+<div class="container py-3">
+  <h4 class="mb-3">オンラインアップデート</h4>
 
 <?php
-// 実行結果表示
 if ($res === false) {
-    echo '<div class="alert alert-danger">' . htmlspecialchars($errmsg) . '</div>';
+    echo '<div class="alert alert-danger alert-dismissible">'
+       . htmlspecialchars($errmsg)
+       . '<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>';
 } elseif ($res === true) {
     if ($req_action === 'git_gc' || $req_action === 'git_gc_aggressive') {
-        $action_label = 'リポジトリの最適化';
+        $label = 'リポジトリの最適化';
     } elseif ($req_action === 'git_init') {
-        $action_label = 'Git リポジトリの初期化';
+        $label = 'Git リポジトリの初期化';
     } else {
-        $action_label = 'アップデート';
+        $label = 'アップデート';
     }
-    echo '<div class="alert alert-success">' . htmlspecialchars($action_label) . 'に成功しました</div>';
+    echo '<div class="alert alert-success alert-dismissible">'
+       . htmlspecialchars($label) . 'に成功しました'
+       . '<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>';
 }
 
-// 現在バージョン表示
 $curver = get_version();
 if (!empty($curver)) {
-    echo '<p><strong>現在のバージョン:</strong> ' . htmlspecialchars($curver) . '</p>';
+    echo '<p class="text-muted"><small>現在のバージョン: <strong>' . htmlspecialchars($curver) . '</strong></small></p>';
 }
 ?>
 
 <?php if ($git_available): ?>
-<!-- タブ（git が設定されている場合のみ） -->
-<ul class="nav nav-tabs" id="updateTabs">
-  <li role="presentation" <?php if ($active_tab === 'zip') echo 'class="active"'; ?>>
-    <a href="#tab-zip" data-toggle="tab">ZIP方式（推奨）</a>
+<!-- タブ -->
+<ul class="nav nav-tabs mb-3" id="updateTabs" role="tablist">
+  <li class="nav-item" role="presentation">
+    <button class="nav-link <?php echo ($active_tab === 'zip') ? 'active' : ''; ?>"
+            id="zip-tab" data-bs-toggle="tab" data-bs-target="#tab-zip"
+            type="button" role="tab">ZIP方式（推奨）</button>
   </li>
-  <li role="presentation" <?php if ($active_tab === 'git') echo 'class="active"'; ?>>
-    <a href="#tab-git" data-toggle="tab">Git方式</a>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link <?php echo ($active_tab === 'git') ? 'active' : ''; ?>"
+            id="git-tab" data-bs-toggle="tab" data-bs-target="#tab-git"
+            type="button" role="tab">Git方式</button>
   </li>
 </ul>
-<div class="tab-content" style="margin-top:15px;">
+<div class="tab-content" id="updateTabsContent">
 
-  <!-- ZIP 方式タブ -->
-  <div role="tabpanel" class="tab-pane <?php echo ($active_tab === 'zip') ? 'active' : ''; ?>" id="tab-zip">
+<div class="tab-pane fade <?php echo ($active_tab === 'zip') ? 'show active' : ''; ?>" id="tab-zip" role="tabpanel">
 <?php else: ?>
-<div><div>
+<div>
 <?php endif; ?>
 
-<?php /* ========== ZIP 方式コンテンツ ========== */ ?>
+<?php /* ========== ZIP 方式 ========== */ ?>
 <?php
 $zip_check = check_zip_update_available();
 if ($zip_check !== true):
 ?>
-    <div class="alert alert-warning">
-      ZIP方式は現在利用できません: <?php echo htmlspecialchars($zip_check); ?>
-    </div>
+  <div class="alert alert-warning"><?php echo htmlspecialchars($zip_check); ?></div>
 <?php else:
     $zip_errmsg  = '';
     $zip_taglist = get_archive_taglist($zip_errmsg);
     if (!empty($zip_errmsg)):
 ?>
-    <div class="alert alert-warning">タグ一覧の取得に失敗しました: <?php echo htmlspecialchars($zip_errmsg); ?></div>
+  <div class="alert alert-warning">タグ一覧の取得に失敗しました: <?php echo htmlspecialchars($zip_errmsg); ?></div>
 <?php elseif (count($zip_taglist) === 0): ?>
-    <div class="alert alert-info">タグ情報を取得できませんでした（ネットワークを確認してください）</div>
+  <div class="alert alert-info">タグ情報を取得できませんでした（ネットワークを確認してください）</div>
 <?php else: ?>
-    <dl class="dl-horizontal">
-      <dt>最新版 (master)</dt>
-      <dd>
-        <a href="online_update.php?UPDATEVERSION=<?php echo urlencode('master'); ?>&METHOD=zip"
-           class="btn btn-primary btn-sm"
-           onclick="return confirm('master ブランチの最新版に更新します。よろしいですか？');">更新</a>
-      </dd>
+  <div class="card mb-3">
+    <div class="card-header fw-bold">バージョン選択</div>
+    <div class="card-body p-0">
+      <table class="table table-sm table-hover mb-0">
+        <tbody>
+          <tr>
+            <td class="align-middle"><strong>最新版 (master)</strong></td>
+            <td class="text-end">
+              <a href="online_update.php?UPDATEVERSION=<?php echo urlencode('master'); ?>&METHOD=zip"
+                 class="btn btn-primary btn-sm"
+                 onclick="return confirm('master ブランチの最新版に更新します。よろしいですか？');">更新</a>
+            </td>
+          </tr>
 <?php   foreach ($zip_taglist as $tag):
           if (strcmp($tag, 'v0.09.5-alpha') === 0): ?>
-      <dt><?php echo htmlspecialchars($tag); ?></dt>
-      <dd>これ以前のバージョンはコマンドプロンプトでのコマンド実行が必要です</dd>
+          <tr>
+            <td colspan="2" class="text-muted small"><?php echo htmlspecialchars($tag); ?> 以前はコマンドプロンプトでの操作が必要です</td>
+          </tr>
 <?php       break; endif; ?>
-      <dt><?php echo htmlspecialchars($tag); ?></dt>
-      <dd>
-        <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($tag); ?>&METHOD=zip"
-           class="btn btn-default btn-sm"
-           onclick="return confirm('<?php echo htmlspecialchars($tag, ENT_QUOTES); ?> に更新します。よろしいですか？');">更新</a>
-      </dd>
+          <tr>
+            <td class="align-middle"><?php echo htmlspecialchars($tag); ?></td>
+            <td class="text-end">
+              <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($tag); ?>&METHOD=zip"
+                 class="btn btn-outline-secondary btn-sm"
+                 onclick="return confirm('<?php echo htmlspecialchars($tag, ENT_QUOTES); ?> に更新します。よろしいですか？');">更新</a>
+            </td>
+          </tr>
 <?php   endforeach; ?>
-    </dl>
-
-    <div class="panel panel-default" style="margin-top:10px;">
-      <div class="panel-body">
-        <form method="GET" class="form-inline">
-          <input type="hidden" name="METHOD" value="zip" />
-          <div class="form-group">
-            <label>任意タグ / コミットハッシュ&nbsp;</label>
-            <input type="text" name="UPDATEVERSION" class="form-control" placeholder="例: v0.09.9-alpha" />
-          </div>
-          &nbsp;<input type="submit" value="実行" class="btn btn-warning"
-                       onclick="return confirm('指定バージョンで更新します。よろしいですか？');" />
-        </form>
-      </div>
+        </tbody>
+      </table>
     </div>
+  </div>
+
+  <div class="card mb-3">
+    <div class="card-header fw-bold">任意タグ / コミットハッシュ</div>
+    <div class="card-body">
+      <form method="GET" class="d-flex gap-2 align-items-center">
+        <input type="hidden" name="METHOD" value="zip" />
+        <input type="text" name="UPDATEVERSION" class="form-control form-control-sm" style="max-width:280px;"
+               placeholder="例: v0.09.9-alpha" />
+        <button type="submit" class="btn btn-warning btn-sm"
+                onclick="return confirm('指定バージョンで更新します。よろしいですか？');">実行</button>
+      </form>
+    </div>
+  </div>
 <?php endif; endif; // zip_check / taglist ?>
 
-  </div><!-- /zip tab pane -->
+<?php if ($git_available): ?>
+</div><!-- /tab-zip -->
 
-<?php if ($git_available): /* ========== Git 方式タブ ========== */ ?>
-
-  <div role="tabpanel" class="tab-pane <?php echo ($active_tab === 'git') ? 'active' : ''; ?>" id="tab-git">
+<?php /* ========== Git 方式 ========== */ ?>
+<div class="tab-pane fade <?php echo ($active_tab === 'git') ? 'show active' : ''; ?>" id="tab-git" role="tabpanel">
 
 <?php if (!$git_repo_exists): ?>
-    <!-- .git フォルダなし → 初期化案内 -->
-    <div class="panel panel-warning">
-      <div class="panel-heading"><strong>.git フォルダが見つかりません</strong></div>
-      <div class="panel-body">
-        <p>Git 方式でアップデートするには、まずリポジトリを初期化してください。<br>
-           <small class="text-muted">初期化後は <code>.git</code> フォルダが作成されます（数 MB、shallow clone）。</small></p>
-        <a href="online_update.php?ACTION=git_init&METHOD=git"
-           class="btn btn-warning"
-           onclick="return confirm('リポジトリを初期化します（git init + fetch --depth=1 + reset --hard）。\nconfig.ini・request.db などのユーザーデータは保護されます。よろしいですか？');">
-          Git リポジトリを初期化する
-        </a>
-      </div>
+  <div class="card border-warning mb-3">
+    <div class="card-header bg-warning bg-opacity-25 fw-bold">.git フォルダが見つかりません</div>
+    <div class="card-body">
+      <p class="mb-2">Git 方式でアップデートするには、まずリポジトリを初期化してください。<br>
+         <small class="text-muted">初期化後は <code>.git</code> フォルダが作成されます（数 MB、shallow clone）。</small></p>
+      <a href="online_update.php?ACTION=git_init&METHOD=git" class="btn btn-warning"
+         onclick="return confirm('リポジトリを初期化します（git init + fetch --depth=1 + reset --hard）。\nconfig.ini・request.db などのユーザーデータは保護されます。よろしいですか？');">
+        Git リポジトリを初期化する
+      </a>
     </div>
+  </div>
 <?php else:
-    $git_errmsg   = '';
-    $git_taglist  = get_gittaglist($git_errmsg);           // fetch もここで実行（--prune付き）
-    $git_branches = get_gitbranchlist($git_errmsg, false); // fetch 済みなのでスキップ
-    // master を先頭に、残りは git が返した新しい順を維持
+    $git_errmsg     = '';
+    $git_taglist    = get_gittaglist($git_errmsg);
+    $git_branches   = get_gitbranchlist($git_errmsg, false);
+    $fetch_failed   = !empty($git_errmsg) && $git_errmsg !== 'none';
+    $current_branch = get_current_git_branch();
+
+    // master を先頭に、残りは新しい順を維持
     $master_key = array_search('master', $git_branches, true);
     if ($master_key !== false) {
         array_splice($git_branches, $master_key, 1);
         array_unshift($git_branches, 'master');
     }
-    $fetch_failed = !empty($git_errmsg) && $git_errmsg !== 'none';
-    $current_branch = get_current_git_branch();
 ?>
 
-    <!-- (1) 現在のブランチ表示 + アップデートボタン -->
-    <div class="panel panel-primary">
-      <div class="panel-heading"><strong>現在のブランチ</strong></div>
-      <div class="panel-body">
+  <!-- (1) 現在のブランチ + アップデートボタン -->
+  <div class="card border-primary mb-3">
+    <div class="card-header bg-primary bg-opacity-10 fw-bold">現在のブランチ</div>
+    <div class="card-body">
 <?php if ($current_branch !== null): ?>
-        <p style="margin-bottom:10px;">
-          <span class="label label-default" style="font-size:1em; padding:4px 10px;">
-            <?php echo htmlspecialchars($current_branch); ?>
-          </span>
-        </p>
-        <a href="online_update.php?UPDATEVERSION=<?php echo urlencode('origin/' . $current_branch); ?>&METHOD=git"
-           class="btn btn-primary"
-           onclick="return confirm('<?php echo htmlspecialchars($current_branch, ENT_QUOTES); ?> ブランチを最新に更新します。よろしいですか？');">
-          このブランチを最新に更新
-        </a>
+      <p class="mb-2">
+        <span class="badge bg-secondary fs-6"><?php echo htmlspecialchars($current_branch); ?></span>
+      </p>
+      <a href="online_update.php?UPDATEVERSION=<?php echo urlencode('origin/' . $current_branch); ?>&METHOD=git"
+         class="btn btn-primary"
+         onclick="return confirm('<?php echo htmlspecialchars($current_branch, ENT_QUOTES); ?> ブランチを最新に更新します。よろしいですか？');">
+        このブランチを最新に更新
+      </a>
 <?php else: ?>
-        <p class="text-muted">ブランチ情報を取得できませんでした</p>
+      <p class="text-muted mb-0">ブランチ情報を取得できませんでした</p>
 <?php endif; ?>
-      </div>
     </div>
+  </div>
 
 <?php if ($fetch_failed): ?>
-    <div class="alert alert-warning">リモート情報の取得に失敗しました: <?php echo htmlspecialchars($git_errmsg); ?></div>
+  <div class="alert alert-warning">リモート情報の取得に失敗しました: <?php echo htmlspecialchars($git_errmsg); ?></div>
 <?php else: ?>
 
-    <!-- (2) ブランチ選択（折りたたみ） -->
+  <!-- (2) ブランチ選択（折りたたみ） -->
 <?php if (count($git_branches) > 0): ?>
-    <div class="panel panel-default">
-      <div class="panel-heading" style="cursor:pointer;" data-toggle="collapse" data-target="#branchList">
-        <strong>ブランチ選択</strong>
-        <span class="text-muted small">&nbsp;（<?php echo count($git_branches); ?> 件）&nbsp;▼</span>
-      </div>
-      <div id="branchList" class="panel-collapse collapse">
-        <div class="panel-body" style="padding:0;">
-          <dl class="dl-horizontal" style="margin:10px 0;">
+  <div class="card mb-3">
+    <div class="card-header p-0">
+      <button class="btn btn-link text-decoration-none text-start w-100 px-3 py-2 fw-bold"
+              type="button" data-bs-toggle="collapse" data-bs-target="#branchList">
+        ブランチ選択
+        <span class="badge bg-secondary ms-1"><?php echo count($git_branches); ?></span>
+      </button>
+    </div>
+    <div id="branchList" class="collapse">
+      <div class="card-body p-0">
+        <table class="table table-sm table-hover mb-0">
+          <tbody>
 <?php   foreach ($git_branches as $branch):
-          $ver = 'origin/' . $branch;
           $is_current = ($branch === $current_branch); ?>
-            <dt style="overflow:hidden; text-overflow:ellipsis;">
-              <?php echo htmlspecialchars($branch); ?>
-              <?php if ($is_current): ?><span class="label label-primary">現在</span><?php endif; ?>
-            </dt>
-            <dd>
+            <tr class="<?php echo $is_current ? 'table-active' : ''; ?>">
+              <td class="align-middle">
+                <?php echo htmlspecialchars($branch); ?>
+                <?php if ($is_current): ?><span class="badge bg-primary ms-1">現在</span><?php endif; ?>
+              </td>
+              <td class="text-end align-middle">
 <?php       if (!$is_current): ?>
-              <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($ver); ?>&METHOD=git"
-                 class="btn btn-default btn-sm"
-                 onclick="return confirm('<?php echo htmlspecialchars($branch, ENT_QUOTES); ?> ブランチに切り替えます。よろしいですか？');">切替</a>
+                <a href="online_update.php?UPDATEVERSION=<?php echo urlencode('origin/' . $branch); ?>&METHOD=git"
+                   class="btn btn-outline-secondary btn-sm"
+                   onclick="return confirm('<?php echo htmlspecialchars($branch, ENT_QUOTES); ?> ブランチに切り替えます。よろしいですか？');">切替</a>
 <?php       else: ?>
-              <span class="text-muted small">（選択中）</span>
+                <span class="text-muted small">選択中</span>
 <?php       endif; ?>
-            </dd>
+              </td>
+            </tr>
 <?php   endforeach; ?>
-          </dl>
-        </div>
+          </tbody>
+        </table>
       </div>
     </div>
+  </div>
 <?php endif; ?>
 
-    <!-- (3) タグ一覧（折りたたみ） -->
+  <!-- (3) タグ一覧（折りたたみ） -->
 <?php if (count($git_taglist) > 0): ?>
-    <div class="panel panel-default">
-      <div class="panel-heading" style="cursor:pointer;" data-toggle="collapse" data-target="#tagList">
-        <strong>タグ一覧（リリース版）</strong>
-        <span class="text-muted small">&nbsp;（<?php echo count($git_taglist); ?> 件）&nbsp;▼</span>
-      </div>
-      <div id="tagList" class="panel-collapse collapse">
-        <div class="panel-body" style="padding:0;">
-          <dl class="dl-horizontal" style="margin:10px 0;">
+  <div class="card mb-3">
+    <div class="card-header p-0">
+      <button class="btn btn-link text-decoration-none text-start w-100 px-3 py-2 fw-bold"
+              type="button" data-bs-toggle="collapse" data-bs-target="#tagList">
+        タグ一覧（リリース版）
+        <span class="badge bg-secondary ms-1"><?php echo count($git_taglist); ?></span>
+      </button>
+    </div>
+    <div id="tagList" class="collapse">
+      <div class="card-body p-0">
+        <table class="table table-sm table-hover mb-0">
+          <tbody>
 <?php   foreach (array_reverse($git_taglist) as $tag):
           if (strcmp($tag, 'v0.09.5-alpha') === 0): ?>
-            <dt><?php echo htmlspecialchars($tag); ?></dt>
-            <dd><span class="text-muted small">これ以前はコマンドプロンプトでの操作が必要です</span></dd>
+            <tr>
+              <td colspan="2" class="text-muted small"><?php echo htmlspecialchars($tag); ?> 以前はコマンドプロンプトでの操作が必要です</td>
+            </tr>
 <?php       break; endif; ?>
-            <dt><?php echo htmlspecialchars($tag); ?></dt>
-            <dd>
-              <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($tag); ?>&METHOD=git"
-                 class="btn btn-default btn-sm"
-                 onclick="return confirm('<?php echo htmlspecialchars($tag, ENT_QUOTES); ?> に更新します。よろしいですか？');">更新</a>
-            </dd>
+            <tr>
+              <td class="align-middle"><?php echo htmlspecialchars($tag); ?></td>
+              <td class="text-end align-middle">
+                <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($tag); ?>&METHOD=git"
+                   class="btn btn-outline-secondary btn-sm"
+                   onclick="return confirm('<?php echo htmlspecialchars($tag, ENT_QUOTES); ?> に更新します。よろしいですか？');">更新</a>
+              </td>
+            </tr>
 <?php   endforeach; ?>
-          </dl>
-        </div>
+          </tbody>
+        </table>
       </div>
     </div>
+  </div>
 <?php endif; ?>
 
-    <!-- (4) 任意ブランチ / タグ / ハッシュ -->
-    <div class="panel panel-default">
-      <div class="panel-heading"><strong>任意ブランチ / タグ / ハッシュ</strong></div>
-      <div class="panel-body">
-        <form method="GET" class="form-inline">
-          <input type="hidden" name="METHOD" value="git" />
-          <div class="form-group">
-            <input type="text" name="UPDATEVERSION" class="form-control" placeholder="例: origin/my-branch" style="width:280px;" />
-          </div>
-          &nbsp;<input type="submit" value="実行" class="btn btn-warning"
-                       onclick="return confirm('指定のブランチ/タグ/ハッシュに切り替えます。よろしいですか？');" />
-        </form>
-      </div>
+  <!-- (4) 任意ブランチ / タグ / ハッシュ -->
+  <div class="card mb-3">
+    <div class="card-header fw-bold">任意ブランチ / タグ / ハッシュ</div>
+    <div class="card-body">
+      <form method="GET" class="d-flex gap-2 align-items-center">
+        <input type="hidden" name="METHOD" value="git" />
+        <input type="text" name="UPDATEVERSION" class="form-control form-control-sm" style="max-width:280px;"
+               placeholder="例: origin/my-branch" />
+        <button type="submit" class="btn btn-warning btn-sm"
+                onclick="return confirm('指定のブランチ/タグ/ハッシュに切り替えます。よろしいですか？');">実行</button>
+      </form>
     </div>
+  </div>
 
 <?php endif; // fetch_failed ?>
 
-    <!-- (5) リポジトリ最適化 -->
+  <!-- (5) リポジトリ最適化 -->
 <?php
-    $git_size    = get_git_dir_size();
+    $git_size     = get_git_dir_size();
     $git_size_str = $git_size !== null ? format_filesize($git_size) : '取得失敗';
     $git_cmd_ver  = get_git_command_version();
 ?>
-    <div class="panel panel-default">
-      <div class="panel-heading"><strong>リポジトリ最適化</strong></div>
-      <div class="panel-body">
-        <p>
-          <strong>git バージョン:</strong>
-          <?php if ($git_cmd_ver !== null): ?>
-            <code><?php echo htmlspecialchars($git_cmd_ver); ?></code>
-            <small class="text-muted">&nbsp;（gitcmd フォルダの git.exe を差し替えると更新できます）</small>
-          <?php else: ?>
-            <span class="text-muted">取得失敗</span>
-          <?php endif; ?>
-        </p>
-        <p><strong>.git フォルダ サイズ:</strong> <?php echo htmlspecialchars($git_size_str); ?>
-           <small class="text-muted">&nbsp;（アップデート後に git gc を実行すると削減できます）</small></p>
-        <a href="online_update.php?ACTION=git_gc&METHOD=git"
-           class="btn btn-default btn-sm"
+  <div class="card mb-3">
+    <div class="card-header fw-bold">リポジトリ最適化</div>
+    <div class="card-body">
+      <p class="mb-1">
+        <small class="text-muted">git バージョン: </small>
+        <?php if ($git_cmd_ver !== null): ?>
+          <code class="small"><?php echo htmlspecialchars($git_cmd_ver); ?></code>
+          <small class="text-muted">（gitcmd フォルダの git.exe を差し替えると更新できます）</small>
+        <?php else: ?>
+          <span class="text-muted small">取得失敗</span>
+        <?php endif; ?>
+      </p>
+      <p class="mb-2">
+        <small class="text-muted">.git フォルダ サイズ: </small>
+        <strong><?php echo htmlspecialchars($git_size_str); ?></strong>
+        <small class="text-muted">（アップデート後に git gc を実行すると削減できます）</small>
+      </p>
+      <div class="d-flex gap-2">
+        <a href="online_update.php?ACTION=git_gc&METHOD=git" class="btn btn-outline-secondary btn-sm"
            onclick="return confirm('git gc --prune=all を実行します。通常数十秒かかります。よろしいですか？');">
           最適化（git gc）
         </a>
-        &nbsp;
-        <a href="online_update.php?ACTION=git_gc_aggressive&METHOD=git"
-           class="btn btn-default btn-sm"
+        <a href="online_update.php?ACTION=git_gc_aggressive&METHOD=git" class="btn btn-outline-secondary btn-sm"
            onclick="return confirm('git gc --aggressive --prune=all を実行します。通常数分かかります。よろしいですか？');">
           徹底最適化（--aggressive）
         </a>
-        <p class="text-muted" style="margin-top:8px; margin-bottom:0;">
-          <small>通常最適化で大半の不要データを除去できます。徹底最適化はより小さくなりますが時間がかかります。</small>
-        </p>
       </div>
+      <p class="text-muted mt-2 mb-0"><small>通常最適化で大半の不要データを除去できます。徹底最適化はより小さくなりますが時間がかかります。</small></p>
     </div>
+  </div>
 
 <?php endif; // git_repo_exists ?>
-
-  </div><!-- /git tab pane -->
-
+</div><!-- /tab-git -->
 </div><!-- /tab-content -->
 
-<?php else: /* git_available が false → ZIP のみ表示 + セットアップ案内 */
-    echo '</div></div>';
-?>
+<?php else: // git_available が false ?>
+</div>
 
-<!-- ============================================================ -->
-<!-- Git 方式を有効にする手順（git 未設定時に表示）              -->
-<!-- ============================================================ -->
-<div class="panel-group" id="gitSetupAccordion" style="margin-top:20px;">
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h4 class="panel-title">
-        <a data-toggle="collapse" data-parent="#gitSetupAccordion" href="#collapseGitSetup">
-          Git 方式を有効にする手順（任意）
-        </a>
-      </h4>
-    </div>
-    <div id="collapseGitSetup" class="panel-collapse collapse">
-      <div class="panel-body">
-
+<!-- Git 方式を有効にする手順 -->
+<div class="accordion mt-4" id="gitSetupAccordion">
+  <div class="accordion-item">
+    <h2 class="accordion-header">
+      <button class="accordion-button collapsed" type="button"
+              data-bs-toggle="collapse" data-bs-target="#collapseGitSetup">
+        Git 方式を有効にする手順（任意）
+      </button>
+    </h2>
+    <div id="collapseGitSetup" class="accordion-collapse collapse">
+      <div class="accordion-body">
         <div class="alert alert-info">
           Git 方式を使うと過去の任意バージョンへの巻き戻しが可能になります。
-          ただし <code>.git</code> フォルダのぶんディスクを多く使います（初期数 MB、以後増加）。
-          通常は ZIP 方式で十分です。
+          ただし <code>.git</code> フォルダのぶんディスクを多く使います。通常は ZIP 方式で十分です。
         </div>
 
-        <!-- Step 1 -->
-        <h4>Step 1 &mdash; Portable Git を配置する</h4>
+        <h6>Step 1 &mdash; Portable Git を配置する</h6>
         <ol>
-          <li>
-            <a href="https://git-scm.com/download/win" target="_blank">git-scm.com</a> から
-            <strong>Portable ("thumbdrive edition")</strong> 版をダウンロードします。
-          </li>
-          <li>
-            ダウンロードした EXE を実行し、アプリフォルダ直下の <code>gitcmd</code> フォルダへ展開します。<br>
-            <code>（例: C:\xampp\htdocs\gitcmd\）</code>
-          </li>
-          <li>
-            展開後に <code>gitcmd\cmd\git.exe</code> が存在することを確認します。
-          </li>
+          <li><a href="https://git-scm.com/download/win" target="_blank">git-scm.com</a> から <strong>Portable ("thumbdrive edition")</strong> 版をダウンロード</li>
+          <li>ダウンロードした EXE を実行し、アプリフォルダ直下の <code>gitcmd</code> フォルダへ展開<br>
+              <code class="small">例: C:\xampp\htdocs\gitcmd\</code></li>
+          <li><code>gitcmd\cmd\git.exe</code> が存在することを確認</li>
         </ol>
 
-        <!-- Step 2 -->
-        <h4>Step 2 &mdash; 管理画面でパスを設定する</h4>
+        <h6>Step 2 &mdash; 管理画面でパスを設定する</h6>
         <ol>
-          <li><a href="init.php" target="_blank">管理画面 (init.php)</a> を開きます。</li>
-          <li>
-            <strong>gitcommandpath</strong> の項目に <code>git.exe</code> の絶対パスを入力して保存します。<br>
-            <code>（例: C:\xampp\htdocs\gitcmd\cmd\git.exe）</code>
-          </li>
-          <li>このページをリロードすると「Git 方式」タブが追加されます。</li>
+          <li><a href="init.php" target="_blank">管理画面 (init.php)</a> を開く</li>
+          <li><strong>gitcommandpath</strong> に <code>git.exe</code> の絶対パスを入力して保存<br>
+              <code class="small">例: C:\xampp\htdocs\gitcmd\cmd\git.exe</code></li>
+          <li>このページをリロードすると「Git 方式」タブが追加されます</li>
         </ol>
 
 <?php if ($git_configured && !$git_available): ?>
         <div class="alert alert-warning">
-          <strong>注意:</strong> <code>gitcommandpath</code> は設定されていますが、
-          ファイルが見つかりません。パスを確認してください。<br>
+          <strong>注意:</strong> <code>gitcommandpath</code> は設定されていますが、ファイルが見つかりません。パスを確認してください。<br>
           設定値: <code><?php echo htmlspecialchars(urldecode($config_ini['gitcommandpath'])); ?></code>
         </div>
 <?php endif; ?>
 
 <?php if ($git_configured && $git_available && !$git_repo_exists): ?>
-        <!-- git コマンドは使えるが .git がない → 初期化ボタンを表示 -->
-        <h4>Step 3 &mdash; リポジトリを初期化する</h4>
+        <h6>Step 3 &mdash; リポジトリを初期化する</h6>
         <p>git コマンドが利用可能です。下のボタンでリポジトリを初期化できます。</p>
-        <a href="online_update.php?ACTION=git_init&METHOD=git"
-           class="btn btn-warning"
+        <a href="online_update.php?ACTION=git_init&METHOD=git" class="btn btn-warning"
            onclick="return confirm('リポジトリを初期化します（git init + fetch --depth=1）。\nconfig.ini・request.db などのユーザーデータは保護されます。よろしいですか？');">
           Git リポジトリを初期化する
         </a>
 <?php else: ?>
-        <!-- Step 3 (generic) -->
-        <h4>Step 3 &mdash; リポジトリを初期化する</h4>
-        <p>Step 2 完了後にこのページをリロードすると、「Git リポジトリを初期化する」ボタンが表示されます。
-           ボタンを押すと <code>git init + fetch --depth=1</code> が自動実行されます。</p>
+        <h6>Step 3 &mdash; リポジトリを初期化する</h6>
+        <p class="text-muted">Step 2 完了後にこのページをリロードすると「Git リポジトリを初期化する」ボタンが表示されます。</p>
 <?php endif; ?>
 
-      </div><!-- /panel-body -->
-    </div><!-- /collapse -->
-  </div><!-- /panel -->
-</div><!-- /accordion -->
+      </div>
+    </div>
+  </div>
+</div>
 
 <?php endif; // git_available ?>
 
-<hr/>
+<hr class="mt-4"/>
 <p class="text-muted small">
   バージョン情報:
   <a href="https://github.com/bee7813993/KaraokeRequestorWeb/commits/master" target="_blank">
@@ -416,6 +411,6 @@ if ($zip_check !== true):
   </a>
 </p>
 </div><!-- /container -->
-
+<?php print_bg_style_block(true); ?>
 </body>
 </html>

--- a/online_update.php
+++ b/online_update.php
@@ -169,12 +169,12 @@ if ($zip_check !== true):
     $git_errmsg   = '';
     $git_taglist  = get_gittaglist($git_errmsg);           // fetch もここで実行（--prune付き）
     $git_branches = get_gitbranchlist($git_errmsg, false); // fetch 済みなのでスキップ
-    // master を先頭に並び替え
-    usort($git_branches, function($a, $b) {
-        if ($a === 'master') return -1;
-        if ($b === 'master') return 1;
-        return strcmp($a, $b);
-    });
+    // master を先頭に、残りは git が返した新しい順を維持
+    $master_key = array_search('master', $git_branches, true);
+    if ($master_key !== false) {
+        array_splice($git_branches, $master_key, 1);
+        array_unshift($git_branches, 'master');
+    }
     $fetch_failed = !empty($git_errmsg) && $git_errmsg !== 'none';
     $current_branch = get_current_git_branch();
 ?>

--- a/online_update.php
+++ b/online_update.php
@@ -284,12 +284,22 @@ if ($zip_check !== true):
 
     <!-- (5) リポジトリ最適化 -->
 <?php
-    $git_size = get_git_dir_size();
+    $git_size    = get_git_dir_size();
     $git_size_str = $git_size !== null ? format_filesize($git_size) : '取得失敗';
+    $git_cmd_ver  = get_git_command_version();
 ?>
     <div class="panel panel-default">
       <div class="panel-heading"><strong>リポジトリ最適化</strong></div>
       <div class="panel-body">
+        <p>
+          <strong>git バージョン:</strong>
+          <?php if ($git_cmd_ver !== null): ?>
+            <code><?php echo htmlspecialchars($git_cmd_ver); ?></code>
+            <small class="text-muted">&nbsp;（gitcmd フォルダの git.exe を差し替えると更新できます）</small>
+          <?php else: ?>
+            <span class="text-muted">取得失敗</span>
+          <?php endif; ?>
+        </p>
         <p><strong>.git フォルダ サイズ:</strong> <?php echo htmlspecialchars($git_size_str); ?>
            <small class="text-muted">&nbsp;（アップデート後に git gc を実行すると削減できます）</small></p>
         <a href="online_update.php?ACTION=git_gc&METHOD=git"

--- a/online_update.php
+++ b/online_update.php
@@ -206,21 +206,29 @@ if ($zip_check !== true):
     <div class="alert alert-warning">取得に失敗しました: <?php echo htmlspecialchars($git_errmsg); ?></div>
 <?php else: ?>
 
-    <!-- ブランチ一覧 -->
+    <!-- ブランチ一覧（折りたたみ） -->
 <?php if (count($git_branches) > 0): ?>
-    <h5><strong>ブランチ</strong></h5>
-    <dl class="dl-horizontal">
+    <div class="panel panel-default">
+      <div class="panel-heading" style="cursor:pointer;" data-toggle="collapse" data-target="#branchList">
+        <strong>ブランチ一覧</strong>
+        <span class="text-muted small">&nbsp;（<?php echo count($git_branches); ?> 件）&nbsp;▼</span>
+      </div>
+      <div id="branchList" class="panel-collapse collapse">
+        <div class="panel-body" style="padding-top:8px; padding-bottom:8px;">
+          <dl class="dl-horizontal" style="margin-bottom:0;">
 <?php   foreach ($git_branches as $branch):
           $ver = 'origin/' . $branch; ?>
-      <dt style="overflow:hidden; text-overflow:ellipsis;"><?php echo htmlspecialchars($branch); ?></dt>
-      <dd>
-        <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($ver); ?>&METHOD=git"
-           class="btn btn-<?php echo ($branch === 'master') ? 'primary' : 'default'; ?> btn-sm"
-           onclick="return confirm('<?php echo htmlspecialchars($branch, ENT_QUOTES); ?> ブランチに切り替えます。よろしいですか？');">更新</a>
-      </dd>
+            <dt style="overflow:hidden; text-overflow:ellipsis;"><?php echo htmlspecialchars($branch); ?></dt>
+            <dd>
+              <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($ver); ?>&METHOD=git"
+                 class="btn btn-<?php echo ($branch === 'master') ? 'primary' : 'default'; ?> btn-sm"
+                 onclick="return confirm('<?php echo htmlspecialchars($branch, ENT_QUOTES); ?> ブランチに切り替えます。よろしいですか？');">更新</a>
+            </dd>
 <?php   endforeach; ?>
-    </dl>
-    <hr/>
+          </dl>
+        </div>
+      </div>
+    </div>
 <?php endif; ?>
 
     <!-- タグ一覧 -->

--- a/online_update.php
+++ b/online_update.php
@@ -165,8 +165,118 @@ if ($zip_check !== true):
         </a>
       </div>
     </div>
+<?php else:
+    $git_errmsg   = '';
+    $git_taglist  = get_gittaglist($git_errmsg);           // fetch もここで実行（--prune付き）
+    $git_branches = get_gitbranchlist($git_errmsg, false); // fetch 済みなのでスキップ
+    $fetch_failed = !empty($git_errmsg) && $git_errmsg !== 'none';
+    $current_branch = get_current_git_branch();
+?>
+
+    <!-- (1) 現在のブランチ表示 + アップデートボタン -->
+    <div class="panel panel-primary">
+      <div class="panel-heading"><strong>現在のブランチ</strong></div>
+      <div class="panel-body">
+<?php if ($current_branch !== null): ?>
+        <p style="margin-bottom:10px;">
+          <span class="label label-default" style="font-size:1em; padding:4px 10px;">
+            <?php echo htmlspecialchars($current_branch); ?>
+          </span>
+        </p>
+        <a href="online_update.php?UPDATEVERSION=<?php echo urlencode('origin/' . $current_branch); ?>&METHOD=git"
+           class="btn btn-primary"
+           onclick="return confirm('<?php echo htmlspecialchars($current_branch, ENT_QUOTES); ?> ブランチを最新に更新します。よろしいですか？');">
+          このブランチを最新に更新
+        </a>
 <?php else: ?>
-    <!-- .git サイズ表示 + 最適化ボタン -->
+        <p class="text-muted">ブランチ情報を取得できませんでした</p>
+<?php endif; ?>
+      </div>
+    </div>
+
+<?php if ($fetch_failed): ?>
+    <div class="alert alert-warning">リモート情報の取得に失敗しました: <?php echo htmlspecialchars($git_errmsg); ?></div>
+<?php else: ?>
+
+    <!-- (2) ブランチ選択（折りたたみ） -->
+<?php if (count($git_branches) > 0): ?>
+    <div class="panel panel-default">
+      <div class="panel-heading" style="cursor:pointer;" data-toggle="collapse" data-target="#branchList">
+        <strong>ブランチ選択</strong>
+        <span class="text-muted small">&nbsp;（<?php echo count($git_branches); ?> 件）&nbsp;▼</span>
+      </div>
+      <div id="branchList" class="panel-collapse collapse">
+        <div class="panel-body" style="padding:0;">
+          <dl class="dl-horizontal" style="margin:10px 0;">
+<?php   foreach ($git_branches as $branch):
+          $ver = 'origin/' . $branch;
+          $is_current = ($branch === $current_branch); ?>
+            <dt style="overflow:hidden; text-overflow:ellipsis;">
+              <?php echo htmlspecialchars($branch); ?>
+              <?php if ($is_current): ?><span class="label label-primary">現在</span><?php endif; ?>
+            </dt>
+            <dd>
+<?php       if (!$is_current): ?>
+              <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($ver); ?>&METHOD=git"
+                 class="btn btn-default btn-sm"
+                 onclick="return confirm('<?php echo htmlspecialchars($branch, ENT_QUOTES); ?> ブランチに切り替えます。よろしいですか？');">切替</a>
+<?php       else: ?>
+              <span class="text-muted small">（選択中）</span>
+<?php       endif; ?>
+            </dd>
+<?php   endforeach; ?>
+          </dl>
+        </div>
+      </div>
+    </div>
+<?php endif; ?>
+
+    <!-- (3) タグ一覧（折りたたみ） -->
+<?php if (count($git_taglist) > 0): ?>
+    <div class="panel panel-default">
+      <div class="panel-heading" style="cursor:pointer;" data-toggle="collapse" data-target="#tagList">
+        <strong>タグ一覧（リリース版）</strong>
+        <span class="text-muted small">&nbsp;（<?php echo count($git_taglist); ?> 件）&nbsp;▼</span>
+      </div>
+      <div id="tagList" class="panel-collapse collapse">
+        <div class="panel-body" style="padding:0;">
+          <dl class="dl-horizontal" style="margin:10px 0;">
+<?php   foreach (array_reverse($git_taglist) as $tag):
+          if (strcmp($tag, 'v0.09.5-alpha') === 0): ?>
+            <dt><?php echo htmlspecialchars($tag); ?></dt>
+            <dd><span class="text-muted small">これ以前はコマンドプロンプトでの操作が必要です</span></dd>
+<?php       break; endif; ?>
+            <dt><?php echo htmlspecialchars($tag); ?></dt>
+            <dd>
+              <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($tag); ?>&METHOD=git"
+                 class="btn btn-default btn-sm"
+                 onclick="return confirm('<?php echo htmlspecialchars($tag, ENT_QUOTES); ?> に更新します。よろしいですか？');">更新</a>
+            </dd>
+<?php   endforeach; ?>
+          </dl>
+        </div>
+      </div>
+    </div>
+<?php endif; ?>
+
+    <!-- (4) 任意ブランチ / タグ / ハッシュ -->
+    <div class="panel panel-default">
+      <div class="panel-heading"><strong>任意ブランチ / タグ / ハッシュ</strong></div>
+      <div class="panel-body">
+        <form method="GET" class="form-inline">
+          <input type="hidden" name="METHOD" value="git" />
+          <div class="form-group">
+            <input type="text" name="UPDATEVERSION" class="form-control" placeholder="例: origin/my-branch" style="width:280px;" />
+          </div>
+          &nbsp;<input type="submit" value="実行" class="btn btn-warning"
+                       onclick="return confirm('指定のブランチ/タグ/ハッシュに切り替えます。よろしいですか？');" />
+        </form>
+      </div>
+    </div>
+
+<?php endif; // fetch_failed ?>
+
+    <!-- (5) リポジトリ最適化 -->
 <?php
     $git_size = get_git_dir_size();
     $git_size_str = $git_size !== null ? format_filesize($git_size) : '取得失敗';
@@ -175,7 +285,7 @@ if ($zip_check !== true):
       <div class="panel-heading"><strong>リポジトリ最適化</strong></div>
       <div class="panel-body">
         <p><strong>.git フォルダ サイズ:</strong> <?php echo htmlspecialchars($git_size_str); ?>
-           &nbsp;<small class="text-muted">（アップデート後に <code>git gc</code> を実行すると削減できます）</small></p>
+           <small class="text-muted">&nbsp;（アップデート後に git gc を実行すると削減できます）</small></p>
         <a href="online_update.php?ACTION=git_gc&METHOD=git"
            class="btn btn-default btn-sm"
            onclick="return confirm('git gc --prune=all を実行します。通常数十秒かかります。よろしいですか？');">
@@ -193,79 +303,6 @@ if ($zip_check !== true):
       </div>
     </div>
 
-    <div class="alert alert-info" style="margin-top:0;">
-      Git 方式: <code>git fetch</code> + <code>git reset --hard</code> でアップデートします。
-    </div>
-<?php
-    $git_errmsg   = '';
-    $git_taglist  = get_gittaglist($git_errmsg);               // fetch もここで実行
-    $git_branches = get_gitbranchlist($git_errmsg, false);     // fetch 済みなのでスキップ
-    $fetch_failed = !empty($git_errmsg) && $git_errmsg !== 'none';
-?>
-<?php if ($fetch_failed): ?>
-    <div class="alert alert-warning">取得に失敗しました: <?php echo htmlspecialchars($git_errmsg); ?></div>
-<?php else: ?>
-
-    <!-- ブランチ一覧（折りたたみ） -->
-<?php if (count($git_branches) > 0): ?>
-    <div class="panel panel-default">
-      <div class="panel-heading" style="cursor:pointer;" data-toggle="collapse" data-target="#branchList">
-        <strong>ブランチ一覧</strong>
-        <span class="text-muted small">&nbsp;（<?php echo count($git_branches); ?> 件）&nbsp;▼</span>
-      </div>
-      <div id="branchList" class="panel-collapse collapse">
-        <div class="panel-body" style="padding-top:8px; padding-bottom:8px;">
-          <dl class="dl-horizontal" style="margin-bottom:0;">
-<?php   foreach ($git_branches as $branch):
-          $ver = 'origin/' . $branch; ?>
-            <dt style="overflow:hidden; text-overflow:ellipsis;"><?php echo htmlspecialchars($branch); ?></dt>
-            <dd>
-              <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($ver); ?>&METHOD=git"
-                 class="btn btn-<?php echo ($branch === 'master') ? 'primary' : 'default'; ?> btn-sm"
-                 onclick="return confirm('<?php echo htmlspecialchars($branch, ENT_QUOTES); ?> ブランチに切り替えます。よろしいですか？');">更新</a>
-            </dd>
-<?php   endforeach; ?>
-          </dl>
-        </div>
-      </div>
-    </div>
-<?php endif; ?>
-
-    <!-- タグ一覧 -->
-<?php if (count($git_taglist) === 0): ?>
-    <div class="alert alert-info">タグが見つかりませんでした</div>
-<?php else: ?>
-    <h5><strong>タグ（リリース版）</strong></h5>
-    <dl class="dl-horizontal">
-<?php   foreach (array_reverse($git_taglist) as $tag):
-          if (strcmp($tag, 'v0.09.5-alpha') === 0): ?>
-      <dt><?php echo htmlspecialchars($tag); ?></dt>
-      <dd>これ以前のバージョンはコマンドプロンプトでのコマンド実行が必要です</dd>
-<?php       break; endif; ?>
-      <dt><?php echo htmlspecialchars($tag); ?></dt>
-      <dd>
-        <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($tag); ?>&METHOD=git"
-           class="btn btn-default btn-sm"
-           onclick="return confirm('<?php echo htmlspecialchars($tag, ENT_QUOTES); ?> に更新します。よろしいですか？');">更新</a>
-      </dd>
-<?php   endforeach; ?>
-    </dl>
-<?php endif; // git_taglist ?>
-
-    <div class="panel panel-default" style="margin-top:10px;">
-      <div class="panel-body">
-        <form method="GET" class="form-inline">
-          <input type="hidden" name="METHOD" value="git" />
-          <div class="form-group">
-            <label>任意ブランチ / タグ / ハッシュ&nbsp;</label>
-            <input type="text" name="UPDATEVERSION" class="form-control" placeholder="例: origin/my-branch" />
-          </div>
-          &nbsp;<input type="submit" value="実行" class="btn btn-warning" />
-        </form>
-      </div>
-    </div>
-
-<?php endif; // fetch_failed ?>
 <?php endif; // git_repo_exists ?>
 
   </div><!-- /git tab pane -->

--- a/online_update.php
+++ b/online_update.php
@@ -2,13 +2,21 @@
 require_once 'commonfunc.php';
 print_meta_header();
 
-$res    = 2;    // 2=何もしていない, true=成功, false=失敗
+$res    = 2;   // 2=何もしていない, true=成功, false=失敗
 $errmsg = '';
 
-$req_version = array_key_exists('UPDATEVERSION', $_REQUEST) ? urldecode($_REQUEST['UPDATEVERSION']) : null;
-$req_method  = (array_key_exists('METHOD', $_REQUEST) && $_REQUEST['METHOD'] === 'git') ? 'git' : 'zip';
+$req_version = isset($_REQUEST['UPDATEVERSION']) ? urldecode($_REQUEST['UPDATEVERSION']) : null;
+$req_method  = (isset($_REQUEST['METHOD']) && $_REQUEST['METHOD'] === 'git') ? 'git' : 'zip';
+$req_action  = isset($_REQUEST['ACTION']) ? $_REQUEST['ACTION'] : '';
 
-if ($req_version !== null && $req_version !== '') {
+// アクション処理
+if ($req_action === 'git_gc') {
+    $res = run_git_gc($errmsg, false);
+} elseif ($req_action === 'git_gc_aggressive') {
+    $res = run_git_gc($errmsg, true);
+} elseif ($req_action === 'git_init') {
+    $res = init_git_repo($errmsg);
+} elseif ($req_version !== null && $req_version !== '') {
     if ($req_method === 'git') {
         $res = update_fromgit($req_version, $errmsg);
     } else {
@@ -16,21 +24,23 @@ if ($req_version !== null && $req_version !== '') {
     }
 }
 
-// git が利用可能か判定
-$git_available = false;
+// git 状態判定
+$git_configured  = false;
+$git_available   = false;
+$git_repo_exists = is_dir(realpath(__DIR__) . DIRECTORY_SEPARATOR . '.git');
+
 if (array_key_exists('gitcommandpath', $config_ini)) {
     $gitcmd = urldecode($config_ini['gitcommandpath']);
-    $git_available = file_exists($gitcmd);
+    $git_configured = ($gitcmd !== '');
+    $git_available  = $git_configured && file_exists($gitcmd);
 }
 
 $active_tab = $git_available ? $req_method : 'zip';
 ?>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta http-equiv="Content-Style-Type" content="text/css" />
-
     <!-- Bootstrap -->
     <link href="css/bootstrap.min.css" rel="stylesheet">
-
   <title>オンラインアップデート</title>
   <link type="text/css" rel="stylesheet" href="css/style.css" />
   <script type="text/javascript" charset="utf8" src="js/jquery.js"></script>
@@ -43,11 +53,16 @@ $active_tab = $git_available ? $req_method : 'zip';
   <h3>オンラインアップデート</h3>
 
 <?php
-// 更新結果表示
+// 実行結果表示
 if ($res === false) {
     echo '<div class="alert alert-danger">' . htmlspecialchars($errmsg) . '</div>';
 } elseif ($res === true) {
-    echo '<div class="alert alert-success">アップデートに成功しました</div>';
+    $action_label = match($req_action) {
+        'git_gc', 'git_gc_aggressive' => 'リポジトリの最適化',
+        'git_init'                    => 'Git リポジトリの初期化',
+        default                       => 'アップデート',
+    };
+    echo '<div class="alert alert-success">' . htmlspecialchars($action_label) . 'に成功しました</div>';
 }
 
 // 現在バージョン表示
@@ -58,7 +73,7 @@ if (!empty($curver)) {
 ?>
 
 <?php if ($git_available): ?>
-<!-- タブ（git が設定されている場合のみ表示） -->
+<!-- タブ（git が設定されている場合のみ） -->
 <ul class="nav nav-tabs" id="updateTabs">
   <li role="presentation" <?php if ($active_tab === 'zip') echo 'class="active"'; ?>>
     <a href="#tab-zip" data-toggle="tab">ZIP方式（推奨）</a>
@@ -72,11 +87,10 @@ if (!empty($curver)) {
   <!-- ZIP 方式タブ -->
   <div role="tabpanel" class="tab-pane <?php echo ($active_tab === 'zip') ? 'active' : ''; ?>" id="tab-zip">
 <?php else: ?>
-<!-- git 未設定: ZIP方式のみ -->
-<div>
-  <div>
+<div><div>
 <?php endif; ?>
 
+<?php /* ========== ZIP 方式コンテンツ ========== */ ?>
 <?php
 $zip_check = check_zip_update_available();
 if ($zip_check !== true):
@@ -85,7 +99,7 @@ if ($zip_check !== true):
       ZIP方式は現在利用できません: <?php echo htmlspecialchars($zip_check); ?>
     </div>
 <?php else:
-    $zip_errmsg = '';
+    $zip_errmsg  = '';
     $zip_taglist = get_archive_taglist($zip_errmsg);
     if (!empty($zip_errmsg)):
 ?>
@@ -104,8 +118,7 @@ if ($zip_check !== true):
           if (strcmp($tag, 'v0.09.5-alpha') === 0): ?>
       <dt><?php echo htmlspecialchars($tag); ?></dt>
       <dd>これ以前のバージョンはコマンドプロンプトでのコマンド実行が必要です</dd>
-<?php       break;
-          endif; ?>
+<?php       break; endif; ?>
       <dt><?php echo htmlspecialchars($tag); ?></dt>
       <dd>
         <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($tag); ?>&METHOD=zip"
@@ -120,11 +133,11 @@ if ($zip_check !== true):
         <form method="GET" class="form-inline">
           <input type="hidden" name="METHOD" value="zip" />
           <div class="form-group">
-            <label>任意タグ/コミットハッシュ&nbsp;</label>
+            <label>任意タグ / コミットハッシュ&nbsp;</label>
             <input type="text" name="UPDATEVERSION" class="form-control" placeholder="例: v0.09.9-alpha" />
           </div>
           &nbsp;<input type="submit" value="実行" class="btn btn-warning"
-                        onclick="return confirm('指定バージョンで更新します。よろしいですか？');" />
+                       onclick="return confirm('指定バージョンで更新します。よろしいですか？');" />
         </form>
       </div>
     </div>
@@ -132,13 +145,54 @@ if ($zip_check !== true):
 
   </div><!-- /zip tab pane -->
 
-<?php if ($git_available): ?>
+<?php if ($git_available): /* ========== Git 方式タブ ========== */ ?>
 
-  <!-- Git 方式タブ -->
   <div role="tabpanel" class="tab-pane <?php echo ($active_tab === 'git') ? 'active' : ''; ?>" id="tab-git">
-    <div class="alert alert-info">
+
+<?php if (!$git_repo_exists): ?>
+    <!-- .git フォルダなし → 初期化案内 -->
+    <div class="panel panel-warning">
+      <div class="panel-heading"><strong>.git フォルダが見つかりません</strong></div>
+      <div class="panel-body">
+        <p>Git 方式でアップデートするには、まずリポジトリを初期化してください。<br>
+           <small class="text-muted">初期化後は <code>.git</code> フォルダが作成されます（数 MB、shallow clone）。</small></p>
+        <a href="online_update.php?ACTION=git_init&METHOD=git"
+           class="btn btn-warning"
+           onclick="return confirm('リポジトリを初期化します（git init + fetch --depth=1 + reset --hard）。\nconfig.ini・request.db などのユーザーデータは保護されます。よろしいですか？');">
+          Git リポジトリを初期化する
+        </a>
+      </div>
+    </div>
+<?php else: ?>
+    <!-- .git サイズ表示 + 最適化ボタン -->
+<?php
+    $git_size = get_git_dir_size();
+    $git_size_str = $git_size !== null ? format_filesize($git_size) : '取得失敗';
+?>
+    <div class="panel panel-default">
+      <div class="panel-heading"><strong>リポジトリ最適化</strong></div>
+      <div class="panel-body">
+        <p><strong>.git フォルダ サイズ:</strong> <?php echo htmlspecialchars($git_size_str); ?>
+           &nbsp;<small class="text-muted">（アップデート後に <code>git gc</code> を実行すると削減できます）</small></p>
+        <a href="online_update.php?ACTION=git_gc&METHOD=git"
+           class="btn btn-default btn-sm"
+           onclick="return confirm('git gc --prune=all を実行します。通常数十秒かかります。よろしいですか？');">
+          最適化（git gc）
+        </a>
+        &nbsp;
+        <a href="online_update.php?ACTION=git_gc_aggressive&METHOD=git"
+           class="btn btn-default btn-sm"
+           onclick="return confirm('git gc --aggressive --prune=all を実行します。通常数分かかります。よろしいですか？');">
+          徹底最適化（--aggressive）
+        </a>
+        <p class="text-muted" style="margin-top:8px; margin-bottom:0;">
+          <small>通常最適化で大半の不要データを除去できます。徹底最適化はより小さくなりますが時間がかかります。</small>
+        </p>
+      </div>
+    </div>
+
+    <div class="alert alert-info" style="margin-top:0;">
       Git 方式: <code>git fetch</code> + <code>git reset --hard</code> でアップデートします。
-      <code>.git</code> フォルダを保持するためディスク容量が多くなります。
     </div>
 <?php
     $git_errmsg  = '';
@@ -160,8 +214,7 @@ if ($zip_check !== true):
           if (strcmp($tag, 'v0.09.5-alpha') === 0): ?>
       <dt><?php echo htmlspecialchars($tag); ?></dt>
       <dd>これ以前のバージョンはコマンドプロンプトでのコマンド実行が必要です</dd>
-<?php       break;
-          endif; ?>
+<?php       break; endif; ?>
       <dt><?php echo htmlspecialchars($tag); ?></dt>
       <dd>
         <a href="online_update.php?UPDATEVERSION=<?php echo urlencode($tag); ?>&METHOD=git"
@@ -183,13 +236,95 @@ if ($zip_check !== true):
         </form>
       </div>
     </div>
-<?php endif; ?>
+<?php endif; // git_taglist ?>
+<?php endif; // git_repo_exists ?>
+
   </div><!-- /git tab pane -->
 
 </div><!-- /tab-content -->
-<?php else: ?>
-  </div>
+
+<?php else: /* git_available が false → ZIP のみ表示 + セットアップ案内 */
+    echo '</div></div>';
+?>
+
+<!-- ============================================================ -->
+<!-- Git 方式を有効にする手順（git 未設定時に表示）              -->
+<!-- ============================================================ -->
+<div class="panel-group" id="gitSetupAccordion" style="margin-top:20px;">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h4 class="panel-title">
+        <a data-toggle="collapse" data-parent="#gitSetupAccordion" href="#collapseGitSetup">
+          Git 方式を有効にする手順（任意）
+        </a>
+      </h4>
+    </div>
+    <div id="collapseGitSetup" class="panel-collapse collapse">
+      <div class="panel-body">
+
+        <div class="alert alert-info">
+          Git 方式を使うと過去の任意バージョンへの巻き戻しが可能になります。
+          ただし <code>.git</code> フォルダのぶんディスクを多く使います（初期数 MB、以後増加）。
+          通常は ZIP 方式で十分です。
+        </div>
+
+        <!-- Step 1 -->
+        <h4>Step 1 &mdash; Portable Git を配置する</h4>
+        <ol>
+          <li>
+            <a href="https://git-scm.com/download/win" target="_blank">git-scm.com</a> から
+            <strong>Portable ("thumbdrive edition")</strong> 版をダウンロードします。
+          </li>
+          <li>
+            ダウンロードした EXE を実行し、アプリフォルダ直下の <code>gitcmd</code> フォルダへ展開します。<br>
+            <code>（例: C:\xampp\htdocs\gitcmd\）</code>
+          </li>
+          <li>
+            展開後に <code>gitcmd\cmd\git.exe</code> が存在することを確認します。
+          </li>
+        </ol>
+
+        <!-- Step 2 -->
+        <h4>Step 2 &mdash; 管理画面でパスを設定する</h4>
+        <ol>
+          <li><a href="init.php" target="_blank">管理画面 (init.php)</a> を開きます。</li>
+          <li>
+            <strong>gitcommandpath</strong> の項目に <code>git.exe</code> の絶対パスを入力して保存します。<br>
+            <code>（例: C:\xampp\htdocs\gitcmd\cmd\git.exe）</code>
+          </li>
+          <li>このページをリロードすると「Git 方式」タブが追加されます。</li>
+        </ol>
+
+<?php if ($git_configured && !$git_available): ?>
+        <div class="alert alert-warning">
+          <strong>注意:</strong> <code>gitcommandpath</code> は設定されていますが、
+          ファイルが見つかりません。パスを確認してください。<br>
+          設定値: <code><?php echo htmlspecialchars(urldecode($config_ini['gitcommandpath'])); ?></code>
+        </div>
 <?php endif; ?>
+
+<?php if ($git_configured && $git_available && !$git_repo_exists): ?>
+        <!-- git コマンドは使えるが .git がない → 初期化ボタンを表示 -->
+        <h4>Step 3 &mdash; リポジトリを初期化する</h4>
+        <p>git コマンドが利用可能です。下のボタンでリポジトリを初期化できます。</p>
+        <a href="online_update.php?ACTION=git_init&METHOD=git"
+           class="btn btn-warning"
+           onclick="return confirm('リポジトリを初期化します（git init + fetch --depth=1）。\nconfig.ini・request.db などのユーザーデータは保護されます。よろしいですか？');">
+          Git リポジトリを初期化する
+        </a>
+<?php else: ?>
+        <!-- Step 3 (generic) -->
+        <h4>Step 3 &mdash; リポジトリを初期化する</h4>
+        <p>Step 2 完了後にこのページをリロードすると、「Git リポジトリを初期化する」ボタンが表示されます。
+           ボタンを押すと <code>git init + fetch --depth=1</code> が自動実行されます。</p>
+<?php endif; ?>
+
+      </div><!-- /panel-body -->
+    </div><!-- /collapse -->
+  </div><!-- /panel -->
+</div><!-- /accordion -->
+
+<?php endif; // git_available ?>
 
 <hr/>
 <p class="text-muted small">

--- a/online_update.php
+++ b/online_update.php
@@ -71,8 +71,10 @@ if ($res === false) {
 
 $curver = get_version();
 if (!empty($curver)) {
-    echo '<p class="text-muted"><small>現在のバージョン: <strong>' . htmlspecialchars($curver) . '</strong></small></p>';
+    echo '<p class="text-muted mb-1"><small>現在のバージョン: <strong>' . htmlspecialchars($curver) . '</strong></small></p>';
 }
+echo '<p class="text-muted"><small>取得元リポジトリ: <code>' . htmlspecialchars(get_update_repo()) . '</code>'
+   . ' <span class="text-muted">（config.ini の <code>update_repo</code> で変更可能）</span></small></p>';
 ?>
 
 <?php if ($git_available): ?>
@@ -410,7 +412,7 @@ if ($zip_check !== true):
 <hr class="mt-4"/>
 <p class="text-muted small">
   バージョン情報:
-  <a href="https://github.com/bee7813993/KaraokeRequestorWeb/commits/master" target="_blank">
+  <a href="https://github.com/<?php echo htmlspecialchars(get_update_repo(), ENT_QUOTES); ?>/commits/master" target="_blank">
     GitHub コミット履歴
   </a>
 </p>


### PR DESCRIPTION
## 概要

オンラインアップデート（`online_update.php`）に **ZIPアーカイブ方式** を追加し、Git方式の機能を強化したうえで画面を **Bootstrap 5** 化しました。`.git` フォルダによるディスク容量増加への懸念が出発点です。

## 主な変更

### 1. ZIPアーカイブ方式（新規）
- GitHubのアーカイブZIPをPHPのみでDL・展開・上書き。`.git` も git インストールも不要で容量最小
- `config.ini`・DBファイル・`images/bg/` はユーザーデータとして上書き保護
- タグ・ブランチ・コミットハッシュのいずれも指定可能（`archive/<ref>.zip` 形式）

### 2. Git方式の強化
- ブランチ一覧表示（`git for-each-ref` で新しい順・master先頭、git 1.x互換）
- 現在のブランチ表示 + そのまま最新化ボタン
- `git gc` / `--aggressive` によるリポジトリ容量削減ボタンと `.git` サイズ表示
- `.git` 未作成時の初期化ボタン（shallow clone + `fetch --tags`）
- git バージョン表示
- 削除済みブランチを `fetch --prune` で除去

### 3. 取得元リポジトリの設定化
- リポジトリURLのハードコードを廃止し `config.ini` の `update_repo`（owner/repo形式）で一元管理
- 開発移譲や取得元が操作不能になった場合に、設定変更だけで別リポジトリへ追従可能

### 4. UI
- `online_update.php` を Bootstrap 5 に移行（card / table / accordion / BS5タブ）
- ダークモード対応（プロジェクトのテーマ変数 `--color-text` を使用）
- ボタン文言の整理（更新 / 反映 / 切替 / 実行）
- git未設定時は ZIP方式のみ表示＋Portable Gitセットアップ手順を案内

## テスト
- 全変更ファイルで `php -l` による構文チェック実施
- ZIP方式・Git方式の各操作をユーザー環境で動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtfAeuJe4cqWkxxWnFPuUk)_