### PR TITLE
feat: toolinfo.php を BS5化し WiFi接続情報と GD不要 QRコード表示を追加

### DIFF
--- a/init.php
+++ b/init.php
@@ -1875,36 +1875,49 @@ if(array_key_exists("useeasyauth_word",$config_ini)) {
 
 <div class="card cfg-card mb-4"><div class="card-body">
   <h1 id="myiplist" class="menulink"> 自IP一覧 </h1>
-  <pre>
   <?php
   require_once("ipconfig.php");
-  $result_ipconfig=getiplist();
-  
-  //var_dump($result_ipconfig);
-  foreach($result_ipconfig as $ifinfo){
-     $count= 0;
-     foreach($ifinfo as $ips){
-        if($count != 0){
-        if(strchr($ips,':') !== false){
-          $ips = '['.strchr($ips,'%',$before_needle=true).']';
-        }
-        if(!empty($ips)){
-           $link = 'http://'.$ips.'/';
-           if(array_key_exists('useeasyauth_word', $config_ini)){
-               if(!empty($config_ini['useeasyauth_word'])){
-                  $link = $link.'?easypass='.$config_ini['useeasyauth_word'];
-               }
-           }
-           print '<a href='.$link.' > '.$link.'</a><br />';
-        }
-        }
-        $count ++;
-     }
-     
+  $result_ipconfig = getiplist();
+  $init_v4 = []; $init_v6 = []; $init_seen = [];
+  foreach ($result_ipconfig as $ifinfo) {
+      foreach ($ifinfo as $idx => $ip_str) {
+          if ($idx === 0) continue;
+          $ip = trim($ip_str);
+          if (empty($ip)) continue;
+          if (strpos($ip, '%') !== false) $ip = substr($ip, 0, strpos($ip, '%'));
+          if ($ip === '127.0.0.1' || $ip === '::1') continue;
+          if (in_array($ip, $init_seen, true)) continue;
+          $init_seen[] = $ip;
+          $is_ipv6 = (strpos($ip, ':') !== false);
+          $url_ip  = $is_ipv6 ? '[' . $ip . ']' : $ip;
+          $link    = 'http://' . $url_ip . '/';
+          if (!empty($config_ini['useeasyauth_word'])) {
+              $link .= '?easypass=' . urlencode($config_ini['useeasyauth_word']);
+          }
+          if ($is_ipv6) { $init_v6[] = $link; } else { $init_v4[] = $link; }
+      }
   }
-  
   ?>
-  </pre>
+  <div style="font-family:monospace; font-size:0.875rem; word-break:break-all; margin-bottom:.5rem">
+    <?php foreach ($init_v4 as $link): ?>
+    <a href="<?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?></a><br>
+    <?php endforeach; ?>
+  </div>
+  <?php if (!empty($init_v6)): ?>
+  <div class="mb-2">
+    <button class="btn btn-sm btn-outline-secondary" type="button"
+            data-bs-toggle="collapse" data-bs-target="#init-ipv6-list">
+      IPv6アドレスを表示 (<?= count($init_v6) ?>件)
+    </button>
+    <div class="collapse mt-1" id="init-ipv6-list">
+      <div style="font-family:monospace; font-size:0.875rem; word-break:break-all">
+        <?php foreach ($init_v6 as $link): ?>
+        <a href="<?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?></a><br>
+        <?php endforeach; ?>
+      </div>
+    </div>
+  </div>
+  <?php endif; ?>
 
   </div></div>
 </div><!-- col-lg-9 -->

--- a/init.php
+++ b/init.php
@@ -1876,48 +1876,9 @@ if(array_key_exists("useeasyauth_word",$config_ini)) {
 <div class="card cfg-card mb-4"><div class="card-body">
   <h1 id="myiplist" class="menulink"> 自IP一覧 </h1>
   <?php
-  require_once("ipconfig.php");
-  $result_ipconfig = getiplist();
-  $init_v4 = []; $init_v6 = []; $init_seen = [];
-  foreach ($result_ipconfig as $ifinfo) {
-      foreach ($ifinfo as $idx => $ip_str) {
-          if ($idx === 0) continue;
-          $ip = trim($ip_str);
-          if (empty($ip)) continue;
-          if (strpos($ip, '%') !== false) $ip = substr($ip, 0, strpos($ip, '%'));
-          if ($ip === '127.0.0.1' || $ip === '::1') continue;
-          if (in_array($ip, $init_seen, true)) continue;
-          $init_seen[] = $ip;
-          $is_ipv6 = (strpos($ip, ':') !== false);
-          $url_ip  = $is_ipv6 ? '[' . $ip . ']' : $ip;
-          $link    = 'http://' . $url_ip . '/';
-          if (!empty($config_ini['useeasyauth_word'])) {
-              $link .= '?easypass=' . urlencode($config_ini['useeasyauth_word']);
-          }
-          if ($is_ipv6) { $init_v6[] = $link; } else { $init_v4[] = $link; }
-      }
-  }
+  require_once 'ipconfig.php';
+  print_iplist($config_ini, 'init-ipv6-list');
   ?>
-  <div style="font-family:monospace; font-size:0.875rem; word-break:break-all; margin-bottom:.5rem">
-    <?php foreach ($init_v4 as $link): ?>
-    <a href="<?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?></a><br>
-    <?php endforeach; ?>
-  </div>
-  <?php if (!empty($init_v6)): ?>
-  <div class="mb-2">
-    <button class="btn btn-sm btn-outline-secondary" type="button"
-            data-bs-toggle="collapse" data-bs-target="#init-ipv6-list">
-      IPv6アドレスを表示 (<?= count($init_v6) ?>件)
-    </button>
-    <div class="collapse mt-1" id="init-ipv6-list">
-      <div style="font-family:monospace; font-size:0.875rem; word-break:break-all">
-        <?php foreach ($init_v6 as $link): ?>
-        <a href="<?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?></a><br>
-        <?php endforeach; ?>
-      </div>
-    </div>
-  </div>
-  <?php endif; ?>
 
   </div></div>
 </div><!-- col-lg-9 -->

--- a/ipconfig.php
+++ b/ipconfig.php
@@ -49,6 +49,69 @@ function getiplist() {
   // var_dump($iplist);
   return $iplist;
 }
-  
+
+/**
+ * ipconfig の結果からURLリストを生成する。
+ * ループバック・重複・ゾーンIDを除去し IPv4/IPv6 に分類して返す。
+ *
+ * @param array $config_ini  useeasyauth_word を参照してURLにeasypassを付与する
+ * @return array{v4: string[], v6: string[]}
+ */
+function getiplinks(array $config_ini): array {
+    $result = getiplist();
+    $v4 = []; $v6 = []; $seen = [];
+    foreach ($result as $ifinfo) {
+        foreach ($ifinfo as $idx => $ip_str) {
+            if ($idx === 0) continue;
+            $ip = trim($ip_str);
+            if (empty($ip)) continue;
+            if (strpos($ip, '%') !== false) $ip = substr($ip, 0, strpos($ip, '%'));
+            if ($ip === '127.0.0.1' || $ip === '::1') continue;
+            if (in_array($ip, $seen, true)) continue;
+            $seen[] = $ip;
+            $is_ipv6 = (strpos($ip, ':') !== false);
+            $url_ip  = $is_ipv6 ? '[' . $ip . ']' : $ip;
+            $link    = 'http://' . $url_ip . '/';
+            if (!empty($config_ini['useeasyauth_word'])) {
+                $link .= '?easypass=' . urlencode($config_ini['useeasyauth_word']);
+            }
+            if ($is_ipv6) { $v6[] = $link; } else { $v4[] = $link; }
+        }
+    }
+    return ['v4' => $v4, 'v6' => $v6];
+}
+
+/**
+ * 自IP一覧をBootstrap 5スタイルで出力する。
+ * IPv4は常時表示、IPv6は折りたたみ（初期: 非表示）。
+ *
+ * @param array  $config_ini   getiplinks() に渡す設定
+ * @param string $collapse_id  IPv6折りたたみ要素のid（ページ内重複しないよう指定）
+ */
+function print_iplist(array $config_ini, string $collapse_id = 'ipv6-list'): void {
+    $ips = getiplinks($config_ini);
+    $cid = htmlspecialchars($collapse_id, ENT_QUOTES, 'UTF-8');
+    echo '<div style="font-family:monospace; font-size:0.875rem; word-break:break-all">' . "\n";
+    foreach ($ips['v4'] as $link) {
+        $h = htmlspecialchars($link, ENT_QUOTES, 'UTF-8');
+        echo '<a href="' . $h . '">' . $h . '</a><br>' . "\n";
+    }
+    echo '</div>' . "\n";
+    if (!empty($ips['v6'])) {
+        echo '<div class="mt-2">' . "\n";
+        echo '<button class="btn btn-sm btn-outline-secondary" type="button"'
+           . ' data-bs-toggle="collapse" data-bs-target="#' . $cid . '">'
+           . 'IPv6アドレスを表示 (' . count($ips['v6']) . '件)'
+           . '</button>' . "\n";
+        echo '<div class="collapse mt-1" id="' . $cid . '">' . "\n";
+        echo '<div style="font-family:monospace; font-size:0.875rem; word-break:break-all">' . "\n";
+        foreach ($ips['v6'] as $link) {
+            $h = htmlspecialchars($link, ENT_QUOTES, 'UTF-8');
+            echo '<a href="' . $h . '">' . $h . '</a><br>' . "\n";
+        }
+        echo '</div></div></div>' . "\n";
+    }
+}
+
 ?>
 

--- a/pfwd_settings.php
+++ b/pfwd_settings.php
@@ -512,50 +512,49 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
   <div class="card mb-3">
     <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">自IP一覧</div>
     <div class="card-body">
-      <div style="font-family: monospace; white-space: pre-wrap; word-break: break-all; font-size: 0.875rem;"><?php
+      <?php
       require_once 'ipconfig.php';
       $result_ipconfig = getiplist();
-      $ips_to_show = array(); // 重複排除用
-
-      // すべてのインターフェースからIPを抽出（ループバック除外）
+      $pfwd_v4 = []; $pfwd_v6 = []; $pfwd_seen = [];
       foreach ($result_ipconfig as $ifinfo) {
           foreach ($ifinfo as $idx => $ip_str) {
-              if ($idx === 0) continue; // インターフェース名をスキップ
+              if ($idx === 0) continue;
               $ip = trim($ip_str);
               if (empty($ip)) continue;
-
-              // IPv6 zone ID を削除
-              if (strpos($ip, '%') !== false) {
-                  $ip = substr($ip, 0, strpos($ip, '%'));
+              if (strpos($ip, '%') !== false) $ip = substr($ip, 0, strpos($ip, '%'));
+              if ($ip === '127.0.0.1' || $ip === '::1') continue;
+              if (in_array($ip, $pfwd_seen, true)) continue;
+              $pfwd_seen[] = $ip;
+              $is_ipv6 = (strpos($ip, ':') !== false);
+              $url_ip  = $is_ipv6 ? '[' . $ip . ']' : $ip;
+              $link    = 'http://' . $url_ip . '/';
+              if (!empty($config_ini['useeasyauth_word'])) {
+                  $link .= '?easypass=' . urlencode($config_ini['useeasyauth_word']);
               }
-
-              // ループバック判定
-              if ($ip === '127.0.0.1' || $ip === '::1') {
-                  continue;
-              }
-
-              // 重複排除
-              if (in_array($ip, $ips_to_show, true)) {
-                  continue;
-              }
-
-              $ips_to_show[] = $ip;
+              if ($is_ipv6) { $pfwd_v6[] = $link; } else { $pfwd_v4[] = $link; }
           }
       }
-
-      // リンク生成（バッファに集める）
-      $link_output = '';
-      foreach ($ips_to_show as $ip) {
-          $is_ipv6 = (strpos($ip, ':') !== false);
-          $url_ip = $is_ipv6 ? '[' . $ip . ']' : $ip;
-          $link = 'http://' . $url_ip . '/';
-          if (array_key_exists('useeasyauth_word', $config_ini) && !empty($config_ini['useeasyauth_word'])) {
-              $link = $link . '?easypass=' . $config_ini['useeasyauth_word'];
-          }
-          $link_output .= '<a href="' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '" target="_blank">' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '</a>' . "\n";
-      }
-      echo $link_output;
-      ?></div>
+      ?>
+      <div style="font-family:monospace; font-size:0.875rem; word-break:break-all">
+        <?php foreach ($pfwd_v4 as $link): ?>
+        <a href="<?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?>" target="_blank"><?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?></a><br>
+        <?php endforeach; ?>
+      </div>
+      <?php if (!empty($pfwd_v6)): ?>
+      <div class="mt-2">
+        <button class="btn btn-sm btn-outline-secondary" type="button"
+                data-bs-toggle="collapse" data-bs-target="#pfwd-ipv6-list">
+          IPv6アドレスを表示 (<?= count($pfwd_v6) ?>件)
+        </button>
+        <div class="collapse mt-1" id="pfwd-ipv6-list">
+          <div style="font-family:monospace; font-size:0.875rem; word-break:break-all">
+            <?php foreach ($pfwd_v6 as $link): ?>
+            <a href="<?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?>" target="_blank"><?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?></a><br>
+            <?php endforeach; ?>
+          </div>
+        </div>
+      </div>
+      <?php endif; ?>
     </div>
   </div>
 

--- a/pfwd_settings.php
+++ b/pfwd_settings.php
@@ -512,49 +512,7 @@ $local_ip_for_ddns = get_first_non_loopback_ip();
   <div class="card mb-3">
     <div class="card-header fw-semibold py-2 px-3" style="font-size:1rem;">自IP一覧</div>
     <div class="card-body">
-      <?php
-      require_once 'ipconfig.php';
-      $result_ipconfig = getiplist();
-      $pfwd_v4 = []; $pfwd_v6 = []; $pfwd_seen = [];
-      foreach ($result_ipconfig as $ifinfo) {
-          foreach ($ifinfo as $idx => $ip_str) {
-              if ($idx === 0) continue;
-              $ip = trim($ip_str);
-              if (empty($ip)) continue;
-              if (strpos($ip, '%') !== false) $ip = substr($ip, 0, strpos($ip, '%'));
-              if ($ip === '127.0.0.1' || $ip === '::1') continue;
-              if (in_array($ip, $pfwd_seen, true)) continue;
-              $pfwd_seen[] = $ip;
-              $is_ipv6 = (strpos($ip, ':') !== false);
-              $url_ip  = $is_ipv6 ? '[' . $ip . ']' : $ip;
-              $link    = 'http://' . $url_ip . '/';
-              if (!empty($config_ini['useeasyauth_word'])) {
-                  $link .= '?easypass=' . urlencode($config_ini['useeasyauth_word']);
-              }
-              if ($is_ipv6) { $pfwd_v6[] = $link; } else { $pfwd_v4[] = $link; }
-          }
-      }
-      ?>
-      <div style="font-family:monospace; font-size:0.875rem; word-break:break-all">
-        <?php foreach ($pfwd_v4 as $link): ?>
-        <a href="<?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?>" target="_blank"><?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?></a><br>
-        <?php endforeach; ?>
-      </div>
-      <?php if (!empty($pfwd_v6)): ?>
-      <div class="mt-2">
-        <button class="btn btn-sm btn-outline-secondary" type="button"
-                data-bs-toggle="collapse" data-bs-target="#pfwd-ipv6-list">
-          IPv6アドレスを表示 (<?= count($pfwd_v6) ?>件)
-        </button>
-        <div class="collapse mt-1" id="pfwd-ipv6-list">
-          <div style="font-family:monospace; font-size:0.875rem; word-break:break-all">
-            <?php foreach ($pfwd_v6 as $link): ?>
-            <a href="<?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?>" target="_blank"><?= htmlspecialchars($link, ENT_QUOTES, 'UTF-8') ?></a><br>
-            <?php endforeach; ?>
-          </div>
-        </div>
-      </div>
-      <?php endif; ?>
+      <?php print_iplist($config_ini, 'pfwd-ipv6-list'); ?>
     </div>
   </div>
 

--- a/qrcode_php/outputqrsvg.php
+++ b/qrcode_php/outputqrsvg.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * QRコードをSVGで出力する。GD拡張なしで動作する。
+ * パラメータ: data (URLエンコード済み文字列), qrsize (1-16, モジュールpx)
+ */
+require_once "./qrcode.php";
+
+if (!array_key_exists("data", $_REQUEST)) {
+    header("Content-type: image/svg+xml");
+    echo '<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="white"/></svg>';
+    exit;
+}
+
+$l_data = $_REQUEST["data"];
+$l_qrsize = 5;
+if (array_key_exists("qrsize", $_REQUEST)) {
+    $sz = (int)$_REQUEST["qrsize"];
+    if ($sz >= 1 && $sz <= 16) {
+        $l_qrsize = $sz;
+    }
+}
+
+$qr  = new Qrcode();
+$raw = $qr->cal_qrcode($l_data);
+
+$rows = explode("\n", $raw);
+while (!empty($rows) && end($rows) === '') {
+    array_pop($rows);
+}
+$n     = count($rows);
+$quiet = 4;
+$cell  = $l_qrsize;
+$total = ($n + $quiet * 2) * $cell;
+
+header("Content-type: image/svg+xml");
+echo '<?xml version="1.0" encoding="UTF-8"?>';
+echo '<svg xmlns="http://www.w3.org/2000/svg"'
+    . ' width="' . $total . '" height="' . $total . '"'
+    . ' viewBox="0 0 ' . $total . ' ' . $total . '">';
+echo '<rect width="100%" height="100%" fill="white"/>';
+
+foreach ($rows as $y => $row) {
+    $row_len = strlen($row);
+    for ($x = 0; $x < $row_len; $x++) {
+        if ($row[$x] === '1') {
+            $px = ($x + $quiet) * $cell;
+            $py = ($y + $quiet) * $cell;
+            echo '<rect x="' . $px . '" y="' . $py
+                . '" width="' . $cell . '" height="' . $cell . '" fill="black"/>';
+        }
+    }
+}
+echo '</svg>';

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -184,6 +184,22 @@ function qr_img(string $data, int $size): string {
         <div id="localUrlBody" class="collapse <?= !$online_available ? 'show' : '' ?>">
         <div class="card-body">
           <?php if ($has_local_url): ?>
+            <!-- QRコード（上部） -->
+            <div class="d-flex justify-content-center gap-4 mb-3">
+              <?php if ($localname_valid): ?>
+                <div class="text-center">
+                  <div class="qr-wrap"><?= qr_img($localhosturl, $l_qrsize) ?></div>
+                  <div class="small text-muted mt-1">ホスト名</div>
+                </div>
+              <?php endif; ?>
+              <?php if ($localip_valid): ?>
+                <div class="text-center">
+                  <div class="qr-wrap"><?= qr_img($localipurl, $l_qrsize) ?></div>
+                  <div class="small text-muted mt-1">IPアドレス</div>
+                </div>
+              <?php endif; ?>
+            </div>
+            <!-- URLコピー（下部） -->
             <?php if ($localname_valid): ?>
               <p class="fw-bold small mb-1">ホスト名</p>
               <div class="input-group input-group-sm mb-2">
@@ -194,12 +210,8 @@ function qr_img(string $data, int $size): string {
                   コピー
                 </button>
               </div>
-              <div class="text-center <?= $localip_valid ? 'mb-3' : '' ?>">
-                <div class="qr-wrap mx-auto"><?= qr_img($localhosturl, $l_qrsize) ?></div>
-              </div>
             <?php endif; ?>
             <?php if ($localip_valid): ?>
-              <?php if ($localname_valid): ?><hr class="my-2"><?php endif; ?>
               <p class="fw-bold small mb-1">IPアドレス</p>
               <div class="input-group input-group-sm mb-2">
                 <input type="text" class="form-control url-display"
@@ -208,9 +220,6 @@ function qr_img(string $data, int $size): string {
                         onclick="navigator.clipboard.writeText(<?= json_encode($localipurl) ?>);this.textContent='✓'">
                   コピー
                 </button>
-              </div>
-              <div class="text-center">
-                <div class="qr-wrap mx-auto"><?= qr_img($localipurl, $l_qrsize) ?></div>
               </div>
             <?php endif; ?>
           <?php else: ?>
@@ -229,7 +238,22 @@ function qr_img(string $data, int $size): string {
       <div class="card">
         <div class="card-header fw-bold">WiFi接続情報</div>
         <div class="card-body">
-          <form method="GET" class="mb-3">
+          <!-- QRコード（上部） -->
+          <?php if (!empty($wifi_ssid)): ?>
+            <div class="text-center mb-3">
+              <div class="qr-wrap mx-auto"><?= qr_img($wifi_qr_data, $l_qrsize) ?></div>
+              <p class="small text-muted mt-2 mb-0">
+                SSID: <strong><?= htmlspecialchars($wifi_ssid, ENT_QUOTES, 'UTF-8') ?></strong><br>
+                パスワード: <strong><?= htmlspecialchars($wifi_pass, ENT_QUOTES, 'UTF-8') ?></strong>
+              </p>
+              <p class="small text-muted mb-0">カメラで読み取るとWiFiに自動接続できます</p>
+            </div>
+            <hr class="my-3">
+          <?php else: ?>
+            <p class="text-muted small mb-3">SSIDを入力して保存すると、WiFi自動接続用QRコードが表示されます</p>
+          <?php endif; ?>
+          <!-- フォーム（下部） -->
+          <form method="GET">
             <input type="hidden" name="qrsize" value="<?= $l_qrsize ?>">
             <div class="mb-2">
               <label class="form-label small mb-1">WiFi SSID</label>
@@ -245,19 +269,6 @@ function qr_img(string $data, int $size): string {
             </div>
             <button type="submit" class="btn btn-primary btn-sm w-100">保存</button>
           </form>
-          <?php if (!empty($wifi_ssid)): ?>
-            <hr class="my-2">
-            <div class="text-center">
-              <div class="qr-wrap mx-auto"><?= qr_img($wifi_qr_data, $l_qrsize) ?></div>
-              <p class="small text-muted mt-2 mb-0">
-                SSID: <strong><?= htmlspecialchars($wifi_ssid, ENT_QUOTES, 'UTF-8') ?></strong><br>
-                パスワード: <strong><?= htmlspecialchars($wifi_pass, ENT_QUOTES, 'UTF-8') ?></strong>
-              </p>
-              <p class="small text-muted">カメラで読み取るとWiFiに自動接続できます</p>
-            </div>
-          <?php else: ?>
-            <p class="text-muted small mb-0">SSIDを入力して保存すると、WiFi自動接続用QRコードが表示されます</p>
-          <?php endif; ?>
         </div>
       </div>
     </div>

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -85,6 +85,25 @@ function qr_img(string $data, int $size): string {
     return '<img src="' . htmlspecialchars($src, ENT_QUOTES, 'UTF-8') . '"'
          . ' alt="QRコード" class="img-fluid d-block mx-auto" style="max-width:320px">';
 }
+
+// --- URL + QRコードを横並びで表示するブロックHTML ---
+// モバイル: QR上・URL下（縦積み）、md以上: QR左・URL右（横並び）
+function url_card_body(string $label, string $url, int $qrsize): string {
+    $h = htmlspecialchars($url, ENT_QUOTES, 'UTF-8');
+    $j = json_encode($url);
+    $hl = htmlspecialchars($label, ENT_QUOTES, 'UTF-8');
+    return '<div class="d-flex flex-column flex-md-row align-items-md-center gap-3">'
+         . '<div class="flex-shrink-0 text-center"><div class="qr-wrap mx-auto">' . qr_img($url, $qrsize) . '</div></div>'
+         . '<div class="flex-grow-1 w-100">'
+         . '<p class="fw-bold small mb-1">' . $hl . '</p>'
+         . '<div class="input-group input-group-sm">'
+         . '<input type="text" class="form-control url-display" value="' . $h . '" readonly>'
+         . '<button class="btn btn-outline-secondary btn-sm" type="button"'
+         . ' onclick="navigator.clipboard.writeText(' . $j . ');this.textContent=\'✓\'">コピー</button>'
+         . '</div>'
+         . '</div>'
+         . '</div>';
+}
 ?>
 <!DOCTYPE html>
 <html lang="ja">
@@ -145,20 +164,7 @@ $wifi_open   = true;
            aria-labelledby="headingOnline">
         <div class="accordion-body">
           <?php if ($online_available): ?>
-            <p class="text-muted small mb-2">WiFiに接続しなくてもアクセスできるURLです</p>
-            <div class="input-group mb-3">
-              <input type="text" class="form-control url-display"
-                     value="<?= htmlspecialchars($globalurl, ENT_QUOTES, 'UTF-8') ?>" readonly>
-              <button class="btn btn-outline-secondary" type="button"
-                      onclick="navigator.clipboard.writeText(<?= json_encode($globalurl) ?>);this.textContent='コピー済'">
-                コピー
-              </button>
-            </div>
-            <div class="text-center">
-              <div class="qr-wrap mx-auto">
-                <?= qr_img($globalurl, $l_qrsize) ?>
-              </div>
-            </div>
+            <?= url_card_body('オンライン接続URL（WiFiなしでもアクセス可）', $globalurl, $l_qrsize) ?>
           <?php elseif (!empty($globalhost)): ?>
             <p class="text-muted small mb-0">設定されたホスト（<?= htmlspecialchars($globalhost, ENT_QUOTES, 'UTF-8') ?>）に接続できませんでした。</p>
           <?php else: ?>
@@ -188,19 +194,8 @@ $wifi_open   = true;
             <?php if ($localname_valid): ?>
             <div class="col-md-6">
               <div class="card h-100">
-                <div class="card-body text-center">
-                  <p class="fw-bold small mb-2">ホスト名</p>
-                  <div class="input-group input-group-sm mb-2">
-                    <input type="text" class="form-control url-display"
-                           value="<?= htmlspecialchars($localhosturl, ENT_QUOTES, 'UTF-8') ?>" readonly>
-                    <button class="btn btn-outline-secondary btn-sm" type="button"
-                            onclick="navigator.clipboard.writeText(<?= json_encode($localhosturl) ?>);this.textContent='✓'">
-                      コピー
-                    </button>
-                  </div>
-                  <div class="qr-wrap mx-auto">
-                    <?= qr_img($localhosturl, $l_qrsize) ?>
-                  </div>
+                <div class="card-body">
+                  <?= url_card_body('ホスト名', $localhosturl, $l_qrsize) ?>
                 </div>
               </div>
             </div>
@@ -208,19 +203,8 @@ $wifi_open   = true;
             <?php if ($localip_valid): ?>
             <div class="col-md-6">
               <div class="card h-100">
-                <div class="card-body text-center">
-                  <p class="fw-bold small mb-2">IPアドレス</p>
-                  <div class="input-group input-group-sm mb-2">
-                    <input type="text" class="form-control url-display"
-                           value="<?= htmlspecialchars($localipurl, ENT_QUOTES, 'UTF-8') ?>" readonly>
-                    <button class="btn btn-outline-secondary btn-sm" type="button"
-                            onclick="navigator.clipboard.writeText(<?= json_encode($localipurl) ?>);this.textContent='✓'">
-                      コピー
-                    </button>
-                  </div>
-                  <div class="qr-wrap mx-auto">
-                    <?= qr_img($localipurl, $l_qrsize) ?>
-                  </div>
+                <div class="card-body">
+                  <?= url_card_body('IPアドレス', $localipurl, $l_qrsize) ?>
                 </div>
               </div>
             </div>

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -1,258 +1,235 @@
-<html>
-<head>
-<?php 
+<?php
 require_once 'commonfunc.php';
 require_once 'easyauth_class.php';
 $easyauth = new EasyAuth();
-$easyauth -> do_eashauthcheck();
+$easyauth->do_eashauthcheck();
 
-print_meta_header();
+// --- フォーム処理 ---
+$change_counter = 0;
+foreach (['SSID', 'wifipass', 'globalhost'] as $_key) {
+    if (isset($_REQUEST[$_key])) {
+        $config_ini[$_key] = urlencode(trim($_REQUEST[$_key]));
+        $change_counter++;
+    }
+}
+if ($change_counter > 0) {
+    writeconfig2ini($config_ini, $configfile);
+}
+
+// --- QRサイズ ---
+$l_qrsize = 8;
+if (isset($_REQUEST['qrsize'])) {
+    $l_qrsize = max(1, min(16, (int)$_REQUEST['qrsize']));
+}
+
+// --- グローバルURL ---
+$globalhost      = isset($config_ini['globalhost']) ? urldecode($config_ini['globalhost']) : '';
+$online_available = false;
+$globalurl       = '';
+if (!empty($globalhost)) {
+    if (check_online_available($globalhost) === 'OK') {
+        $online_available = true;
+    }
+    $globalurl = 'http://' . $globalhost . '/';
+    if ($config_ini['useeasyauth'] == 1) {
+        $globalurl .= '?easypass=' . urlencode($config_ini['useeasyauth_word']);
+    }
+}
+
+// --- ローカルURL ---
+$server_addr = $_SERVER['SERVER_ADDR'];
+$server_addr_url = (strpos($server_addr, ':') !== false)
+    ? addipv6blanket($server_addr)
+    : $server_addr;
+$localhosturl = 'http://' . $_SERVER['HTTP_HOST'] . '/';
+$localipurl   = 'http://' . $server_addr_url . '/';
+if ($config_ini['useeasyauth'] == 1) {
+    $easypass_q    = '?easypass=' . urlencode($config_ini['useeasyauth_word']);
+    $localhosturl .= $easypass_q;
+    $localipurl   .= $easypass_q;
+}
+
+// --- WiFi情報 ---
+$wifi_ssid = isset($config_ini['SSID'])    ? urldecode($config_ini['SSID'])    : '';
+$wifi_pass = isset($config_ini['wifipass']) ? urldecode($config_ini['wifipass']) : '';
+
+function wifi_qr_escape(string $s): string {
+    return str_replace(
+        ['\\',   ';',   ',',   '"',   ':'],
+        ['\\\\', '\\;', '\\,', '\\"', '\\:'],
+        $s
+    );
+}
+$wifi_qr_data = 'WIFI:T:WPA;S:' . wifi_qr_escape($wifi_ssid)
+              . ';P:'            . wifi_qr_escape($wifi_pass) . ';;';
+
+// --- QR img タグ出力ヘルパー ---
+function qr_img(string $data, int $size): string {
+    $src = 'qrcode_php/outputqrsvg.php?data=' . urlencode($data) . '&qrsize=' . $size;
+    return '<img src="' . htmlspecialchars($src, ENT_QUOTES, 'UTF-8') . '"'
+         . ' alt="QRコード" class="img-fluid d-block mx-auto" style="max-width:320px">';
+}
 ?>
-
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta http-equiv="Content-Script-Type" content="text/javascript" />
-
-    <!-- Bootstrap -->
-    <link href="css/bootstrap.min.css" rel="stylesheet">
-
-
-    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
-
-  <script type="text/javascript">
-
-    // ここに処理を記述します。
-  </script>
-  <title>検索予約ツール接続情報</title>
-  <link type="text/css" rel="stylesheet" href="css/style.css" />
-  <script type="text/javascript" charset="utf8" src="js/jquery.js"></script>
-  <script src="js/bootstrap.min.js"></script>
-
-
-<?php 
-
-?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>接続情報</title>
+<?php print_bs5_search_head(); ?>
+<style>
+.qr-wrap { background:#fff; display:inline-block; padding:4px; border-radius:4px; }
+.url-display { font-family: monospace; font-size:.85rem; word-break:break-all; }
+</style>
 </head>
 <body>
-<?php
-    // 背景色変更
-    if(array_key_exists("bgcolor",$config_ini)){
-         print '<script type="text/javascript" >';
-         print 'document.body.style.backgroundColor = "'.urldecode($config_ini["bgcolor"]).'";';
-         print '</script>';
-    }
-// 処理記述部
-$online_avaiavle = 0;
-$change_counter = 0;
-if(array_key_exists("SSID", $_REQUEST)) {
-    $SSID = urlencode($_REQUEST["SSID"]);
-    $config_ini = array_merge($config_ini,array("SSID" => $SSID));
-    $change_counter ++;
-}
+<?php shownavigatioinbar_bs5('toolinfo.php'); ?>
 
-if(array_key_exists("wifipass", $_REQUEST)) {
-    $wifipass = urlencode($_REQUEST["wifipass"]);
-    $config_ini = array_merge($config_ini,array("wifipass" => $wifipass));
-    $change_counter ++;
-}
-if(array_key_exists("globalhost", $config_ini)) {
-    $globalhost = $config_ini["globalhost"];
-}
+<div class="container py-3" style="max-width:800px">
+  <h4 class="mb-3">接続情報</h4>
 
-if(array_key_exists("globalhost", $_REQUEST)) {
-    $globalhost = urlencode($_REQUEST["globalhost"]);
-    $config_ini = array_merge($config_ini,array("globalhost" => $globalhost));
-    $change_counter ++;
-}
-
-
-$LargeImage = false;
-$l_qrsize = 8;
-if(array_key_exists("qrsize", $_REQUEST)) {
-    $l_qrsize = $_REQUEST["qrsize"];
-}
-if ($l_qrsize > 8 ){
-    $l_qrsize = 8;
-    $LargeImage = true;
-}
-
-if(  $change_counter > 0 ){
-    writeconfig2ini($config_ini,$configfile);
-}
-$globalurl = "";
-if(!empty($globalhost)){
-    $ret = check_online_available($globalhost);
-    if( $ret == 'OK' ){
-        $online_avaiavle = 1;
-    }
-    $globalurl = 'http://'.urldecode($globalhost).'/';
-}
-
-
-print '<div class="container">';
-// 認証キーワード表示
-if(  $config_ini['useeasyauth'] == 1 ){
-    print '<div class="form-group">';
-    print '<label for="useeasyauth_word">認証キーワード <small> もし聞かれたらこれを入力してください </small></label>';
-    print '<input type="text" class="form-control input-lg toolinfo" id="useeasyauth_word"  value="'.$config_ini['useeasyauth_word'].'">';
-    print '</div>';
-    if(isset($globalhost)) {
-        $globalurl = 'http://'.urldecode($globalhost).'/'.'?easypass='.$config_ini['useeasyauth_word'];
-    }
-}
-
-
-if( $online_avaiavle === 1 ){
-    
-    print '<label>オンライン版接続先 URL<small>Wifiに接続しなくてもアクセスできるURLです</small></label>';
-    print '<input type="text" name="toolurl" class="form-control input-lg toolinfo" size="100" value="'.$globalurl.'" />';
-
-
-// オンライン版
-print '<label>QRコード</label>';
-print <<<EOT
-  <div class="row">
-  <div class="col-sm-12" class="text-center">
-    <div class="text-center">
-EOT;
-      print $globalurl.' <br />';
-print <<<EOT
+<?php if ($config_ini['useeasyauth'] == 1): ?>
+  <!-- 認証キーワード -->
+  <div class="card mb-3">
+    <div class="card-header fw-bold">認証キーワード</div>
+    <div class="card-body">
+      <p class="text-muted small mb-2">接続時に入力が必要なキーワードです</p>
+      <input type="text" class="form-control form-control-lg fw-bold text-center"
+             value="<?= htmlspecialchars($config_ini['useeasyauth_word'], ENT_QUOTES, 'UTF-8') ?>" readonly>
     </div>
-<img src="qrcode_php/outputqrimg.php?data=
-EOT;
-print urlencode($globalurl).'&qrsize='.$l_qrsize.'" ';
-if($LargeImage) print ' width="50%"  height="50%" ';
-print <<<EOT
- alt="QRコード" class="img-responsive center-block" /> <br />
   </div>
-EOT;
-print '</div>'; //row
-print <<<EOT
-<div class="panel-group" id="localnetinfo" role="tablist" aria-multiselectable="true">
-  <div class="panel panel-default">
-    <div class="panel-heading" role="tab" id="headingOne">
-      <h4 class="panel-title">
-       <a role="button" data-toggle="collapse" data-parent="#localnetinfo" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne" class="">
-        ローカル接続情報表示
-       </a>
-      </h4>
+<?php endif; ?>
+
+  <!-- WiFi接続情報 -->
+  <div class="card mb-3">
+    <div class="card-header fw-bold">WiFi接続情報</div>
+    <div class="card-body">
+      <form method="GET" class="mb-3">
+        <input type="hidden" name="qrsize" value="<?= $l_qrsize ?>">
+        <div class="row g-3 align-items-end">
+          <div class="col-sm-5">
+            <label class="form-label">WiFi SSID</label>
+            <input type="text" name="SSID" class="form-control"
+                   value="<?= htmlspecialchars($wifi_ssid, ENT_QUOTES, 'UTF-8') ?>"
+                   placeholder="例: MyWifi">
+          </div>
+          <div class="col-sm-5">
+            <label class="form-label">WiFi パスワード</label>
+            <input type="text" name="wifipass" class="form-control"
+                   value="<?= htmlspecialchars($wifi_pass, ENT_QUOTES, 'UTF-8') ?>"
+                   placeholder="パスワード">
+          </div>
+          <div class="col-sm-2">
+            <button type="submit" class="btn btn-primary w-100">保存</button>
+          </div>
+        </div>
+      </form>
+
+<?php if (!empty($wifi_ssid)): ?>
+      <hr class="my-2">
+      <div class="text-center mt-2">
+        <div class="qr-wrap mx-auto">
+          <?= qr_img($wifi_qr_data, $l_qrsize) ?>
+        </div>
+        <p class="small text-muted mt-2 mb-0">
+          SSID: <strong><?= htmlspecialchars($wifi_ssid, ENT_QUOTES, 'UTF-8') ?></strong>
+          &nbsp;/&nbsp;
+          パスワード: <strong><?= htmlspecialchars($wifi_pass, ENT_QUOTES, 'UTF-8') ?></strong>
+        </p>
+        <p class="small text-muted">スマートフォンのカメラで読み取るとWiFiに自動接続できます</p>
+      </div>
+<?php else: ?>
+      <p class="text-muted small mb-0">SSIDを入力して保存すると、WiFi自動接続用QRコードが表示されます</p>
+<?php endif; ?>
     </div>
-    <div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
-EOT;
-}else{
-    print '<div id="localnetinfo" ><div><div>';
-}
-?>
-
-
- <form method="GET" >
- <div class="form-group">
-  <label>接続用WiFI SSID</label>
-  <div class="row">
-   <div class="col-xs-10">
-    <input type="text" name="SSID" size="100" class="form-control input-lg toolinfo" 
-<?php
-require_once 'commonfunc.php';
-if(array_key_exists("SSID", $config_ini)){
-   print 'value="'.urldecode($config_ini["SSID"])."\"\n";
-}
-?>
-/>
-   </div>
-   <div class="col-xs-2">
-    <input type="submit" value="変更" class="btn btn-default btn-lg"/>
-   </div>
   </div>
- </div>
- </form>
- <form method="GET" >
- <div class="form-group">
- 
-  <label>接続用WiFI パスワード</label>
-  <div class="row">
-   <div class="col-xs-10">
-    <input type="text" name="wifipass" size="100" class="form-control input-lg toolinfo" 
-<?php
-require_once 'commonfunc.php';
-if(array_key_exists("wifipass", $config_ini)){
-   print 'value="'.urldecode($config_ini["wifipass"])."\"\n";
-}
-$localipurl = 'http://'.$_SERVER["SERVER_ADDR"].'/';
-$localhosturl = 'http://'.$_SERVER["HTTP_HOST"].'/';
-if(  $config_ini['useeasyauth'] == 1 ){
-    $localipurl = $localipurl.'?easypass='.$config_ini['useeasyauth_word'];
-    $localhosturl = $localhosturl.'?easypass='.$config_ini['useeasyauth_word'];
-}
-?>
-/>
-   </div>
-   <div class="col-xs-2">
-    <input type="submit" value="変更" class="btn btn-default btn-lg"/>
-   </div>
-  </div>
- </div>
- </form>
- <br />
 
- <div class="form-group">
-<label>接続先 URL</label>
-<input type="text" name="toolurl" class="form-control input-lg toolinfo" size="100" value=<?php echo $localhosturl;?> />
-<input type="text" name="toolurl" class="form-control input-lg toolinfo" size="100" value="<?php echo $localipurl;?>" />
-</div>
-<?php
-  if(!empty($globalhost)){
-      $ret = check_online_available($globalhost);
-      if( $ret == 'OK' ){
-          $online_avaiavle = 1;
-          print '<label>オンライン版接続先 URL<small>Wifiに接続しなくてもアクセスできるURLです</small></label>';
-          print '<input type="text" name="toolurl" class="form-control input-lg toolinfo" size="100" value="'.$globalurl.'" />';
-      }
-  }
-?>
-
-<div class="row">
-  <div class="col-sm-<?php print $online_avaiavle ? 6 : 6 ;?>" class="text-center">
-    <div class="text-center">
-    <?php
-      print $localhosturl.' <br />'
-    ?>
+<?php if ($online_available): ?>
+  <!-- オンライン接続URL -->
+  <div class="card mb-3 border-success">
+    <div class="card-header fw-bold text-success">
+      オンライン接続URL
+      <small class="text-muted fw-normal">（WiFiなしでもアクセス可）</small>
     </div>
-<img src="qrcode_php/outputqrimg.php?data=
-<?php
-print urlencode($localhosturl).'&qrsize='.$l_qrsize;
-?>
-" alt="QRコード" class="img-responsive center-block" /> <br />
-  </div>
-  <div class="col-sm-<?php print $online_avaiavle ? 6 : 6 ;?>" >
-    <div class="text-center">
-  <?php
-    print $localipurl.' <br />'
-  ?>
+    <div class="card-body">
+      <div class="input-group mb-3">
+        <input type="text" class="form-control url-display"
+               value="<?= htmlspecialchars($globalurl, ENT_QUOTES, 'UTF-8') ?>" readonly>
+        <button class="btn btn-outline-secondary" type="button"
+                onclick="navigator.clipboard.writeText(<?= json_encode($globalurl) ?>);this.textContent='コピー済'">
+          コピー
+        </button>
+      </div>
+      <div class="text-center">
+        <div class="qr-wrap mx-auto">
+          <?= qr_img($globalurl, $l_qrsize) ?>
+        </div>
+      </div>
     </div>
-<img src="qrcode_php/outputqrimg.php?data=
-<?php
-print urlencode($localipurl).'&qrsize='.$l_qrsize;
-?>
-" alt="QRコード" class="img-responsive center-block" /> <br />
+  </div>
+<?php endif; ?>
+
+  <!-- ローカル接続URL -->
+  <div class="card mb-3">
+    <div class="card-header fw-bold">
+      ローカル接続URL
+      <small class="text-muted fw-normal">（同じWiFi内からアクセス）</small>
+    </div>
+    <div class="card-body">
+      <div class="row g-3">
+        <div class="col-md-6">
+          <div class="card h-100">
+            <div class="card-body text-center">
+              <p class="fw-bold small mb-2">ホスト名</p>
+              <div class="input-group input-group-sm mb-2">
+                <input type="text" class="form-control url-display"
+                       value="<?= htmlspecialchars($localhosturl, ENT_QUOTES, 'UTF-8') ?>" readonly>
+                <button class="btn btn-outline-secondary btn-sm" type="button"
+                        onclick="navigator.clipboard.writeText(<?= json_encode($localhosturl) ?>);this.textContent='✓'">
+                  コピー
+                </button>
+              </div>
+              <div class="qr-wrap mx-auto">
+                <?= qr_img($localhosturl, $l_qrsize) ?>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="card h-100">
+            <div class="card-body text-center">
+              <p class="fw-bold small mb-2">IPアドレス</p>
+              <div class="input-group input-group-sm mb-2">
+                <input type="text" class="form-control url-display"
+                       value="<?= htmlspecialchars($localipurl, ENT_QUOTES, 'UTF-8') ?>" readonly>
+                <button class="btn btn-outline-secondary btn-sm" type="button"
+                        onclick="navigator.clipboard.writeText(<?= json_encode($localipurl) ?>);this.textContent='✓'">
+                  コピー
+                </button>
+              </div>
+              <div class="qr-wrap mx-auto">
+                <?= qr_img($localipurl, $l_qrsize) ?>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 
+  <!-- QRサイズ切り替え -->
+  <div class="d-flex gap-2 justify-content-center mb-4">
+    <span class="text-muted small align-self-center">QRサイズ:</span>
+    <a href="?qrsize=5"  class="btn btn-sm <?= $l_qrsize == 5  ? 'btn-secondary' : 'btn-outline-secondary' ?>">小</a>
+    <a href="?qrsize=8"  class="btn btn-sm <?= $l_qrsize == 8  ? 'btn-secondary' : 'btn-outline-secondary' ?>">標準</a>
+    <a href="?qrsize=12" class="btn btn-sm <?= $l_qrsize == 12 ? 'btn-secondary' : 'btn-outline-secondary' ?>">大</a>
+  </div>
+
+  <div class="text-center">
+    <a href="requestlist_top.php" class="btn btn-secondary">リクエストTOPに戻る</a>
+  </div>
 </div>
 
-</div> </div> 
-<hr />
-<div class="row">
-    <div class="btn-group btn-group-justified" role="group">
-	  <a href="?qrsize=5" class="btn btn-default" role="button">小</a>
-	  <a href="?qrsize=8" class="btn btn-default" role="button">標準</a>
-	  <a href="?qrsize=16" class="btn btn-default" role="button">大</a>
-    </div>
-</div>
-<a href="requestlist_top.php" > リクエストTOPに戻る </a>
-</div>
+<?php print_bg_style_block(true); ?>
 </body>
 </html>

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -58,6 +58,11 @@ $localipurl    = $localip_valid
     ? 'http://' . $server_addr . '/' . $easypass_q
     : '';
 
+// ホスト名とIPが同じURLになる場合はどちらか一方を無効化
+if ($localname_valid && $localip_valid && $localhosturl === $localipurl) {
+    $localip_valid = false;
+}
+
 $has_local_url = $localname_valid || $localip_valid;
 
 // --- WiFi情報 ---

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -42,7 +42,12 @@ if (!empty($globalhost) && $config_ini['connectinternet'] == 1) {
 $easypass_q = ($config_ini['useeasyauth'] == 1)
     ? '?easypass=' . urlencode($config_ini['useeasyauth_word'])
     : '';
-$localhosturl = 'http://' . $_SERVER['HTTP_HOST'] . '/' . $easypass_q;
+
+// ホスト名（localhost は除外）
+$http_host      = $_SERVER['HTTP_HOST'];
+$host_only      = strtolower(explode(':', $http_host)[0]);
+$localname_valid = ($host_only !== 'localhost');
+$localhosturl   = $localname_valid ? 'http://' . $http_host . '/' . $easypass_q : '';
 
 // IPv6・ループバックを除外した IPv4 アドレスのみ表示
 $server_addr   = $_SERVER['SERVER_ADDR'];
@@ -51,6 +56,8 @@ $localip_valid = (strpos($server_addr, ':') === false)   // IPv6除外
 $localipurl    = $localip_valid
     ? 'http://' . $server_addr . '/' . $easypass_q
     : '';
+
+$has_local_url = $localname_valid || $localip_valid;
 
 // --- WiFi情報 ---
 $wifi_ssid = isset($config_ini['SSID'])    ? urldecode($config_ini['SSID'])    : '';
@@ -170,7 +177,9 @@ $wifi_open   = true;
            class="accordion-collapse collapse <?= $local_open ? 'show' : '' ?>"
            aria-labelledby="headingLocal">
         <div class="accordion-body">
+          <?php if ($has_local_url): ?>
           <div class="row g-3">
+            <?php if ($localname_valid): ?>
             <div class="col-md-6">
               <div class="card h-100">
                 <div class="card-body text-center">
@@ -189,6 +198,7 @@ $wifi_open   = true;
                 </div>
               </div>
             </div>
+            <?php endif; ?>
             <?php if ($localip_valid): ?>
             <div class="col-md-6">
               <div class="card h-100">
@@ -210,6 +220,51 @@ $wifi_open   = true;
             </div>
             <?php endif; ?>
           </div>
+          <?php else: ?>
+          <?php /* ホスト名・IPアドレスがいずれも対象外のとき */ ?>
+          <div class="alert alert-info mb-3">
+            IPアドレスまたはホスト名を直接指定してアクセスしてください。
+          </div>
+          <?php
+            require_once 'ipconfig.php';
+            $_ic = getiplist();
+            $_v4 = []; $_v6 = []; $_seen = [];
+            foreach ($_ic as $_if) {
+                foreach ($_if as $_ki => $_s) {
+                    if ($_ki === 0) continue;
+                    $_ip = trim($_s);
+                    if (empty($_ip)) continue;
+                    if (strpos($_ip, '%') !== false) $_ip = substr($_ip, 0, strpos($_ip, '%'));
+                    if ($_ip === '127.0.0.1' || $_ip === '::1') continue;
+                    if (in_array($_ip, $_seen, true)) continue;
+                    $_seen[] = $_ip;
+                    $_is6 = (strpos($_ip, ':') !== false);
+                    $_lk  = 'http://' . ($_is6 ? '[' . $_ip . ']' : $_ip) . '/' . $easypass_q;
+                    if ($_is6) { $_v6[] = $_lk; } else { $_v4[] = $_lk; }
+                }
+            }
+          ?>
+          <div style="font-family:monospace; font-size:.875rem">
+            <?php foreach ($_v4 as $_lk): ?>
+            <a href="<?= htmlspecialchars($_lk, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($_lk, ENT_QUOTES, 'UTF-8') ?></a><br>
+            <?php endforeach; ?>
+          </div>
+          <?php if (!empty($_v6)): ?>
+          <div class="mt-2">
+            <button class="btn btn-sm btn-outline-secondary" type="button"
+                    data-bs-toggle="collapse" data-bs-target="#local-ipv6-list">
+              IPv6アドレスを表示 (<?= count($_v6) ?>件)
+            </button>
+            <div class="collapse mt-1" id="local-ipv6-list">
+              <div style="font-family:monospace; font-size:.875rem">
+                <?php foreach ($_v6 as $_lk): ?>
+                <a href="<?= htmlspecialchars($_lk, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($_lk, ENT_QUOTES, 'UTF-8') ?></a><br>
+                <?php endforeach; ?>
+              </div>
+            </div>
+          </div>
+          <?php endif; ?>
+          <?php endif; ?>
         </div>
       </div>
     </div>

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -86,24 +86,6 @@ function qr_img(string $data, int $size): string {
          . ' alt="QRコード" class="img-fluid d-block mx-auto" style="max-width:320px">';
 }
 
-// --- URL + QRコードを横並びで表示するブロックHTML ---
-// モバイル: QR上・URL下（縦積み）、md以上: QR左・URL右（横並び）
-function url_card_body(string $label, string $url, int $qrsize): string {
-    $h = htmlspecialchars($url, ENT_QUOTES, 'UTF-8');
-    $j = json_encode($url);
-    $hl = htmlspecialchars($label, ENT_QUOTES, 'UTF-8');
-    return '<div class="d-flex flex-column flex-md-row align-items-md-center gap-3">'
-         . '<div class="flex-shrink-0 text-center"><div class="qr-wrap mx-auto">' . qr_img($url, $qrsize) . '</div></div>'
-         . '<div class="flex-grow-1 w-100">'
-         . '<p class="fw-bold small mb-1">' . $hl . '</p>'
-         . '<div class="input-group input-group-sm">'
-         . '<input type="text" class="form-control url-display" value="' . $h . '" readonly>'
-         . '<button class="btn btn-outline-secondary btn-sm" type="button"'
-         . ' onclick="navigator.clipboard.writeText(' . $j . ');this.textContent=\'✓\'">コピー</button>'
-         . '</div>'
-         . '</div>'
-         . '</div>';
-}
 ?>
 <!DOCTYPE html>
 <html lang="ja">
@@ -120,7 +102,7 @@ function url_card_body(string $label, string $url, int $qrsize): string {
 <body>
 <?php shownavigatioinbar_bs5('toolinfo.php'); ?>
 
-<div class="container py-3" style="max-width:800px">
+<div class="container py-3">
   <h4 class="mb-3">接続情報</h4>
 
 <?php if ($config_ini['useeasyauth'] == 1): ?>
@@ -135,36 +117,31 @@ function url_card_body(string $label, string $url, int $qrsize): string {
   </div>
 <?php endif; ?>
 
-<?php
-// アコーディオン初期開閉状態
-$online_open = $online_available;
-$local_open  = !$online_available;
-$wifi_open   = true;
-?>
-
-  <div class="accordion mb-3" id="infoAccordion">
+  <!-- lg以上: 3カラム横並び / lg未満: 縦積み -->
+  <div class="row g-3 mb-3">
 
     <!-- オンライン接続URL -->
-    <div class="accordion-item">
-      <h2 class="accordion-header" id="headingOnline">
-        <button class="accordion-button <?= $online_open ? '' : 'collapsed' ?>" type="button"
-                data-bs-toggle="collapse" data-bs-target="#collapseOnline"
-                aria-expanded="<?= $online_open ? 'true' : 'false' ?>"
-                aria-controls="collapseOnline">
+    <div class="col-12 col-lg-4">
+      <div class="card h-100">
+        <div class="card-header fw-bold d-flex align-items-center">
           オンライン接続URL
+          <span class="badge <?= $online_available ? 'bg-success' : 'bg-secondary' ?> ms-auto">
+            <?= $online_available ? '接続可' : '未接続' ?>
+          </span>
+        </div>
+        <div class="card-body">
           <?php if ($online_available): ?>
-            <span class="badge bg-success ms-2">接続可</span>
-          <?php else: ?>
-            <span class="badge bg-secondary ms-2">未接続</span>
-          <?php endif; ?>
-        </button>
-      </h2>
-      <div id="collapseOnline"
-           class="accordion-collapse collapse <?= $online_open ? 'show' : '' ?>"
-           aria-labelledby="headingOnline">
-        <div class="accordion-body">
-          <?php if ($online_available): ?>
-            <?= url_card_body('オンライン接続URL（WiFiなしでもアクセス可）', $globalurl, $l_qrsize) ?>
+            <div class="text-center mb-2">
+              <div class="qr-wrap mx-auto"><?= qr_img($globalurl, $l_qrsize) ?></div>
+            </div>
+            <div class="input-group input-group-sm">
+              <input type="text" class="form-control url-display"
+                     value="<?= htmlspecialchars($globalurl, ENT_QUOTES, 'UTF-8') ?>" readonly>
+              <button class="btn btn-outline-secondary btn-sm" type="button"
+                      onclick="navigator.clipboard.writeText(<?= json_encode($globalurl) ?>);this.textContent='✓'">
+                コピー
+              </button>
+            </div>
           <?php elseif (!empty($globalhost)): ?>
             <p class="text-muted small mb-0">設定されたホスト（<?= htmlspecialchars($globalhost, ENT_QUOTES, 'UTF-8') ?>）に接続できませんでした。</p>
           <?php else: ?>
@@ -175,98 +152,82 @@ $wifi_open   = true;
     </div>
 
     <!-- ローカル接続URL -->
-    <div class="accordion-item">
-      <h2 class="accordion-header" id="headingLocal">
-        <button class="accordion-button <?= $local_open ? '' : 'collapsed' ?>" type="button"
-                data-bs-toggle="collapse" data-bs-target="#collapseLocal"
-                aria-expanded="<?= $local_open ? 'true' : 'false' ?>"
-                aria-controls="collapseLocal">
-          ローカル接続URL
-          <small class="text-muted fw-normal ms-2">同じWiFi内からアクセス</small>
-        </button>
-      </h2>
-      <div id="collapseLocal"
-           class="accordion-collapse collapse <?= $local_open ? 'show' : '' ?>"
-           aria-labelledby="headingLocal">
-        <div class="accordion-body">
+    <div class="col-12 col-lg-4">
+      <div class="card h-100">
+        <div class="card-header fw-bold">
+          ローカル接続URL <small class="text-muted fw-normal">同じWiFi内</small>
+        </div>
+        <div class="card-body">
           <?php if ($has_local_url): ?>
-          <div class="row g-3 justify-content-center">
             <?php if ($localname_valid): ?>
-            <div class="col-md-6">
-              <div class="card h-100">
-                <div class="card-body">
-                  <?= url_card_body('ホスト名', $localhosturl, $l_qrsize) ?>
-                </div>
+              <p class="fw-bold small mb-1">ホスト名</p>
+              <div class="input-group input-group-sm mb-2">
+                <input type="text" class="form-control url-display"
+                       value="<?= htmlspecialchars($localhosturl, ENT_QUOTES, 'UTF-8') ?>" readonly>
+                <button class="btn btn-outline-secondary btn-sm" type="button"
+                        onclick="navigator.clipboard.writeText(<?= json_encode($localhosturl) ?>);this.textContent='✓'">
+                  コピー
+                </button>
               </div>
-            </div>
+              <div class="text-center <?= $localip_valid ? 'mb-3' : '' ?>">
+                <div class="qr-wrap mx-auto"><?= qr_img($localhosturl, $l_qrsize) ?></div>
+              </div>
             <?php endif; ?>
             <?php if ($localip_valid): ?>
-            <div class="col-md-6">
-              <div class="card h-100">
-                <div class="card-body">
-                  <?= url_card_body('IPアドレス', $localipurl, $l_qrsize) ?>
-                </div>
+              <?php if ($localname_valid): ?><hr class="my-2"><?php endif; ?>
+              <p class="fw-bold small mb-1">IPアドレス</p>
+              <div class="input-group input-group-sm mb-2">
+                <input type="text" class="form-control url-display"
+                       value="<?= htmlspecialchars($localipurl, ENT_QUOTES, 'UTF-8') ?>" readonly>
+                <button class="btn btn-outline-secondary btn-sm" type="button"
+                        onclick="navigator.clipboard.writeText(<?= json_encode($localipurl) ?>);this.textContent='✓'">
+                  コピー
+                </button>
               </div>
-            </div>
+              <div class="text-center">
+                <div class="qr-wrap mx-auto"><?= qr_img($localipurl, $l_qrsize) ?></div>
+              </div>
             <?php endif; ?>
-          </div>
           <?php else: ?>
-          <?php /* ホスト名・IPアドレスがいずれも対象外のとき */ ?>
-          <div class="alert alert-info mb-3">
-            IPアドレスまたはホスト名を直接指定してアクセスしてください。
-          </div>
-          <?php print_iplist($config_ini, 'local-ipv6-list'); ?>
+            <div class="alert alert-info mb-3">
+              IPアドレスまたはホスト名を直接指定してアクセスしてください。
+            </div>
+            <?php print_iplist($config_ini, 'local-ipv6-list'); ?>
           <?php endif; ?>
         </div>
       </div>
     </div>
 
     <!-- WiFi接続情報 -->
-    <div class="accordion-item">
-      <h2 class="accordion-header" id="headingWifi">
-        <button class="accordion-button <?= $wifi_open ? '' : 'collapsed' ?>" type="button"
-                data-bs-toggle="collapse" data-bs-target="#collapseWifi"
-                aria-expanded="<?= $wifi_open ? 'true' : 'false' ?>"
-                aria-controls="collapseWifi">
-          WiFi接続情報
-        </button>
-      </h2>
-      <div id="collapseWifi"
-           class="accordion-collapse collapse <?= $wifi_open ? 'show' : '' ?>"
-           aria-labelledby="headingWifi">
-        <div class="accordion-body">
+    <div class="col-12 col-lg-4">
+      <div class="card h-100">
+        <div class="card-header fw-bold">WiFi接続情報</div>
+        <div class="card-body">
           <form method="GET" class="mb-3">
             <input type="hidden" name="qrsize" value="<?= $l_qrsize ?>">
-            <div class="row g-3 align-items-end">
-              <div class="col-sm-5">
-                <label class="form-label">WiFi SSID</label>
-                <input type="text" name="SSID" class="form-control"
-                       value="<?= htmlspecialchars($wifi_ssid, ENT_QUOTES, 'UTF-8') ?>"
-                       placeholder="例: MyWifi">
-              </div>
-              <div class="col-sm-5">
-                <label class="form-label">WiFi パスワード</label>
-                <input type="text" name="wifipass" class="form-control"
-                       value="<?= htmlspecialchars($wifi_pass, ENT_QUOTES, 'UTF-8') ?>"
-                       placeholder="パスワード">
-              </div>
-              <div class="col-sm-2">
-                <button type="submit" class="btn btn-primary w-100">保存</button>
-              </div>
+            <div class="mb-2">
+              <label class="form-label small mb-1">WiFi SSID</label>
+              <input type="text" name="SSID" class="form-control form-control-sm"
+                     value="<?= htmlspecialchars($wifi_ssid, ENT_QUOTES, 'UTF-8') ?>"
+                     placeholder="例: MyWifi">
             </div>
+            <div class="mb-2">
+              <label class="form-label small mb-1">WiFi パスワード</label>
+              <input type="text" name="wifipass" class="form-control form-control-sm"
+                     value="<?= htmlspecialchars($wifi_pass, ENT_QUOTES, 'UTF-8') ?>"
+                     placeholder="パスワード">
+            </div>
+            <button type="submit" class="btn btn-primary btn-sm w-100">保存</button>
           </form>
           <?php if (!empty($wifi_ssid)): ?>
             <hr class="my-2">
-            <div class="text-center mt-2">
-              <div class="qr-wrap mx-auto">
-                <?= qr_img($wifi_qr_data, $l_qrsize) ?>
-              </div>
+            <div class="text-center">
+              <div class="qr-wrap mx-auto"><?= qr_img($wifi_qr_data, $l_qrsize) ?></div>
               <p class="small text-muted mt-2 mb-0">
-                SSID: <strong><?= htmlspecialchars($wifi_ssid, ENT_QUOTES, 'UTF-8') ?></strong>
-                &nbsp;/&nbsp;
+                SSID: <strong><?= htmlspecialchars($wifi_ssid, ENT_QUOTES, 'UTF-8') ?></strong><br>
                 パスワード: <strong><?= htmlspecialchars($wifi_pass, ENT_QUOTES, 'UTF-8') ?></strong>
               </p>
-              <p class="small text-muted">スマートフォンのカメラで読み取るとWiFiに自動接続できます</p>
+              <p class="small text-muted">カメラで読み取るとWiFiに自動接続できます</p>
             </div>
           <?php else: ?>
             <p class="text-muted small mb-0">SSIDを入力して保存すると、WiFi自動接続用QRコードが表示されます</p>
@@ -275,7 +236,7 @@ $wifi_open   = true;
       </div>
     </div>
 
-  </div><!-- /accordion -->
+  </div><!-- /row -->
 
   <!-- QRサイズ切り替え -->
   <div class="d-flex gap-2 justify-content-center mb-4">

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'commonfunc.php';
+require_once 'ipconfig.php';
 require_once 'easyauth_class.php';
 $easyauth = new EasyAuth();
 $easyauth->do_eashauthcheck();
@@ -225,45 +226,7 @@ $wifi_open   = true;
           <div class="alert alert-info mb-3">
             IPアドレスまたはホスト名を直接指定してアクセスしてください。
           </div>
-          <?php
-            require_once 'ipconfig.php';
-            $_ic = getiplist();
-            $_v4 = []; $_v6 = []; $_seen = [];
-            foreach ($_ic as $_if) {
-                foreach ($_if as $_ki => $_s) {
-                    if ($_ki === 0) continue;
-                    $_ip = trim($_s);
-                    if (empty($_ip)) continue;
-                    if (strpos($_ip, '%') !== false) $_ip = substr($_ip, 0, strpos($_ip, '%'));
-                    if ($_ip === '127.0.0.1' || $_ip === '::1') continue;
-                    if (in_array($_ip, $_seen, true)) continue;
-                    $_seen[] = $_ip;
-                    $_is6 = (strpos($_ip, ':') !== false);
-                    $_lk  = 'http://' . ($_is6 ? '[' . $_ip . ']' : $_ip) . '/' . $easypass_q;
-                    if ($_is6) { $_v6[] = $_lk; } else { $_v4[] = $_lk; }
-                }
-            }
-          ?>
-          <div style="font-family:monospace; font-size:.875rem">
-            <?php foreach ($_v4 as $_lk): ?>
-            <a href="<?= htmlspecialchars($_lk, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($_lk, ENT_QUOTES, 'UTF-8') ?></a><br>
-            <?php endforeach; ?>
-          </div>
-          <?php if (!empty($_v6)): ?>
-          <div class="mt-2">
-            <button class="btn btn-sm btn-outline-secondary" type="button"
-                    data-bs-toggle="collapse" data-bs-target="#local-ipv6-list">
-              IPv6アドレスを表示 (<?= count($_v6) ?>件)
-            </button>
-            <div class="collapse mt-1" id="local-ipv6-list">
-              <div style="font-family:monospace; font-size:.875rem">
-                <?php foreach ($_v6 as $_lk): ?>
-                <a href="<?= htmlspecialchars($_lk, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($_lk, ENT_QUOTES, 'UTF-8') ?></a><br>
-                <?php endforeach; ?>
-              </div>
-            </div>
-          </div>
-          <?php endif; ?>
+          <?php print_iplist($config_ini, 'local-ipv6-list'); ?>
           <?php endif; ?>
         </div>
       </div>

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -154,9 +154,15 @@ function qr_img(string $data, int $size): string {
     <!-- ローカル接続URL -->
     <div class="col-12 col-lg-4">
       <div class="card h-100">
-        <div class="card-header fw-bold">
-          ローカル接続URL <small class="text-muted fw-normal">同じWiFi内</small>
+        <div class="card-header fw-bold d-flex align-items-center">
+          ローカル接続URL <small class="text-muted fw-normal ms-2">同じWiFi内</small>
+          <?php if ($online_available): ?>
+          <button id="localToggleBtn" class="btn btn-sm btn-outline-secondary ms-auto collapsed"
+                  type="button" data-bs-toggle="collapse" data-bs-target="#localUrlBody"
+                  aria-expanded="false" aria-controls="localUrlBody">表示</button>
+          <?php endif; ?>
         </div>
+        <div id="localUrlBody" class="<?= $online_available ? 'collapse' : '' ?>">
         <div class="card-body">
           <?php if ($has_local_url): ?>
             <?php if ($localname_valid): ?>
@@ -195,6 +201,7 @@ function qr_img(string $data, int $size): string {
             <?php print_iplist($config_ini, 'local-ipv6-list'); ?>
           <?php endif; ?>
         </div>
+        </div><!-- /#localUrlBody -->
       </div>
     </div>
 
@@ -252,5 +259,16 @@ function qr_img(string $data, int $size): string {
 </div>
 
 <?php print_bg_style_block(true); ?>
+<?php if ($online_available): ?>
+<script>
+(function () {
+  var body = document.getElementById('localUrlBody');
+  var btn  = document.getElementById('localToggleBtn');
+  if (!body || !btn) return;
+  body.addEventListener('show.bs.collapse', function () { btn.textContent = '非表示'; });
+  body.addEventListener('hide.bs.collapse', function () { btn.textContent = '表示'; });
+})();
+</script>
+<?php endif; ?>
 </body>
 </html>

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -100,122 +100,170 @@ function qr_img(string $data, int $size): string {
   </div>
 <?php endif; ?>
 
-  <!-- WiFi接続情報 -->
-  <div class="card mb-3">
-    <div class="card-header fw-bold">WiFi接続情報</div>
-    <div class="card-body">
-      <form method="GET" class="mb-3">
-        <input type="hidden" name="qrsize" value="<?= $l_qrsize ?>">
-        <div class="row g-3 align-items-end">
-          <div class="col-sm-5">
-            <label class="form-label">WiFi SSID</label>
-            <input type="text" name="SSID" class="form-control"
-                   value="<?= htmlspecialchars($wifi_ssid, ENT_QUOTES, 'UTF-8') ?>"
-                   placeholder="例: MyWifi">
-          </div>
-          <div class="col-sm-5">
-            <label class="form-label">WiFi パスワード</label>
-            <input type="text" name="wifipass" class="form-control"
-                   value="<?= htmlspecialchars($wifi_pass, ENT_QUOTES, 'UTF-8') ?>"
-                   placeholder="パスワード">
-          </div>
-          <div class="col-sm-2">
-            <button type="submit" class="btn btn-primary w-100">保存</button>
-          </div>
-        </div>
-      </form>
+<?php
+// アコーディオン初期開閉状態
+$online_open = $online_available;
+$local_open  = !$online_available;
+$wifi_open   = true;
+?>
 
-<?php if (!empty($wifi_ssid)): ?>
-      <hr class="my-2">
-      <div class="text-center mt-2">
-        <div class="qr-wrap mx-auto">
-          <?= qr_img($wifi_qr_data, $l_qrsize) ?>
-        </div>
-        <p class="small text-muted mt-2 mb-0">
-          SSID: <strong><?= htmlspecialchars($wifi_ssid, ENT_QUOTES, 'UTF-8') ?></strong>
-          &nbsp;/&nbsp;
-          パスワード: <strong><?= htmlspecialchars($wifi_pass, ENT_QUOTES, 'UTF-8') ?></strong>
-        </p>
-        <p class="small text-muted">スマートフォンのカメラで読み取るとWiFiに自動接続できます</p>
-      </div>
-<?php else: ?>
-      <p class="text-muted small mb-0">SSIDを入力して保存すると、WiFi自動接続用QRコードが表示されます</p>
-<?php endif; ?>
-    </div>
-  </div>
+  <div class="accordion mb-3" id="infoAccordion">
 
-<?php if ($online_available): ?>
-  <!-- オンライン接続URL -->
-  <div class="card mb-3 border-success">
-    <div class="card-header fw-bold text-success">
-      オンライン接続URL
-      <small class="text-muted fw-normal">（WiFiなしでもアクセス可）</small>
-    </div>
-    <div class="card-body">
-      <div class="input-group mb-3">
-        <input type="text" class="form-control url-display"
-               value="<?= htmlspecialchars($globalurl, ENT_QUOTES, 'UTF-8') ?>" readonly>
-        <button class="btn btn-outline-secondary" type="button"
-                onclick="navigator.clipboard.writeText(<?= json_encode($globalurl) ?>);this.textContent='コピー済'">
-          コピー
+    <!-- オンライン接続URL -->
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="headingOnline">
+        <button class="accordion-button <?= $online_open ? '' : 'collapsed' ?>" type="button"
+                data-bs-toggle="collapse" data-bs-target="#collapseOnline"
+                aria-expanded="<?= $online_open ? 'true' : 'false' ?>"
+                aria-controls="collapseOnline">
+          オンライン接続URL
+          <?php if ($online_available): ?>
+            <span class="badge bg-success ms-2">接続可</span>
+          <?php else: ?>
+            <span class="badge bg-secondary ms-2">未接続</span>
+          <?php endif; ?>
         </button>
-      </div>
-      <div class="text-center">
-        <div class="qr-wrap mx-auto">
-          <?= qr_img($globalurl, $l_qrsize) ?>
+      </h2>
+      <div id="collapseOnline"
+           class="accordion-collapse collapse <?= $online_open ? 'show' : '' ?>"
+           aria-labelledby="headingOnline">
+        <div class="accordion-body">
+          <?php if ($online_available): ?>
+            <p class="text-muted small mb-2">WiFiに接続しなくてもアクセスできるURLです</p>
+            <div class="input-group mb-3">
+              <input type="text" class="form-control url-display"
+                     value="<?= htmlspecialchars($globalurl, ENT_QUOTES, 'UTF-8') ?>" readonly>
+              <button class="btn btn-outline-secondary" type="button"
+                      onclick="navigator.clipboard.writeText(<?= json_encode($globalurl) ?>);this.textContent='コピー済'">
+                コピー
+              </button>
+            </div>
+            <div class="text-center">
+              <div class="qr-wrap mx-auto">
+                <?= qr_img($globalurl, $l_qrsize) ?>
+              </div>
+            </div>
+          <?php elseif (!empty($globalhost)): ?>
+            <p class="text-muted small mb-0">設定されたホスト（<?= htmlspecialchars($globalhost, ENT_QUOTES, 'UTF-8') ?>）に接続できませんでした。</p>
+          <?php else: ?>
+            <p class="text-muted small mb-0">オンライン接続URLは設定されていません。管理画面（init.php）で設定できます。</p>
+          <?php endif; ?>
         </div>
       </div>
     </div>
-  </div>
-<?php endif; ?>
 
-  <!-- ローカル接続URL -->
-  <div class="card mb-3">
-    <div class="card-header fw-bold">
-      ローカル接続URL
-      <small class="text-muted fw-normal">（同じWiFi内からアクセス）</small>
-    </div>
-    <div class="card-body">
-      <div class="row g-3">
-        <div class="col-md-6">
-          <div class="card h-100">
-            <div class="card-body text-center">
-              <p class="fw-bold small mb-2">ホスト名</p>
-              <div class="input-group input-group-sm mb-2">
-                <input type="text" class="form-control url-display"
-                       value="<?= htmlspecialchars($localhosturl, ENT_QUOTES, 'UTF-8') ?>" readonly>
-                <button class="btn btn-outline-secondary btn-sm" type="button"
-                        onclick="navigator.clipboard.writeText(<?= json_encode($localhosturl) ?>);this.textContent='✓'">
-                  コピー
-                </button>
-              </div>
-              <div class="qr-wrap mx-auto">
-                <?= qr_img($localhosturl, $l_qrsize) ?>
+    <!-- ローカル接続URL -->
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="headingLocal">
+        <button class="accordion-button <?= $local_open ? '' : 'collapsed' ?>" type="button"
+                data-bs-toggle="collapse" data-bs-target="#collapseLocal"
+                aria-expanded="<?= $local_open ? 'true' : 'false' ?>"
+                aria-controls="collapseLocal">
+          ローカル接続URL
+          <small class="text-muted fw-normal ms-2">同じWiFi内からアクセス</small>
+        </button>
+      </h2>
+      <div id="collapseLocal"
+           class="accordion-collapse collapse <?= $local_open ? 'show' : '' ?>"
+           aria-labelledby="headingLocal">
+        <div class="accordion-body">
+          <div class="row g-3">
+            <div class="col-md-6">
+              <div class="card h-100">
+                <div class="card-body text-center">
+                  <p class="fw-bold small mb-2">ホスト名</p>
+                  <div class="input-group input-group-sm mb-2">
+                    <input type="text" class="form-control url-display"
+                           value="<?= htmlspecialchars($localhosturl, ENT_QUOTES, 'UTF-8') ?>" readonly>
+                    <button class="btn btn-outline-secondary btn-sm" type="button"
+                            onclick="navigator.clipboard.writeText(<?= json_encode($localhosturl) ?>);this.textContent='✓'">
+                      コピー
+                    </button>
+                  </div>
+                  <div class="qr-wrap mx-auto">
+                    <?= qr_img($localhosturl, $l_qrsize) ?>
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        </div>
-        <div class="col-md-6">
-          <div class="card h-100">
-            <div class="card-body text-center">
-              <p class="fw-bold small mb-2">IPアドレス</p>
-              <div class="input-group input-group-sm mb-2">
-                <input type="text" class="form-control url-display"
-                       value="<?= htmlspecialchars($localipurl, ENT_QUOTES, 'UTF-8') ?>" readonly>
-                <button class="btn btn-outline-secondary btn-sm" type="button"
-                        onclick="navigator.clipboard.writeText(<?= json_encode($localipurl) ?>);this.textContent='✓'">
-                  コピー
-                </button>
-              </div>
-              <div class="qr-wrap mx-auto">
-                <?= qr_img($localipurl, $l_qrsize) ?>
+            <div class="col-md-6">
+              <div class="card h-100">
+                <div class="card-body text-center">
+                  <p class="fw-bold small mb-2">IPアドレス</p>
+                  <div class="input-group input-group-sm mb-2">
+                    <input type="text" class="form-control url-display"
+                           value="<?= htmlspecialchars($localipurl, ENT_QUOTES, 'UTF-8') ?>" readonly>
+                    <button class="btn btn-outline-secondary btn-sm" type="button"
+                            onclick="navigator.clipboard.writeText(<?= json_encode($localipurl) ?>);this.textContent='✓'">
+                      コピー
+                    </button>
+                  </div>
+                  <div class="qr-wrap mx-auto">
+                    <?= qr_img($localipurl, $l_qrsize) ?>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+
+    <!-- WiFi接続情報 -->
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="headingWifi">
+        <button class="accordion-button <?= $wifi_open ? '' : 'collapsed' ?>" type="button"
+                data-bs-toggle="collapse" data-bs-target="#collapseWifi"
+                aria-expanded="<?= $wifi_open ? 'true' : 'false' ?>"
+                aria-controls="collapseWifi">
+          WiFi接続情報
+        </button>
+      </h2>
+      <div id="collapseWifi"
+           class="accordion-collapse collapse <?= $wifi_open ? 'show' : '' ?>"
+           aria-labelledby="headingWifi">
+        <div class="accordion-body">
+          <form method="GET" class="mb-3">
+            <input type="hidden" name="qrsize" value="<?= $l_qrsize ?>">
+            <div class="row g-3 align-items-end">
+              <div class="col-sm-5">
+                <label class="form-label">WiFi SSID</label>
+                <input type="text" name="SSID" class="form-control"
+                       value="<?= htmlspecialchars($wifi_ssid, ENT_QUOTES, 'UTF-8') ?>"
+                       placeholder="例: MyWifi">
+              </div>
+              <div class="col-sm-5">
+                <label class="form-label">WiFi パスワード</label>
+                <input type="text" name="wifipass" class="form-control"
+                       value="<?= htmlspecialchars($wifi_pass, ENT_QUOTES, 'UTF-8') ?>"
+                       placeholder="パスワード">
+              </div>
+              <div class="col-sm-2">
+                <button type="submit" class="btn btn-primary w-100">保存</button>
+              </div>
+            </div>
+          </form>
+          <?php if (!empty($wifi_ssid)): ?>
+            <hr class="my-2">
+            <div class="text-center mt-2">
+              <div class="qr-wrap mx-auto">
+                <?= qr_img($wifi_qr_data, $l_qrsize) ?>
+              </div>
+              <p class="small text-muted mt-2 mb-0">
+                SSID: <strong><?= htmlspecialchars($wifi_ssid, ENT_QUOTES, 'UTF-8') ?></strong>
+                &nbsp;/&nbsp;
+                パスワード: <strong><?= htmlspecialchars($wifi_pass, ENT_QUOTES, 'UTF-8') ?></strong>
+              </p>
+              <p class="small text-muted">スマートフォンのカメラで読み取るとWiFiに自動接続できます</p>
+            </div>
+          <?php else: ?>
+            <p class="text-muted small mb-0">SSIDを入力して保存すると、WiFi自動接続用QRコードが表示されます</p>
+          <?php endif; ?>
+        </div>
+      </div>
+    </div>
+
+  </div><!-- /accordion -->
 
   <!-- QRサイズ切り替え -->
   <div class="d-flex gap-2 justify-content-center mb-4">

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -22,12 +22,14 @@ if (isset($_REQUEST['qrsize'])) {
     $l_qrsize = max(1, min(16, (int)$_REQUEST['qrsize']));
 }
 
-// --- グローバルURL ---
-$globalhost      = isset($config_ini['globalhost']) ? urldecode($config_ini['globalhost']) : '';
+// --- グローバルURL（5秒タイムアウトで1回だけ試行）---
+$globalhost       = isset($config_ini['globalhost']) ? urldecode($config_ini['globalhost']) : '';
 $online_available = false;
-$globalurl       = '';
-if (!empty($globalhost)) {
-    if (check_online_available($globalhost) === 'OK') {
+$globalurl        = '';
+if (!empty($globalhost) && $config_ini['connectinternet'] == 1) {
+    $checkurl = 'http://' . $globalhost;
+    $ret = file_get_html_with_retry($checkurl, 1, 5);
+    if ($ret !== false) {
         $online_available = true;
     }
     $globalurl = 'http://' . $globalhost . '/';
@@ -37,17 +39,18 @@ if (!empty($globalhost)) {
 }
 
 // --- ローカルURL ---
-$server_addr = $_SERVER['SERVER_ADDR'];
-$server_addr_url = (strpos($server_addr, ':') !== false)
-    ? addipv6blanket($server_addr)
-    : $server_addr;
-$localhosturl = 'http://' . $_SERVER['HTTP_HOST'] . '/';
-$localipurl   = 'http://' . $server_addr_url . '/';
-if ($config_ini['useeasyauth'] == 1) {
-    $easypass_q    = '?easypass=' . urlencode($config_ini['useeasyauth_word']);
-    $localhosturl .= $easypass_q;
-    $localipurl   .= $easypass_q;
-}
+$easypass_q = ($config_ini['useeasyauth'] == 1)
+    ? '?easypass=' . urlencode($config_ini['useeasyauth_word'])
+    : '';
+$localhosturl = 'http://' . $_SERVER['HTTP_HOST'] . '/' . $easypass_q;
+
+// IPv6・ループバックを除外した IPv4 アドレスのみ表示
+$server_addr   = $_SERVER['SERVER_ADDR'];
+$localip_valid = (strpos($server_addr, ':') === false)   // IPv6除外
+              && ($server_addr !== '127.0.0.1');           // ループバック除外
+$localipurl    = $localip_valid
+    ? 'http://' . $server_addr . '/' . $easypass_q
+    : '';
 
 // --- WiFi情報 ---
 $wifi_ssid = isset($config_ini['SSID'])    ? urldecode($config_ini['SSID'])    : '';
@@ -186,6 +189,7 @@ $wifi_open   = true;
                 </div>
               </div>
             </div>
+            <?php if ($localip_valid): ?>
             <div class="col-md-6">
               <div class="card h-100">
                 <div class="card-body text-center">
@@ -204,6 +208,7 @@ $wifi_open   = true;
                 </div>
               </div>
             </div>
+            <?php endif; ?>
           </div>
         </div>
       </div>

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -121,8 +121,8 @@ function qr_img(string $data, int $size): string {
   <div class="row g-3 mb-3">
 
     <!-- オンライン接続URL -->
-    <div class="col-12 col-lg-4">
-      <div class="card h-100">
+    <div class="col-12 col-lg">
+      <div class="card">
         <div class="card-header fw-bold d-flex align-items-center">
           オンライン接続URL
           <span class="badge <?= $online_available ? 'bg-success' : 'bg-secondary' ?> ms-auto">
@@ -152,8 +152,8 @@ function qr_img(string $data, int $size): string {
     </div>
 
     <!-- ローカル接続URL -->
-    <div class="col-12 col-lg-4">
-      <div class="card h-100">
+    <div id="col-local" class="col-12 <?= $online_available ? 'col-lg-auto' : 'col-lg' ?>">
+      <div class="card">
         <div class="card-header fw-bold d-flex align-items-center">
           ローカル接続URL <small class="text-muted fw-normal ms-2">同じWiFi内</small>
           <?php if ($online_available): ?>
@@ -206,8 +206,8 @@ function qr_img(string $data, int $size): string {
     </div>
 
     <!-- WiFi接続情報 -->
-    <div class="col-12 col-lg-4">
-      <div class="card h-100">
+    <div class="col-12 col-lg">
+      <div class="card">
         <div class="card-header fw-bold">WiFi接続情報</div>
         <div class="card-body">
           <form method="GET" class="mb-3">
@@ -264,9 +264,18 @@ function qr_img(string $data, int $size): string {
 (function () {
   var body = document.getElementById('localUrlBody');
   var btn  = document.getElementById('localToggleBtn');
-  if (!body || !btn) return;
-  body.addEventListener('show.bs.collapse', function () { btn.textContent = '非表示'; });
-  body.addEventListener('hide.bs.collapse', function () { btn.textContent = '表示'; });
+  var col  = document.getElementById('col-local');
+  if (!body || !btn || !col) return;
+  body.addEventListener('show.bs.collapse', function () {
+    btn.textContent = '非表示';
+    col.classList.remove('col-lg-auto');
+    col.classList.add('col-lg');
+  });
+  body.addEventListener('hide.bs.collapse', function () {
+    btn.textContent = '表示';
+    col.classList.remove('col-lg');
+    col.classList.add('col-lg-auto');
+  });
 })();
 </script>
 <?php endif; ?>

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -98,17 +98,20 @@ function qr_img(string $data, int $size): string {
 .qr-wrap { background:#fff; display:inline-block; padding:4px; border-radius:4px; }
 .url-display { font-family: monospace; font-size:.85rem; word-break:break-all; }
 .card-header .hd-short { display: none; }
-.card-vtab { height: 100%; cursor: pointer; }
-.card-vtab .card-header {
-  writing-mode: vertical-rl;
-  min-height: 5rem;
-  padding: .5rem !important;
-  justify-content: center;
-  user-select: none;
-  letter-spacing: .05em;
+.card-vtab { cursor: pointer; }
+@media (min-width: 992px) {
+  .card-vtab { height: 100%; }
+  .card-vtab .card-header {
+    writing-mode: vertical-rl;
+    min-height: 5rem;
+    padding: .5rem !important;
+    justify-content: center;
+    user-select: none;
+    letter-spacing: .05em;
+  }
+  .card-vtab .card-header .hd-full { display: none !important; }
+  .card-vtab .card-header .hd-short { display: block; }
 }
-.card-vtab .card-header .hd-full { display: none !important; }
-.card-vtab .card-header .hd-short { display: block; }
 </style>
 </head>
 <body>

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -184,7 +184,7 @@ $wifi_open   = true;
            aria-labelledby="headingLocal">
         <div class="accordion-body">
           <?php if ($has_local_url): ?>
-          <div class="row g-3">
+          <div class="row g-3 justify-content-center">
             <?php if ($localname_valid): ?>
             <div class="col-md-6">
               <div class="card h-100">

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -144,7 +144,7 @@ function qr_img(string $data, int $size): string {
               <?= $online_available ? '接続可' : '未接続' ?>
             </span>
           </span>
-          <span class="hd-short">Online</span>
+          <span class="hd-short">オンライン接続URL</span>
         </div>
         <div id="onlineUrlBody" class="collapse <?= $online_available ? 'show' : '' ?>">
         <div class="card-body">
@@ -179,7 +179,7 @@ function qr_img(string $data, int $size): string {
           <span class="hd-full d-flex align-items-center w-100">
             ローカル接続URL <small class="text-muted fw-normal ms-2">同じWiFi内</small>
           </span>
-          <span class="hd-short">Local</span>
+          <span class="hd-short">ローカル接続URL</span>
         </div>
         <div id="localUrlBody" class="collapse <?= !$online_available ? 'show' : '' ?>">
         <div class="card-body">

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -133,7 +133,7 @@ function qr_img(string $data, int $size): string {
   <div class="row g-3 mb-3">
 
     <!-- オンライン接続URL -->
-    <div id="col-online" class="col-12 <?= $online_available ? 'col-lg order-lg-1' : 'col-lg-auto order-lg-5' ?>">
+    <div id="col-online" class="col-12 <?= $online_available ? 'col-lg order-lg-1' : 'col-lg-auto order-lg-last' ?>">
       <div class="<?= $online_available ? 'card' : 'card card-vtab' ?>">
         <div class="card-header fw-bold d-flex align-items-center"
              style="cursor:pointer" data-bs-toggle="collapse" data-bs-target="#onlineUrlBody"
@@ -171,7 +171,7 @@ function qr_img(string $data, int $size): string {
     </div>
 
     <!-- ローカル接続URL -->
-    <div id="col-local" class="col-12 <?= $online_available ? 'col-lg-auto order-lg-4' : 'col-lg order-lg-2' ?>">
+    <div id="col-local" class="col-12 <?= $online_available ? 'col-lg-auto order-lg-last' : 'col-lg order-lg-2' ?>">
       <div class="<?= $online_available ? 'card card-vtab' : 'card' ?>">
         <div class="card-header fw-bold d-flex align-items-center"
              style="cursor:pointer" data-bs-toggle="collapse" data-bs-target="#localUrlBody"
@@ -234,9 +234,15 @@ function qr_img(string $data, int $size): string {
     </div>
 
     <!-- WiFi接続情報 -->
-    <div class="col-12 col-lg order-lg-3">
-      <div class="card">
-        <div class="card-header fw-bold">WiFi接続情報</div>
+    <div id="col-wifi" class="col-12 <?= !empty($wifi_ssid) ? 'col-lg order-lg-3' : 'col-lg-auto order-lg-last' ?>">
+      <div class="<?= !empty($wifi_ssid) ? 'card' : 'card card-vtab' ?>">
+        <div class="card-header fw-bold d-flex align-items-center"
+             style="cursor:pointer" data-bs-toggle="collapse" data-bs-target="#wifiUrlBody"
+             aria-expanded="<?= !empty($wifi_ssid) ? 'true' : 'false' ?>" aria-controls="wifiUrlBody">
+          <span class="hd-full">WiFi接続情報</span>
+          <span class="hd-short">WiFi接続情報</span>
+        </div>
+        <div id="wifiUrlBody" class="collapse <?= !empty($wifi_ssid) ? 'show' : '' ?>">
         <div class="card-body">
           <!-- QRコード（上部） -->
           <?php if (!empty($wifi_ssid)): ?>
@@ -270,6 +276,7 @@ function qr_img(string $data, int $size): string {
             <button type="submit" class="btn btn-primary btn-sm w-100">保存</button>
           </form>
         </div>
+        </div><!-- /#wifiUrlBody -->
       </div>
     </div>
 
@@ -291,24 +298,25 @@ function qr_img(string $data, int $size): string {
 <?php print_bg_style_block(true); ?>
 <script>
 (function () {
-  function setupCol(bodyId, colId, expandOrder, collapseOrder) {
+  function setupCol(bodyId, colId, expandOrder) {
     var body = document.getElementById(bodyId);
     var col  = document.getElementById(colId);
     if (!body || !col) return;
     var card = col.querySelector('.card');
     body.addEventListener('show.bs.collapse', function () {
-      col.classList.remove('col-lg-auto', 'order-lg-' + collapseOrder);
+      col.classList.remove('col-lg-auto', 'order-lg-last');
       col.classList.add('col-lg', 'order-lg-' + expandOrder);
       if (card) card.classList.remove('card-vtab');
     });
     body.addEventListener('hide.bs.collapse', function () {
       col.classList.remove('col-lg', 'order-lg-' + expandOrder);
-      col.classList.add('col-lg-auto', 'order-lg-' + collapseOrder);
+      col.classList.add('col-lg-auto', 'order-lg-last');
       if (card) card.classList.add('card-vtab');
     });
   }
-  setupCol('onlineUrlBody', 'col-online', 1, 5);
-  setupCol('localUrlBody',  'col-local',  2, 4);
+  setupCol('onlineUrlBody', 'col-online', 1);
+  setupCol('localUrlBody',  'col-local',  2);
+  setupCol('wifiUrlBody',   'col-wifi',   3);
 })();
 </script>
 </body>

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -97,6 +97,18 @@ function qr_img(string $data, int $size): string {
 <style>
 .qr-wrap { background:#fff; display:inline-block; padding:4px; border-radius:4px; }
 .url-display { font-family: monospace; font-size:.85rem; word-break:break-all; }
+.card-header .hd-short { display: none; }
+.card-vtab { height: 100%; cursor: pointer; }
+.card-vtab .card-header {
+  writing-mode: vertical-rl;
+  min-height: 5rem;
+  padding: .5rem !important;
+  justify-content: center;
+  user-select: none;
+  letter-spacing: .05em;
+}
+.card-vtab .card-header .hd-full { display: none !important; }
+.card-vtab .card-header .hd-short { display: block; }
 </style>
 </head>
 <body>
@@ -121,14 +133,20 @@ function qr_img(string $data, int $size): string {
   <div class="row g-3 mb-3">
 
     <!-- オンライン接続URL -->
-    <div class="col-12 col-lg">
-      <div class="card">
-        <div class="card-header fw-bold d-flex align-items-center">
-          オンライン接続URL
-          <span class="badge <?= $online_available ? 'bg-success' : 'bg-secondary' ?> ms-auto">
-            <?= $online_available ? '接続可' : '未接続' ?>
+    <div id="col-online" class="col-12 <?= $online_available ? 'col-lg order-lg-1' : 'col-lg-auto order-lg-5' ?>">
+      <div class="<?= $online_available ? 'card' : 'card card-vtab' ?>">
+        <div class="card-header fw-bold d-flex align-items-center"
+             style="cursor:pointer" data-bs-toggle="collapse" data-bs-target="#onlineUrlBody"
+             aria-expanded="<?= $online_available ? 'true' : 'false' ?>" aria-controls="onlineUrlBody">
+          <span class="hd-full d-flex align-items-center w-100">
+            オンライン接続URL
+            <span class="badge <?= $online_available ? 'bg-success' : 'bg-secondary' ?> ms-2">
+              <?= $online_available ? '接続可' : '未接続' ?>
+            </span>
           </span>
+          <span class="hd-short">Online</span>
         </div>
+        <div id="onlineUrlBody" class="collapse <?= $online_available ? 'show' : '' ?>">
         <div class="card-body">
           <?php if ($online_available): ?>
             <div class="text-center mb-2">
@@ -148,21 +166,22 @@ function qr_img(string $data, int $size): string {
             <p class="text-muted small mb-0">オンライン接続URLは設定されていません。管理画面（init.php）で設定できます。</p>
           <?php endif; ?>
         </div>
+        </div><!-- /#onlineUrlBody -->
       </div>
     </div>
 
     <!-- ローカル接続URL -->
-    <div id="col-local" class="col-12 <?= $online_available ? 'col-lg-auto' : 'col-lg' ?>">
-      <div class="card">
-        <div class="card-header fw-bold d-flex align-items-center">
-          ローカル接続URL <small class="text-muted fw-normal ms-2">同じWiFi内</small>
-          <?php if ($online_available): ?>
-          <button id="localToggleBtn" class="btn btn-sm btn-outline-secondary ms-auto collapsed"
-                  type="button" data-bs-toggle="collapse" data-bs-target="#localUrlBody"
-                  aria-expanded="false" aria-controls="localUrlBody">表示</button>
-          <?php endif; ?>
+    <div id="col-local" class="col-12 <?= $online_available ? 'col-lg-auto order-lg-4' : 'col-lg order-lg-2' ?>">
+      <div class="<?= $online_available ? 'card card-vtab' : 'card' ?>">
+        <div class="card-header fw-bold d-flex align-items-center"
+             style="cursor:pointer" data-bs-toggle="collapse" data-bs-target="#localUrlBody"
+             aria-expanded="<?= $online_available ? 'false' : 'true' ?>" aria-controls="localUrlBody">
+          <span class="hd-full d-flex align-items-center w-100">
+            ローカル接続URL <small class="text-muted fw-normal ms-2">同じWiFi内</small>
+          </span>
+          <span class="hd-short">Local</span>
         </div>
-        <div id="localUrlBody" class="<?= $online_available ? 'collapse' : '' ?>">
+        <div id="localUrlBody" class="collapse <?= !$online_available ? 'show' : '' ?>">
         <div class="card-body">
           <?php if ($has_local_url): ?>
             <?php if ($localname_valid): ?>
@@ -206,7 +225,7 @@ function qr_img(string $data, int $size): string {
     </div>
 
     <!-- WiFi接続情報 -->
-    <div class="col-12 col-lg">
+    <div class="col-12 col-lg order-lg-3">
       <div class="card">
         <div class="card-header fw-bold">WiFi接続情報</div>
         <div class="card-body">
@@ -259,25 +278,27 @@ function qr_img(string $data, int $size): string {
 </div>
 
 <?php print_bg_style_block(true); ?>
-<?php if ($online_available): ?>
 <script>
 (function () {
-  var body = document.getElementById('localUrlBody');
-  var btn  = document.getElementById('localToggleBtn');
-  var col  = document.getElementById('col-local');
-  if (!body || !btn || !col) return;
-  body.addEventListener('show.bs.collapse', function () {
-    btn.textContent = '非表示';
-    col.classList.remove('col-lg-auto');
-    col.classList.add('col-lg');
-  });
-  body.addEventListener('hide.bs.collapse', function () {
-    btn.textContent = '表示';
-    col.classList.remove('col-lg');
-    col.classList.add('col-lg-auto');
-  });
+  function setupCol(bodyId, colId, expandOrder, collapseOrder) {
+    var body = document.getElementById(bodyId);
+    var col  = document.getElementById(colId);
+    if (!body || !col) return;
+    var card = col.querySelector('.card');
+    body.addEventListener('show.bs.collapse', function () {
+      col.classList.remove('col-lg-auto', 'order-lg-' + collapseOrder);
+      col.classList.add('col-lg', 'order-lg-' + expandOrder);
+      if (card) card.classList.remove('card-vtab');
+    });
+    body.addEventListener('hide.bs.collapse', function () {
+      col.classList.remove('col-lg', 'order-lg-' + expandOrder);
+      col.classList.add('col-lg-auto', 'order-lg-' + collapseOrder);
+      if (card) card.classList.add('card-vtab');
+    });
+  }
+  setupCol('onlineUrlBody', 'col-online', 1, 5);
+  setupCol('localUrlBody',  'col-local',  2, 4);
 })();
 </script>
-<?php endif; ?>
 </body>
 </html>

--- a/toolinfo.php
+++ b/toolinfo.php
@@ -29,7 +29,7 @@ $online_available = false;
 $globalurl        = '';
 if (!empty($globalhost) && $config_ini['connectinternet'] == 1) {
     $checkurl = 'http://' . $globalhost;
-    $ret = file_get_html_with_retry($checkurl, 1, 5);
+    $ret = file_get_html_with_retry($checkurl, 2, 3);
     if ($ret !== false) {
         $online_available = true;
     }


### PR DESCRIPTION
## 概要
接続情報表示ページ（toolinfo.php）の全面改良。Bootstrap 5への移行、WiFi自動接続QRコード機能、GD拡張不要なSVG QRコード生成を実装。

## 主な変更

### 画面レイアウト
- **PC表示（lg以上）**: 3カラム横並び
  - オンライン接続可時：[オンライン接続URL] [WiFi接続情報] [ローカル接続URL（縦タブ）]
  - オンライン接続不可時：[ローカル接続URL] [WiFi接続情報] [オンライン接続URL（縦タブ）]
- **モバイル表示（lg未満）**: 縦積み表示（タイトルは横書き）
- 各カラムはクリックで展開/折りたたみ可能

### 機能
1. **WiFi自動接続QRコード**
   - SSID・パスワードをフォームで入力し、WiFi自動接続用QRコード生成
   - `WIFI:T:WPA;S:<SSID>;P:<PASSWORD>;;` 形式、特殊文字エスケープ対応

2. **GD不要なSVG QRコード**
   - 新規エンドポイント: `qrcode_php/outputqrsvg.php`
   - 既存 `Qrcode` クラスのマトリクス計算を再利用し、SVG描画出力
   - パラメータ: `data` (URL-encoded), `qrsize` (1-16, モジュール幅px)

3. **ローカルIP一覧の共通化**
   - `ipconfig.php` に `getiplinks()` / `print_iplist()` 関数を追加
   - IPv4常時表示、IPv6は折りたたみ（初期非表示）
   - 3ファイルで統一適用：toolinfo.php / pfwd_settings.php / init.php

4. **フィルタリング**
   - ローカルループバック除外（127.0.0.1, ::1）
   - IPv6アドレス除外（ローカルURL候補）
   - localhost ホスト名除外
   - ホスト名とIPが同一URL時は重複排除

5. **UI/UX改良**
   - QRコードを各カード上部に統一配置、URLコピー機能は下部
   - 折りたたみ時は縦書きタブ（PC）で右端へ移動して視認性向上
   - オンライン接続可時はローカル接続URL初期非表示
   - オンライン判定タイムアウト 3秒×2回

## ファイル変更
- `toolinfo.php` - 全面書き直し（BS5化、QRコード、折りたたみ機能）
- `qrcode_php/outputqrsvg.php` - 新規作成（SVG QRコード生成）
- `ipconfig.php` - `getiplinks()` / `print_iplist()` 関数追加
- `pfwd_settings.php` - 自IP一覧を共通関数に変更
- `init.php` - 自IP一覧を共通関数に変更

## テスト状況
- PC（1280×800）表示確認 ✓
  - オンライン接続可：初期展開状態、折りたたみ・展開動作
  - Local/WiFiタブの動作確認
- モバイル（390×844）表示確認 ✓
  - 縦積み表示、タイトル横書き表示
- ローカルIP検出テスト（192.168.1.157）✓
  - ホスト名・IPアドレスのQRコード同時表示
  - 重複排除ロジック正常動作

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)