### PR TITLE
feat: ZIP展開をPowerShellフォールバック対応＋インストーラでzip拡張を自動有効化

### DIFF
--- a/InnoSetupScript.iss
+++ b/InnoSetupScript.iss
@@ -5,7 +5,7 @@
 
 
 [Setup]
-AppName=u‚ä‚©‚èvUniversal KAraoke REquest Web tool
+AppName=ï¿½uï¿½ä‚©ï¿½ï¿½vUniversal KAraoke REquest Web tool
 AppVersion=0.09.9
 DefaultDirName=C:\xampp\htdocs
 UsePreviousAppDir=yes
@@ -26,8 +26,8 @@ AppPublisherURL=https://github.com/bee7813993/KaraokeRequestorWeb
 Name: japanese; MessagesFile: compiler:Languages\Japanese.isl 
 
 [Messages]
-WelcomeLabel2=‚±‚ÌƒvƒƒOƒ‰ƒ€‚Í‚²g—p‚ÌƒRƒ“ƒsƒ…[ƒ^[‚Ö [name/ver] ‚ğƒCƒ“ƒXƒg[ƒ‹‚µ‚Ü‚·B%n%n‚±‚ÌƒvƒƒOƒ‰ƒ€‚ÌÀs‚É‚Í–‘O‚Éxampp‚ğƒCƒ“ƒXƒg[ƒ‹‚µ‚Ä‚¨‚­•K—v‚ª‚ ‚è‚Ü‚·B%n(Œã‚©‚çxampp‚ğƒCƒ“ƒXƒg[ƒ‹‚µ‚æ‚¤‚Æ‚·‚é‚Æxampp‚ÌƒZƒbƒgƒAƒbƒv‚ª¸”s‚µ‚Ü‚·)%nhttps://www.apachefriends.org/jp/index.html
-SelectDirLabel3=[name] ‚ğƒCƒ“ƒXƒg[ƒ‹‚·‚éXAMPP‚ğƒCƒ“ƒXƒg[ƒ‹‚µ‚½ƒtƒHƒ‹ƒ_“à‚ÌhtdocsƒtƒHƒ‹ƒ_‚ğw’è‚µ‚ÄAuŸ‚Öv‚ğƒNƒŠƒbƒN‚µ‚Ä‚­‚¾‚³‚¢B
+WelcomeLabel2=ï¿½ï¿½ï¿½Ìƒvï¿½ï¿½ï¿½Oï¿½ï¿½ï¿½ï¿½ï¿½Í‚ï¿½ï¿½gï¿½pï¿½ÌƒRï¿½ï¿½ï¿½sï¿½ï¿½ï¿½[ï¿½^ï¿½[ï¿½ï¿½ [name/ver] ï¿½ï¿½ï¿½Cï¿½ï¿½ï¿½Xï¿½gï¿½[ï¿½ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B%n%nï¿½ï¿½ï¿½Ìƒvï¿½ï¿½ï¿½Oï¿½ï¿½ï¿½ï¿½ï¿½Ìï¿½ï¿½sï¿½É‚Íï¿½ï¿½Oï¿½ï¿½xamppï¿½ï¿½ï¿½Cï¿½ï¿½ï¿½Xï¿½gï¿½[ï¿½ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ï¿½Kï¿½vï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B%n(ï¿½ã‚©ï¿½ï¿½xamppï¿½ï¿½ï¿½Cï¿½ï¿½ï¿½Xï¿½gï¿½[ï¿½ï¿½ï¿½ï¿½ï¿½æ‚¤ï¿½Æ‚ï¿½ï¿½ï¿½ï¿½xamppï¿½ÌƒZï¿½bï¿½gï¿½Aï¿½bï¿½vï¿½ï¿½ï¿½ï¿½ï¿½sï¿½ï¿½ï¿½Ü‚ï¿½)%nhttps://www.apachefriends.org/jp/index.html
+SelectDirLabel3=[name] ï¿½ï¿½ï¿½Cï¿½ï¿½ï¿½Xï¿½gï¿½[ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½XAMPPï¿½ï¿½ï¿½Cï¿½ï¿½ï¿½Xï¿½gï¿½[ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½tï¿½Hï¿½ï¿½ï¿½_ï¿½ï¿½ï¿½ï¿½htdocsï¿½tï¿½Hï¿½ï¿½ï¿½_ï¿½ï¿½ï¿½wï¿½è‚µï¿½ÄAï¿½uï¿½ï¿½ï¿½Övï¿½ï¿½ï¿½Nï¿½ï¿½ï¿½bï¿½Nï¿½ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½B
 
 [Files]
 ;;Source: "package\xampp-win32-5.6.12-0-VC11-installer.exe"; DestDir: {tmp}; Components: xampp
@@ -45,7 +45,7 @@ Source: "cms\*"; DestDir: "{app}\cms"; Flags: IgnoreVersion; Components: main
 Source: "video-js\*"; DestDir: "{app}\js"; Flags: IgnoreVersion; Components: main
 Source: "modules\*"; DestDir: "{app}\modules"; Flags: IgnoreVersion; Components: main
 Source: "notfoundrequest\*.php"; DestDir: "{app}\notfoundrequest"; Flags: IgnoreVersion; Components: main
-Source: "ƒjƒRƒJƒ‰ƒRƒƒ“ƒgPlayer2.exe"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
+Source: "ï¿½jï¿½Rï¿½Jï¿½ï¿½ï¿½Rï¿½ï¿½ï¿½ï¿½ï¿½gPlayer2.exe"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
 Source: "ini.ini"; DestDir: "{app}"; Flags: onlyifdoesntexist; Components: main
 Source: "foobar2000\*"; DestDir: "{app}\foobar2000";Flags: IgnoreVersion recursesubdirs; Components: main
 Source: "commentPlayer\*"; DestDir: "{app}\commentPlayer";Flags: IgnoreVersion recursesubdirs; Components: main
@@ -72,3 +72,28 @@ Name: main;  Description: main files ; Types: full compact custom; Flags: fixed
 
 [Icons]
 Name: "{group}\KaraokeRequestorWeb for xampp"; Filename: "{app}\krw.ico"
+
+[code]
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  phpIni: String;
+  content: AnsiString;
+begin
+  if CurStep = ssPostInstall then
+  begin
+    phpIni := ExpandConstant('C:\xampp\php\php.ini');
+    if FileExists(phpIni) then
+    begin
+      if LoadStringFromFile(phpIni, content) then
+      begin
+        // Enable the php zip extension (required by the ZIP update method).
+        // Idempotent: append only when missing, otherwise uncomment.
+        if Pos('extension=zip', content) = 0 then
+          content := content + #13#10 + 'extension=zip' + #13#10
+        else
+          StringChangeEx(content, ';extension=zip', 'extension=zip', True);
+        SaveStringToFile(phpIni, content, False);
+      end;
+    end;
+  end;
+end;

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2385,13 +2385,60 @@ function _kara_http_get($url, &$errmsg) {
 }
 
 function check_zip_update_available() {
-    if (!class_exists('ZipArchive')) {
-        return 'PHP の ZipArchive 拡張が無効です (php.ini で extension=zip を有効化してください)';
+    if (!zip_extract_available()) {
+        return 'ZIP 展開手段がありません (php.ini で extension=zip を有効化するか、PowerShell が利用できる Windows 環境が必要です)';
     }
     if (!function_exists('curl_init') && !ini_get('allow_url_fopen')) {
         return 'curl または allow_url_fopen が必要です';
     }
     return true;
+}
+
+// ZIP 展開が可能か（ZipArchive または PowerShell Expand-Archive）
+function zip_extract_available() {
+    if (class_exists('ZipArchive')) return true;
+    return is_powershell_available();
+}
+
+// PowerShell が利用可能か（Windows 環境を想定）
+function is_powershell_available() {
+    if (stripos(PHP_OS, 'WIN') !== 0) return false;
+    if (!function_exists('exec')) return false;
+    @exec('powershell -NoProfile -Command "exit 0" 2>&1', $out, $ret);
+    return ($ret === 0);
+}
+
+// ZIP ファイルを展開先へ展開。ZipArchive 優先、無ければ PowerShell にフォールバック。
+function extract_zip_archive($zip_file, $extract_dir, &$errmsg = '') {
+    if (!is_dir($extract_dir)) {
+        @mkdir($extract_dir, 0700, true);
+    }
+    if (class_exists('ZipArchive')) {
+        $zip = new ZipArchive();
+        if ($zip->open($zip_file) !== true) {
+            $errmsg = 'ZIP の展開に失敗しました (ZipArchive)';
+            return false;
+        }
+        $zip->extractTo($extract_dir);
+        $zip->close();
+        return true;
+    }
+    if (is_powershell_available()) {
+        // Expand-Archive は PowerShell 5.0+ (Windows 10 / Server 2016 以降は標準)
+        $cmd = 'powershell -NoProfile -ExecutionPolicy Bypass -Command '
+             . escapeshellarg(
+                 "Expand-Archive -LiteralPath '" . $zip_file . "' "
+               . "-DestinationPath '" . $extract_dir . "' -Force"
+             );
+        @exec($cmd . ' 2>&1', $out, $ret);
+        if ($ret !== 0) {
+            $errmsg = 'ZIP の展開に失敗しました (PowerShell): ' . implode(' / ', $out);
+            return false;
+        }
+        return true;
+    }
+    $errmsg = 'ZIP を展開する手段がありません';
+    return false;
 }
 
 // アップデート取得元リポジトリ（owner/repo）を config から取得。未設定時は既定値。
@@ -2512,16 +2559,11 @@ function update_fromarchive($version_str, &$errmsg) {
     file_put_contents($zip_file, $data);
     unset($data);
 
-    $zip = new ZipArchive();
-    if ($zip->open($zip_file) !== true) {
+    $extract_dir = $tmp_dir . DIRECTORY_SEPARATOR . 'extracted';
+    if (!extract_zip_archive($zip_file, $extract_dir, $errmsg)) {
         _kara_update_cleanup($tmp_dir);
-        $errmsg = 'ZIP の展開に失敗しました';
         return false;
     }
-    $extract_dir = $tmp_dir . DIRECTORY_SEPARATOR . 'extracted';
-    mkdir($extract_dir, 0700, true);
-    $zip->extractTo($extract_dir);
-    $zip->close();
 
     // アーカイブ内のトップレベルディレクトリを探す
     $source_dir = null;


### PR DESCRIPTION
## 概要

PHP の `ZipArchive` 拡張が無効な環境でも ZIP アップデート方式が使えるよう PowerShell フォールバックを追加し、新規インストール時には InnoSetup インストーラが php.ini の zip 拡張を自動的に有効化するようにしました。

## 変更内容

### commonfunc.php
- `zip_extract_available()` 追加: `ZipArchive` または PowerShell Expand-Archive のどちらかが使えるか判定
- `is_powershell_available()` 追加: Windows 環境で PowerShell が実行可能か確認
- `extract_zip_archive()` 追加: ZipArchive 優先、使えない場合は `powershell Expand-Archive` にフォールバック
- `check_zip_update_available()` / `update_fromarchive()` を上記の新関数に対応

### InnoSetupScript.iss
- `[code]` セクションを追加
- インストール後 (`ssPostInstall`) に `C:\xampp\php\php.ini` の `;extension=zip` を自動的にコメント解除（または末尾に追記）
- 冪等な実装: 既に `extension=zip` が有効な場合は変更しない

## 対象ユーザー

| ケース | 対応方法 |
|---|---|
| 新規インストール (最新 XAMPP) | インストーラが php.ini を自動修正 |
| 既存ユーザー (zip 無効) | PowerShell Expand-Archive でフォールバック |
| 既存ユーザー (zip 有効) | 従来通り ZipArchive を使用 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtfAeuJe4cqWkxxWnFPuUk)_