### PR TITLE
fix: 曲名・歌手名ソートで大文字小文字を同一扱いに（COLLATE NOCASE）

### DIFF
--- a/search_listerdb_songlist_json.php
+++ b/search_listerdb_songlist_json.php
@@ -388,7 +388,10 @@ $select_where = $select_where . ' GROUP BY song_name, program_name';
 
 
 if (!empty($select_orderby) ){
-    $select_where = $select_where .  ' ORDER BY '. $select_orderby . ' ' . $select_scending ;
+    // テキストカラムは大文字小文字を同一扱いにする
+    $orderby_sql = preg_replace('/\bsong_name\b/', 'song_name COLLATE NOCASE', $select_orderby);
+    $orderby_sql = preg_replace('/\bsong_artist\b/', 'song_artist COLLATE NOCASE', $orderby_sql);
+    $select_where = $select_where .  ' ORDER BY '. $orderby_sql . ' ' . $select_scending ;
 }
 
 if(!empty($select_where) ){


### PR DESCRIPTION
## Summary

- `search_listerdb_songlist_json.php` の ORDER BY 句に `COLLATE NOCASE` を追加
- 曲名（`song_name`）・歌手名（`song_artist`）のソート時に大文字・小文字を同一扱いにする
- 修正前：大文字グループ（A→Z）と小文字グループ（a→z）が分離してソートされていた
- 修正後：`My Best Friend` → `my song` → `My Wish` のように自然なアルファベット順になる

## Test plan

- [ ] `search_listerdb_songlist_bs5.php` で作品名を指定し、曲名昇順ソートを実行
- [ ] 大文字・小文字が混在する英語曲名が正しくアルファベット順に並ぶことを確認
- [ ] 歌手名ソートでも同様に動作することを確認
- [ ] 日本語曲名のソートに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)