### PR TITLE
fix: ListerDB未生成・生成中の状態を検索画面に表示

### DIFF
--- a/css/themes/search.css
+++ b/css/themes/search.css
@@ -402,6 +402,10 @@ table.searchresult tbody td {
   margin-bottom: var(--space-4);
   font-size: 0.9rem;
 }
+.notice-box--warning {
+  border-left-color: #e67e22;
+  background: color-mix(in srgb, #e67e22 8%, var(--bg-card-alt));
+}
 
 /* --- モバイル --- */
 @media (max-width: 767px) {

--- a/search_listerdb_commonfunc_bs5.php
+++ b/search_listerdb_commonfunc_bs5.php
@@ -20,6 +20,22 @@ function headerlistcheck_column($oneheaderlist,$headerlist,$key){
 }
 
 
+function listerdb_is_generating() {
+    global $config_ini;
+    $lister_dbpath = 'list\List.sqlite3';
+    if (array_key_exists('listerDBPATH', $config_ini)) {
+        $lister_dbpath = urldecode($config_ini['listerDBPATH']);
+    }
+    if (!file_exists($lister_dbpath)) return false;
+    try {
+        $pdo = new PDO('sqlite:' . $lister_dbpath);
+        $row = $pdo->query("SELECT 1 FROM t_found WHERE song_name != '' LIMIT 1")->fetch();
+        return ($row === false);
+    } catch (Exception $e) {
+        return false;
+    }
+}
+
 function showuppermenu($target, $linkoption) {
     $items = [
         ['key' => 'filename',         'label' => '詳細検索（キーワード）', 'href' => 'search_listerdb_anysearch_index.php?' . $linkoption],
@@ -42,6 +58,14 @@ function showuppermenu($target, $linkoption) {
     print '</div>';
     print '</div>';
     print '</div>';
+
+    if (listerdb_is_generating()) {
+        print '<div class="container mt-2">';
+        print '<div class="notice-box notice-box--warning" role="status">';
+        print 'ゆかりすたーがDBを生成中です。現在はファイル名でのみ検索できます。';
+        print '</div>';
+        print '</div>';
+    }
 }
 
 function buildgetquery($queries){

--- a/search_listerdb_head_json.php
+++ b/search_listerdb_head_json.php
@@ -17,12 +17,21 @@ if(array_key_exists("list", $_REQUEST)) {
     $list = $_REQUEST["list"];
 }
 
+header('Content-Type: application/json; charset=utf-8');
+
+// DBファイル存在確認
+if (!file_exists($lister_dbpath)) {
+    echo json_encode(['error' => 'db_not_found']);
+    exit;
+}
+
 // DB初期化
 $lister = new ListerDB();
 $lister->listerdbfile = $lister_dbpath;
 $listerdb = $lister->initdb();
 if( !$listerdb ) {
-    die();
+    echo json_encode(['error' => 'db_init_failed']);
+    exit;
 }
 
 if(!empty($list)) {
@@ -30,8 +39,8 @@ if(!empty($list)) {
   $sql = 'select DISTINCT program_category from t_found ;';
   $alldbdata =  $lister->select($sql);
   if($alldbdata === false){
-       print 'failed :'.$sql;
-       die();
+       echo json_encode(['error' => 'db_query_failed']);
+       exit;
   }
 
   $returnarray = $alldbdata;
@@ -51,8 +60,8 @@ if(!empty($list)) {
   $sql = 'select DISTINCT found_head from t_found '. $select_where.';';
   $alldbdata =  $lister->select($sql);
   if($alldbdata === false){
-     print $sql;
-     die();
+     echo json_encode(['error' => 'db_query_failed']);
+     exit;
   }
 
   $returnarray = array( "program_category" => $program_category, "data" => $alldbdata);

--- a/search_listerdb_program_index_bs5.php
+++ b/search_listerdb_program_index_bs5.php
@@ -49,6 +49,7 @@ function checkandbuild_headerlink($oneheader, $headlist, $lister_dbpath)
 
 function sortcategorylist($categorylist)
 {
+    if (!is_array($categorylist)) return [];
     $lister_config = parse_ini_file("listerdb_config.ini", true);
     if ($lister_config === false) return $categorylist;
     if (!array_key_exists("category_order", $lister_config)) return $categorylist;
@@ -146,11 +147,21 @@ $errmsg     = '';
 $categorylist = [];
 $geturl = 'http://localhost/search_listerdb_head_json.php?list=1';
 $categorylist_json = @file_get_contents($geturl);
-if (!$categorylist_json) {
-    $errmsg = 'カテゴリーリストの取得に失敗';
+if ($categorylist_json === false || $categorylist_json === '') {
+    $errmsg = 'カテゴリーリストの取得に失敗しました。';
 } else {
-    $categorylist = json_decode($categorylist_json, true);
-    if (!$categorylist) $errmsg = 'カテゴリーリストのJSON parse 失敗';
+    $decoded = json_decode($categorylist_json, true);
+    if ($decoded === null) {
+        $errmsg = 'カテゴリーリストの解析に失敗しました。';
+    } elseif (isset($decoded['error'])) {
+        if ($decoded['error'] === 'db_not_found') {
+            $errmsg = 'ListerDB（リスターのデータベースファイル）が見つかりません。ゆかりすたー等のツールでDBを生成してください。';
+        } else {
+            $errmsg = 'ListerDB エラー: ' . $decoded['error'];
+        }
+    } else {
+        $categorylist = $decoded;
+    }
 }
 $categorylist = sortcategorylist($categorylist);
 


### PR DESCRIPTION
## Summary

- ListerDBファイルが存在しない場合、PHPエラーではなく「DBファイルが見つかりません」のメッセージを表示するよう修正
- DB生成中（`song_name` が全行空の状態）を検知し、全リスターDB検索画面にオレンジの警告バナーを表示
- `search_listerdb_head_json.php` のエラー時レスポンスをJSONに統一（従来はエラーテキストが混入してJSON parseが失敗していた）

## Changes

- **`search_listerdb_head_json.php`**: DBファイル不在・クエリ失敗時にエラーテキストでなく `{"error":"..."}` JSONを返すよう修正
- **`search_listerdb_program_index_bs5.php`**: `error` キー検出時に分かりやすいメッセージを表示、`sortcategorylist()` の null 安全性を追加
- **`search_listerdb_commonfunc_bs5.php`**: `listerdb_is_generating()` を追加（`song_name != ''` の行が1件も存在しなければ生成中と判定）、`showuppermenu()` で生成中の場合に警告バナーを全ページに表示
- **`css/themes/search.css`**: `.notice-box--warning` モディファイアを追加（オレンジ左ボーダー）

## Test plan

- [x] DBファイルなし → 作品名インデックス画面に「DBファイルが見つかりません」メッセージ表示
- [x] DB生成中（`song_name` 空）→ 全リスターDB検索画面に「ゆかりすたーがDBを生成中です。現在はファイル名でのみ検索できます。」バナー表示（http://ykr.moe:11004/ にて実機確認済み）
- [x] DB完成後はバナーが自動的に消える（`song_name` に値が入れば非表示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)