### PR TITLE
オンラインアップデートのバージョン表示・ブランチ切り替え修正

### DIFF
--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2327,15 +2327,23 @@ function update_fromgit($version_str, &$errmsg){
               return false;
           }
 
-          $execcmd = $gitcmd.' reset --hard '.$version_str;
-          exec($execcmd,$result_str);
+          // origin/ プレフィックスあり → ブランチ切り替え (checkout -B)
+          // タグ / ハッシュ → 現在ブランチのまま reset --hard
+          $result_str = [];
+          if (strpos($version_str, 'origin/') === 0) {
+              $branch_name = substr($version_str, strlen('origin/'));
+              $execcmd = $gitcmd . ' checkout -B ' . escapeshellarg($branch_name) . ' ' . escapeshellarg($version_str);
+          } else {
+              $execcmd = $gitcmd . ' reset --hard ' . $version_str;
+          }
+          exec($execcmd, $result_str);
           foreach($result_str as $line){
               $err_str_pos = mb_strpos($line, "unknown revision");
               if( $err_str_pos  !== false) {
                   $errmsg .= "no version : $version_str";
                   $errorcnt ++;
               }else if (mb_strstr($line, "fatal") !== false) {
-                  $errmsg .= "reset --hard unknown error: $line";
+                  $errmsg .= "checkout/reset unknown error: $line";
                   $errorcnt ++;
               }
           }

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2347,9 +2347,29 @@ function update_fromgit($version_str, &$errmsg){
                   $errorcnt ++;
               }
           }
+
+          if ($errorcnt === 0) {
+              // タグを最新化してから version ファイルに書き込む
+              // shallow clone では git describe が失敗する場合があるため GitHub API でフォールバック
+              exec($gitcmd . ' fetch --tags origin 2>&1');
+              $desc = trim(exec($gitcmd . ' describe --tags 2>&1'));
+              $app_root = realpath(__DIR__);
+              if ($desc !== '' && mb_substr($desc, 0, 1) === 'v' && is_numeric(mb_substr($desc, 1, 1))) {
+                  file_put_contents($app_root . DIRECTORY_SEPARATOR . 'version', $desc);
+              } else {
+                  // shallow clone 等で describe 失敗 → GitHub API で取得
+                  $sha = trim(exec($gitcmd . ' rev-parse HEAD 2>&1'));
+                  if (preg_match('/^[0-9a-f]{40}$/', $sha)) {
+                      $api_ver = _kara_github_describe_version(get_update_repo(), $sha);
+                      if ($api_ver !== null) {
+                          file_put_contents($app_root . DIRECTORY_SEPARATOR . 'version', $api_ver);
+                      }
+                  }
+              }
+          }
       }
     }
-    
+
     if($errorcnt > 0) {
         return false;
     }

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2538,6 +2538,37 @@ function get_archive_taglist(&$errmsg = '') {
     return $taglist;
 }
 
+// GitHub API を使い git describe --tags 相当の文字列を返す。失敗時は null。
+function _kara_github_describe_version($repo, $ref) {
+    $dummy = '';
+    $data = _kara_http_get('https://api.github.com/repos/' . $repo . '/commits/' . rawurlencode($ref), $dummy);
+    if ($data === false) return null;
+    $commit_info = json_decode($data, true);
+    if (!is_array($commit_info) || empty($commit_info['sha'])) return null;
+
+    $full_sha  = $commit_info['sha'];
+    $short_sha = substr($full_sha, 0, 7);
+
+    $taglist = get_archive_taglist($dummy);
+    if (empty($taglist)) return null;
+
+    foreach ($taglist as $tag) {
+        $cdata = _kara_http_get(
+            'https://api.github.com/repos/' . $repo . '/compare/' . rawurlencode($tag) . '...' . $full_sha,
+            $dummy
+        );
+        if ($cdata === false) continue;
+        $compare = json_decode($cdata, true);
+        if (!is_array($compare)) continue;
+        $status   = $compare['status']    ?? '';
+        $ahead_by = (int)($compare['ahead_by'] ?? -1);
+        if ($status === 'identical') return $tag;
+        if ($status === 'ahead')     return $tag . '-' . $ahead_by . '-g' . $short_sha;
+        // behind / diverged は次のタグを試す
+    }
+    return null;
+}
+
 function _kara_update_copy_recursive($src, $dst, $exclude_list, $relative = '') {
     $entries = scandir($src);
     foreach ($entries as $entry) {
@@ -2662,8 +2693,9 @@ function update_fromarchive($version_str, &$errmsg) {
 
     _kara_update_copy_recursive($source_dir, $app_root, $exclude_list);
 
-    // バージョンファイルを更新
-    file_put_contents($app_root . DIRECTORY_SEPARATOR . 'version', $version_str);
+    // バージョンファイルを更新（git describe 相当の形式を GitHub API で取得）
+    $describe_ver = _kara_github_describe_version($repo, $vs);
+    file_put_contents($app_root . DIRECTORY_SEPARATOR . 'version', $describe_ver !== null ? $describe_ver : $version_str);
 
     _kara_update_cleanup($tmp_dir);
     return true;


### PR DESCRIPTION
## 概要

オンラインアップデート（`online_update.php`）の ZIP 方式・Git 方式に関する3件の不具合を修正します。

## 修正内容

### 1. ZIP方式更新後のバージョン表示が `master` になる問題

ZIP方式で更新すると `version` ファイルに単純に `"master"` と書き込まれ、ナビバーのバージョン表示が `master` になっていた。

**修正:** `_kara_github_describe_version()` 関数を新規追加。GitHub Compare API を使って更新後のコミットと最新タグの距離を計算し、`v0.09.9-alpha-12-g3a4b5c6` 形式で `version` ファイルに書き込む。API 失敗時は従来通りのリファレンス名にフォールバック。

### 2. Git方式でブランチ切り替えボタンを押してもブランチが変わらない問題

`git reset --hard origin/xxx` はワーキングツリーの内容を変えるだけで、現在のブランチ名は変わらない。

**修正:** `origin/` プレフィックスを持つバージョン指定（ブランチ操作）の場合は `git checkout -B <branch> origin/<branch>` を使うよう変更。タグ・コミットハッシュ指定は従来通り `reset --hard`。また `git fetch` の出力が次の `exec()` の `$result_str` に混入するバグも併せて修正。

### 3. Git方式で master に更新してもバージョンが変わらない（または古いタグ名のままになる）問題

`init_git_repo` が `--depth=1`（shallow clone）で初期化するため、`git describe --tags` がタグのあるコミットまで履歴を遡れずに失敗し、`version` ファイルの古い値がそのまま表示されていた。

**修正:** `update_fromgit` 成功後に以下の順で version ファイルを更新:
1. `git fetch --tags origin` でタグを最新化
2. `git describe --tags` を試行 → 成功すれば書き込む
3. shallow clone 等で失敗した場合は `git rev-parse HEAD` でSHAを取得し、GitHub API（`_kara_github_describe_version`）でバージョン文字列を取得して書き込む

## テスト計画

- [x] ZIP方式で master を更新 → バージョンが `v0.09.9-alpha-N-gXXXXXXX` 形式で表示されること
- [x] ZIP方式でタグ（例: `v0.09.9-alpha`）を適用 → バージョンがタグ名で表示されること
- [x] Git方式で別ブランチの「切替」ボタンを押す → ブランチが実際に切り替わること（ナビバーのバージョンが変わること）
- [x] Git方式で master を更新 → バージョンが `v0.09.9-alpha-N-gXXXXXXX` 形式で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVb1tCWckWqyTsL9BL5AvM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVb1tCWckWqyTsL9BL5AvM)_