### PR TITLE
feat: インストーラーを v0.10.0-beta 向けに全面刷新

### DIFF
--- a/InnoSetupScript.iss
+++ b/InnoSetupScript.iss
@@ -1,12 +1,9 @@
-; -- Example1.iss --
-; Demonstrates copying 3 files and creating an icon.
-
-; SEE THE DOCUMENTATION FOR DETAILS ON CREATING .ISS SCRIPT FILES!
-
+; -- InnoSetupScript.iss --
+; KaraokeRequestorWeb インストーラースクリプト
 
 [Setup]
-AppName=�u�䂩��vUniversal KAraoke REquest Web tool
-AppVersion=0.09.9
+AppName=ゆかりすたー Universal KAraoke REquest Web tool
+AppVersion=0.10.0-beta
 DefaultDirName=C:\xampp\htdocs
 UsePreviousAppDir=yes
 AppendDefaultDirName=no
@@ -14,86 +11,208 @@ DefaultGroupName=KaraokeRequestorWeb
 Compression=lzma2
 SolidCompression=yes
 OutputDir=userdocs:Inno Setup Examples Output
-;;SourceDir={userdocs}\GitHub\KaraokeRequestorWeb
-;;UninstallFilesDir={userdocs}\krw
 SetupIconFile=krw.ico
-;;CreateAppDir=no
 OutputBaseFilename=KaraokeRequestorWebSetup
 AppPublisher=KaraokeRequestorWeb
 AppPublisherURL=https://github.com/bee7813993/KaraokeRequestorWeb
 
 [Languages]
-Name: japanese; MessagesFile: compiler:Languages\Japanese.isl 
+Name: japanese; MessagesFile: compiler:Languages\Japanese.isl
 
 [Messages]
-WelcomeLabel2=���̃v���O�����͂��g�p�̃R���s���[�^�[�� [name/ver] ���C���X�g�[�����܂��B%n%n���̃v���O�����̎��s�ɂ͎��O��xampp���C���X�g�[�����Ă����K�v������܂��B%n(�ォ��xampp���C���X�g�[�����悤�Ƃ����xampp�̃Z�b�g�A�b�v�����s���܂�)%nhttps://www.apachefriends.org/jp/index.html
-SelectDirLabel3=[name] ���C���X�g�[������XAMPP���C���X�g�[�������t�H���_����htdocs�t�H���_���w�肵�āA�u���ցv���N���b�N���Ă��������B
+WelcomeLabel2=このプログラムはお使いのコンピューターに [name/ver] をインストールします。%n%nこのプログラムの実行には事前にxamppをインストールしておく必要があります。%n(後からxamppをインストールしようとするとxamppのセットアップが先に実行されます)%nhttps://www.apachefriends.org/jp/index.html
+SelectDirLabel3=[name] をインストールするXAMPPをインストールしたフォルダ内のhtdocsフォルダを指定して、「次へ」をクリックしてください。
 
 [Files]
-;;Source: "package\xampp-win32-5.6.12-0-VC11-installer.exe"; DestDir: {tmp}; Components: xampp
+; --- ルートファイル ---
 Source: "*.php"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
-Source: "version"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
+Source: "*.html"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
 Source: "*.bat"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
 Source: "*.js"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
+Source: "*.vbs"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
+Source: "*.txt"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
+Source: "version"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
 Source: "LICENSE"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
-Source: "css\*"; DestDir: "{app}\css"; Flags: IgnoreVersion; Components: main
-Source: "ddns\*"; DestDir: "{app}\ddns"; Flags: IgnoreVersion; Components: main
-Source: "images\*"; DestDir: "{app}\images"; Flags: IgnoreVersion; Components: main
-Source: "fonts\*"; DestDir: "{app}\fonts"; Flags: IgnoreVersion; Components: main
-Source: "js\*"; DestDir: "{app}\js"; Flags: IgnoreVersion; Components: main
-Source: "cms\*"; DestDir: "{app}\cms"; Flags: IgnoreVersion; Components: main
-Source: "video-js\*"; DestDir: "{app}\js"; Flags: IgnoreVersion; Components: main
-Source: "modules\*"; DestDir: "{app}\modules"; Flags: IgnoreVersion; Components: main
-Source: "notfoundrequest\*.php"; DestDir: "{app}\notfoundrequest"; Flags: IgnoreVersion; Components: main
-Source: "�j�R�J���R�����gPlayer2.exe"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
-Source: "ini.ini"; DestDir: "{app}"; Flags: onlyifdoesntexist; Components: main
-Source: "foobar2000\*"; DestDir: "{app}\foobar2000";Flags: IgnoreVersion recursesubdirs; Components: main
-Source: "commentPlayer\*"; DestDir: "{app}\commentPlayer";Flags: IgnoreVersion recursesubdirs; Components: main
+Source: "README.md"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
 Source: "krw.ico"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
 Source: "favicon.ico"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
 Source: ".htaccess"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
-Source: "gitbase\.git\*"; DestDir: "{app}\.git"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
-Source: "gitcmd\*"; DestDir: "{app}\gitcmd"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
-Source: "l-smash\*"; DestDir: "{app}\gitcmd"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
-Source: "pfwd_forykr\*"; DestDir: "{app}\pfwd_forykr"; Flags: IgnoreVersion; Components: main
-Source: "fonts\*"; DestDir: "{app}\fonts"; Flags: IgnoreVersion; Components: main
-Source: "qrcode_php\*"; DestDir: "{app}\qrcode_php"; Flags: IgnoreVersion; Components: main
-Source: "l-smash\*"; DestDir: "{app}\l-smash"; Flags: IgnoreVersion; Components: main
-Source: "cmd\*"; DestDir: "{app}\cmd"; Flags: IgnoreVersion; Components: main
-Source: "ignorecharlist.txt"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
+Source: "ini.ini"; DestDir: "{app}"; Flags: onlyifdoesntexist; Components: main
+Source: "search_sort_priority.json"; DestDir: "{app}"; Flags: onlyifdoesntexist; Components: main
+Source: "search_sort_priority_auth.json"; DestDir: "{app}"; Flags: onlyifdoesntexist; Components: main
+Source: "limitlist_sample.json"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
+
+; --- サブディレクトリ ---
+Source: "css\*"; DestDir: "{app}\css"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+Source: "js\*"; DestDir: "{app}\js"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+Source: "images\*"; DestDir: "{app}\images"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+Source: "fonts\*"; DestDir: "{app}\fonts"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+Source: "modules\*"; DestDir: "{app}\modules"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+Source: "cms\*"; DestDir: "{app}\cms"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+Source: "qrcode_php\*"; DestDir: "{app}\qrcode_php"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+Source: "ddns\*"; DestDir: "{app}\ddns"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+Source: "cmd\*"; DestDir: "{app}\cmd"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+Source: "l-smash\*"; DestDir: "{app}\l-smash"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+Source: "notfoundrequest\*"; DestDir: "{app}\notfoundrequest"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+Source: "samples\*"; DestDir: "{app}\samples"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+Source: "fortest\*"; DestDir: "{app}\fortest"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+Source: "test_race\*"; DestDir: "{app}\test_race"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+Source: "allinone\*"; DestDir: "{app}\allinone"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+
+; --- foobar2000（.gitignore除外分は手動で配置が必要）---
+Source: "foobar2000\*"; DestDir: "{app}\foobar2000"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+
+; --- 別途用意が必要なもの（リポジトリ管理外）---
+Source: "pfwd_forykr\*"; DestDir: "{app}\pfwd_forykr"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+;;Source: "gitcmd\*"; DestDir: "{app}\gitcmd"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+;;Source: "gitbase\.git\*"; DestDir: "{app}\.git"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
 
 [Run]
-;;Filename: "{tmp}\xampp-win32-5.6.12-0-VC11-installer.exe";  StatusMsg: "Installing xampp..."
+; 必要に応じてここに追加
 
 [Components]
-Name: main;  Description: main files ; Types: full compact custom; Flags: fixed
-;;Name: xampp; Description: xampp setup
-
+Name: main; Description: main files; Types: full compact custom; Flags: fixed
 
 [Icons]
 Name: "{group}\KaraokeRequestorWeb for xampp"; Filename: "{app}\krw.ico"
 
-[code]
-procedure CurStepChanged(CurStep: TSetupStep);
+[Code]
 var
-  phpIni: String;
-  content: AnsiString;
+  IsNewInstall: Boolean;
+
+// php.ini の指定 extension を有効化する
+// - コメントアウトされていれば解除
+// - 記述が一切なければ末尾に追記（PR #175 で追加されたフォールバック）
+// PHP 7.x 系: ;extension=php_gd2.dll のような形式
+// PHP 8.x 系: ;extension=gd のような形式
+procedure EnablePHPExtension(PhpIniPath: string; ExtName: string);
+var
+  Lines: TStringList;
+  I: Integer;
+  Line, Trimmed, Content: string;
+  SemiPos: Integer;
+  Modified, Found: Boolean;
 begin
-  if CurStep = ssPostInstall then
-  begin
-    phpIni := ExpandConstant('C:\xampp\php\php.ini');
-    if FileExists(phpIni) then
+  if not FileExists(PhpIniPath) then
+    Exit;
+
+  Modified := False;
+  Found    := False;
+  Lines := TStringList.Create;
+  try
+    Lines.LoadFromFile(PhpIniPath);
+    for I := 0 to Lines.Count - 1 do
     begin
-      if LoadStringFromFile(phpIni, content) then
+      Line    := Lines[I];
+      Trimmed := Trim(Line);
+
+      // すでに有効な行かチェック
+      if (LowerCase(Trimmed) = 'extension=' + LowerCase(ExtName)) or
+         (LowerCase(Trimmed) = 'extension=php_' + LowerCase(ExtName) + '.dll') or
+         (LowerCase(Trimmed) = 'extension=php_' + LowerCase(ExtName) + '2.dll') then
       begin
-        // Enable the php zip extension (required by the ZIP update method).
-        // Idempotent: append only when missing, otherwise uncomment.
-        if Pos('extension=zip', content) = 0 then
-          content := content + #13#10 + 'extension=zip' + #13#10
-        else
-          StringChangeEx(content, ';extension=zip', 'extension=zip', True);
-        SaveStringToFile(phpIni, content, False);
+        Found := True;
+        Continue;
+      end;
+
+      // セミコロンで始まる行のみ対象
+      if (Length(Trimmed) = 0) or (Trimmed[1] <> ';') then
+        Continue;
+
+      // 先頭の ; を取り除いた中身を取得
+      Content := Trim(Copy(Trimmed, 2, Length(Trimmed)));
+
+      // 以下いずれかにマッチすれば有効化
+      //   extension=gd            (PHP 8.x)
+      //   extension=php_gd.dll    (PHP 7.x)
+      //   extension=php_gd2.dll   (PHP 7.x 旧形式)
+      if (LowerCase(Content) = 'extension=' + LowerCase(ExtName)) or
+         (LowerCase(Content) = 'extension=php_' + LowerCase(ExtName) + '.dll') or
+         (LowerCase(Content) = 'extension=php_' + LowerCase(ExtName) + '2.dll') then
+      begin
+        Found := True;
+        // 元の行から最初の ; だけを取り除く（インデントを維持）
+        SemiPos := Pos(';', Line);
+        if SemiPos > 0 then
+        begin
+          Lines[I] := Copy(Line, 1, SemiPos - 1) + Copy(Line, SemiPos + 1, Length(Line));
+          Modified := True;
+        end;
       end;
     end;
+
+    // php.ini に記述が一切ない場合は末尾に追記
+    if not Found then
+    begin
+      Lines.Add('extension=' + ExtName);
+      Modified := True;
+    end;
+
+    if Modified then
+      Lines.SaveToFile(PhpIniPath);
+  finally
+    Lines.Free;
   end;
+end;
+
+function InitializeUninstall(): Boolean;
+begin
+  Result := MsgBox(
+    'アンインストールすると、インストール先フォルダ内のすべてのファイルが削除されます。' + #13#10 +
+    ExpandConstant('{app}') + #13#10#13#10 +
+    '設定のバックアップは、アンインストール前にブラウザで管理画面（init.php）を開いて' + #13#10 +
+    '行うことができます。' + #13#10#13#10 +
+    '続行するとすべてのファイルが削除されます。よろしいですか？',
+    mbConfirmation, MB_OKCANCEL) = IDOK;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep = usUninstall then
+    DelTree(ExpandConstant('{app}'), True, True, True);
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  PhpIniPath: string;
+  Msg: string;
+  ConfigPath: string;
+begin
+  // ファイルコピー開始前に config.ini の有無を記録
+  if CurStep = ssInstall then
+  begin
+    IsNewInstall := not FileExists(ExpandConstant('{app}\config.ini'));
+    Exit;
+  end;
+
+  if CurStep <> ssPostInstall then
+    Exit;
+
+  PhpIniPath := 'C:\xampp\php\php.ini';
+
+  if not FileExists(PhpIniPath) then
+  begin
+    MsgBox('php.ini が既定の場所に見つかりませんでした。' + #13#10 +
+           PhpIniPath + #13#10#13#10 +
+           'XAMPPをインストール後、手動で php.ini の gd と zip の extension を有効化してください。',
+           mbInformation, MB_OK);
+    Exit;
+  end;
+
+  EnablePHPExtension(PhpIniPath, 'gd');
+  EnablePHPExtension(PhpIniPath, 'zip');
+
+  // 新規インストール時のみ UI v2 をデフォルト有効化
+  if IsNewInstall then
+  begin
+    ConfigPath := ExpandConstant('{app}\config.ini');
+    SetIniString('', 'usenewsearchui',    '1', ConfigPath);
+    SetIniString('', 'usenewrequestlist', '1', ConfigPath);
+  end;
+
+  Msg := 'php.ini の設定を確認しました。' + #13#10 + PhpIniPath + #13#10#13#10 +
+         '・extension=gd  → 有効' + #13#10 +
+         '・extension=zip → 有効' + #13#10#13#10 +
+         '※ すでに有効だった場合は変更しません。';
+  MsgBox(Msg, mbInformation, MB_OK);
 end;

--- a/kara_config.php
+++ b/kara_config.php
@@ -141,8 +141,11 @@ function readconfig_array()
         $usebgv = 2;
         $config_ini = array_merge($config_ini,array("usebgv" => $usebgv));
     }
+    if(!array_key_exists("usenewsearchui", $config_ini)){
+        $config_ini = array_merge($config_ini,array("usenewsearchui" => 1));
+    }
     if(!array_key_exists("usenewrequestlist", $config_ini)){
-        $config_ini = array_merge($config_ini,array("usenewrequestlist" => 2));
+        $config_ini = array_merge($config_ini,array("usenewrequestlist" => 1));
     }
     if(!array_key_exists("secret_display_text", $config_ini)){
         $config_ini["secret_display_text"] = urlencode("ヒ・ミ・ツ♪(シークレットリクエスト)");


### PR DESCRIPTION
## 概要

`InnoSetupScript.iss` の全面刷新と、UI v2 のデフォルト有効化対応です。

## 変更内容

### InnoSetupScript.iss

- バージョン `0.09.9` → `0.10.0-beta`
- **[Files] セクション整理**
  - `css\*` / `js\*` に `recursesubdirs` 追加（`bootstrap5/`・`themes/` サブフォルダが漏れていた）
  - 存在しないファイルを削除: `video-js\*`、`commentPlayer\*`、`ニコカラコメントPlayer2.exe`
  - 未収録ファイルを追加: `*.html`、`*.vbs`、`*.json`、`samples\*`、`fortest\*`、`test_race\*`、`allinone\*` など
  - `gitcmd\*` / `gitbase\.git\*` をコメントアウト（不要になったため）
  - 重複・誤コピー先エントリを削除
- **アンインストール改善**
  - 管理画面（init.php）でのバックアップを促すダイアログを表示
  - OK でインストール先フォルダを完全削除、キャンセルで中断
- **php.ini 自動設定**
  - `gd` / `zip` extension をコメント解除、記述がなければ末尾に追記（PR #175 の処理を統合）
  - `C:\xampp\php\php.ini` が見つからない場合はメッセージを表示して終了
- **新規インストール時のみ UI v2 を自動有効化**
  - インストール前に `config.ini` の有無を確認し、新規インストール時のみ `usenewsearchui=1` / `usenewrequestlist=1` を書き込む

### kara_config.php

- `usenewsearchui` のデフォルト値を追加（`1`）
- `usenewrequestlist` のデフォルト値を `2` → `1` に変更

`config.ini` が存在しない場合（新規インストール・全削除後）も UI v2 がデフォルトになります。既存ユーザーは `config.ini` の値が優先されるため影響なし。

## 動作確認

- [x] Inno Setup 7.x でコンパイル成功
- [x] 新規インストール後に UI v2 が有効になっている
- [x] アップデートインストール後に既存設定が維持される
- [x] アンインストール時に確認ダイアログが表示される

🤖 Generated with [Claude Code](https://claude.ai/claude-code)