### PR TITLE
fix: インストーラーから allinone ディレクトリを除外

### DIFF
--- a/InnoSetupScript.iss
+++ b/InnoSetupScript.iss
@@ -57,7 +57,7 @@ Source: "notfoundrequest\*"; DestDir: "{app}\notfoundrequest"; Flags: IgnoreVers
 Source: "samples\*"; DestDir: "{app}\samples"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
 Source: "fortest\*"; DestDir: "{app}\fortest"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
 Source: "test_race\*"; DestDir: "{app}\test_race"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
-Source: "allinone\*"; DestDir: "{app}\allinone"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+;;Source: "allinone\*"; DestDir: "{app}\allinone"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
 
 ; --- foobar2000（.gitignore除外分は手動で配置が必要）---
 Source: "foobar2000\*"; DestDir: "{app}\foobar2000"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main


### PR DESCRIPTION
## 概要

PR #181 のマージ後に発見した問題の修正です。

## 問題

`allinone/` ディレクトリに旧バージョンのインストーラー exe（約 45MB）が含まれており、新インストーラーのファイルサイズが旧バージョン（v0.09.9-alpha）より大きくなっていました。

## 修正内容

- `InnoSetupScript.iss` の `allinone\*` エントリをコメントアウト

`allinone/` はインストール先に配置する必要のないメタファイルのため、インストール対象から除外します。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)