### PR TITLE
fix: ゆかりすたーDB未構築時に曲名をファイル名で表示

### DIFF
--- a/search_listerdb_filelist_bs5.php
+++ b/search_listerdb_filelist_bs5.php
@@ -396,7 +396,7 @@ $displaylast = min($displayfrom + $displaynum, $programlist['recordsTotal']);
   <?php foreach ($programlist['data'] as $k => $program): ?>
     <?php
     $display = $program['song_name'];
-    if (empty($display)) $display = '未分類';
+    if (empty($display)) $display = makesongnamefromfilename(basename_jp($program['found_path']));
     $comment = preg_replace('/\,\/\/.*/', '', $program['found_comment'] ?? '');
     ?>
     <div class="file-item">


### PR DESCRIPTION
## Summary

- ゆかりすたーDBの構築中（`song_name` が null）の場合、検索結果の曲名欄が「未分類」と表示されていた問題を修正
- `song_name` が空の場合、`makesongnamefromfilename()` を使ってファイル名（パス・拡張子除く）を代わりに表示するよう変更

## 変更ファイル

- `search_listerdb_filelist_bs5.php` : 399行目の `'未分類'` フォールバックをファイル名表示に変更

## Test plan

- [x] ゆかりすたーDB構築中の状態でキーワード検索を行い、曲名欄にファイル名が表示されることを確認
- [x] DB構築済みの状態では通常通り `song_name` が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)