### PR TITLE
曲停止ボタンに確認ポップアップを追加する改善

### DIFF
--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -1096,6 +1096,7 @@ function changeItem(id, songfile) {
 
 // 曲終了
 function songEnd() {
+    if (!confirm('曲を停止しますか？')) return;
     fetch('playerctrl_portal.php?songnext=1').then(loadList);
 }
 


### PR DESCRIPTION
﻿## 概要

requestlist_swipe.php のスワイプ式リクエスト一覧で、曲停止ボタンを押すと確認ダイアログなしに即座に曲が停止してしまう問題を修正します。

## 現状の問題

同ファイル内の並び替え（`confirm('この順序でよろしいですか？')`）や削除（`confirm('削除しますか？')`）には確認ダイアログがあるのに対し、曲停止のみ確認なしで動作が不統一でした。誤タップで意図せず曲が停止する可能性があります。

## 原因

`songEnd()` 関数が確認ダイアログを持たず、ボタンタップ直後に `fetch()` で停止処理を実行する実装になっていました。

## 修正内容

`songEnd()` の先頭で `confirm('曲を停止しますか？')` を実行し、キャンセル時は `return` して処理を中断するようにしました。OKの場合のみ既存の `fetch()` 処理を実行します。変更は `requestlist_swipe.php` の `songEnd()` 関数1箇所のみです。

## 影響範囲

- requestlist_swipe.php（`songEnd()` 関数のみ、1行追加）

## 確認方法

1. スワイプ式リクエスト一覧画面で曲停止ボタンを押す。
2. 確認ダイアログが表示され、「キャンセル」で処理が中断されることを確認する。
3. 「OK」で従来どおり曲が停止することを確認する。
4. 並び替え・削除の既存確認ダイアログに影響がないことを確認する。

## 関連Issue

本家Issue作成権限がないため、fork側Issueを修正依頼の整理用Issueとして作成しています。このPR本文を本家向けの修正依頼として提出します。

fork側Issue: https://github.com/hachi515tennis3-glitch/KaraokeRequestorWeb/issues/1
