### PR TITLE
途中参加者が次周以降に正しい順番へ配置されない問題

### DIFF
--- a/function_moveitem.php
+++ b/function_moveitem.php
@@ -139,18 +139,18 @@ class MoveItem {
             $rounds[] = $cur_round;
         }
 
-        // 挿入ラウンド: 新歌い手を含まない最初のラウンド
-        $target_idx = count($rounds);
-        foreach ($rounds as $idx => $round) {
-            $has = false;
-            foreach ($round as $r) {
-                if ($r['singer'] === $newsinger) { $has = true; break; }
-            }
-            if (!$has) {
-                $target_idx = $idx;
-                break;
-            }
+// 挿入ラウンド: 歌い手が最後に登場したラウンドの次
+// 初回参加は last=-1+1=0、途中参加者も含め
+// 最後の出現ラウンド+1を正しく参照する
+$last_singer_idx = -1;
+foreach ($rounds as $idx => $round) {
+    foreach ($round as $r) {
+        if ($r['singer'] === $newsinger) {
+            $last_singer_idx = $idx; break;
         }
+    }
+}
+$target_idx = $last_singer_idx + 1;
 
         // 全ラウンドに既に存在 → 末尾に追加
         if ($target_idx >= count($rounds)) {


### PR DESCRIPTION
﻿## 概要

歌唱途中から参加した歌手（途中参加者）が、参加した回以降のラウンドで正しい順番に配置されず、リクエスト一覧の周回順序がおかしくなる問題を修正します。

## 現状の問題

途中参加した歌手が、初参加時のラウンドでは正しい位置に入るものの、次回以降のラウンドでは本来の周回順（前回歌った位置の次）ではなく、全歌手が一度も歌っていないラウンドの先頭付近に配置されてしまうことがありました。

## 原因

function_moveitem.php の `MoveItem` クラス内 `get_new_reqorder()` で、新規リクエストの挿入位置を「その歌手が一度も登場していない最初のラウンド」を探して決定していました。この実装では、途中参加者がすでに一度歌った後の周では、本来の「前回歌った回の次」ではなく、別の未登場ラウンドが優先的に選ばれてしまうため、周回順序が崩れていました。

## 修正内容

「その歌手が一度も登場していないラウンド」を探すロジックを廃止し、代わりに「その歌手が最後に登場したラウンドのインデックス（`$last_singer_idx`）」を追跡し、挿入位置を `$last_singer_idx + 1` に設定するよう変更しました。これにより、途中参加者も次周以降は必ず前回歌った回の直後に配置されます。

## 影響範囲

- function_moveitem.php（`MoveItem::get_new_reqorder()` のみ）

## 確認方法

1. 複数の歌手が登録された状態で数周分のリクエストを作成する。
2. 途中から新しい歌手を1名追加し、リクエストを行う。
3. 次の周でその歌手のリクエストが、前回歌った回の直後の位置に正しく挿入されることを確認する。
4. 既存の歌手同士の周回順序に影響がないことを確認する。

## 関連Issue

本家Issue作成権限がないため、fork側Issueを修正依頼の整理用Issueとして作成しています。このPR本文を本家向けの修正依頼として提出します。

fork側Issue: https://github.com/hachi515tennis3-glitch/KaraokeRequestorWeb/issues/2
