### PR TITLE
MPC音量増減がベースライン基準にならず、曲終了後に音量が戻らない問題

### DIFF
--- a/manage-mpc.php
+++ b/manage-mpc.php
@@ -1017,27 +1017,21 @@ function start_song($db,$id,$addplaytimes = 0){
                     pclose($fp);
                     }  //★
 
-            //★ MPCの再生開始時に音量を指定値に戻す（設定で有効にしている場合）
-            //   制作者別音量増減（requesttable.volume != 0）が設定されている場合は
-            //   startvolume にオフセットを加算した値を設定する。
-            $req_volume_offset = 0;
-            if(array_key_exists("volume" , $row) && $row["volume"] !== null && $row["volume"] !== ''){
-                $v = intval($row["volume"]);
-                if($v >= -100 && $v <= 100) $req_volume_offset = $v;
-            }
-            if($req_volume_offset !== 0){
-                $base_volume = array_key_exists('startvolume', $config_ini) ? intval($config_ini['startvolume']) : 50;
+            //★ MPCの再生開始時に音量を指定値に戻す（startvolume50 が有効な場合のみ）
+            //   startvolume をベースラインとし、requesttable.volume をオフセットとして加算する。
+            //   startvolume50 が無効の場合は音量を一切変更しない（手動管理優先）。
+            $_sv50_on = array_key_exists('startvolume50', $config_ini) && intval($config_ini['startvolume50']) === 1;
+            if ($_sv50_on) {
+                $base_volume = (array_key_exists('startvolume', $config_ini) && $config_ini['startvolume'] !== '')
+                               ? intval($config_ini['startvolume']) : 50;
+                if ($base_volume <= 0) $base_volume = 50; // 0・未設定時はデフォルト50
+                $req_volume_offset = 0;
+                if (array_key_exists('volume', $row) && $row['volume'] !== null && $row['volume'] !== '') {
+                    $v = intval($row['volume']);
+                    if ($v >= -100 && $v <= 100) $req_volume_offset = $v;
+                }
                 $applied_volume = max(0, min(100, $base_volume + $req_volume_offset));
                 set_volume($applied_volume);
-            }else{
-                if(array_key_exists('startvolume50',$config_ini)){	//★
-                    if($config_ini['startvolume50'] != 1)  {	//★
-                    }else{	//★
-                        set_volume($config_ini["startvolume"]);	//★
-                    }	//★
-                }else{	//★
-                    set_volume($config_ini["startvolume"]);	//★
-                }	//★
             }
             //★ 音声トラックの切替が無いor１回の場合、再生開始を遅延させる。
             if($row["track"] == 0){  //★

--- a/mpcctrl_bs5.php
+++ b/mpcctrl_bs5.php
@@ -74,6 +74,14 @@ function apply_player_compensation_full() {
 /* ---- AJAX / コマンドリクエスト処理 ---- */
 if (!empty($_REQUEST['songnext'])) {
     songnext();
+    // ★ 曲終了後に音量をベースラインに戻す（startvolume50 が有効な場合）
+    //   次の曲が始まるまで offset 音量のまま残らないようにする。
+    if (array_key_exists('startvolume50', $config_ini) && intval($config_ini['startvolume50']) === 1) {
+        $base = (array_key_exists('startvolume', $config_ini) && $config_ini['startvolume'] !== '')
+                ? intval($config_ini['startvolume']) : 50;
+        if ($base <= 0) $base = 50;
+        set_volume($base);
+    }
     die();
 }
 if (array_key_exists('songstart', $_REQUEST)) {


### PR DESCRIPTION
﻿## 概要

MPCプレイヤーで音量オフセット機能を使用している場合、曲終了後に音量がベースライン（基準値）に戻らず、オフセットが累積してしまう問題を修正します。

## 現状の問題

曲送り（songnext）の度に音量オフセットが加算され続け、音量が意図せず増減し続けてしまいます。

## 原因

manage-mpc.php の音量設定処理で、`startvolume50`（起動時音量有効化フラグ）が音量オフセットの適用有無を正しく制御しておらず、オフセットあり・なしのケースで処理が分岐していたため、基準値に対して一貫した音量設定ができていませんでした。また mpcctrl_bs5.php の songnext ハンドラでも曲送り時に音量をベースラインへリセットする処理がありませんでした。

## 修正内容

- manage-mpc.php：`startvolume50` が有効な場合のみ音量設定ブロック全体を実行するよう統一。`$base_volume` は `startvolume` が空または0以下の場合は50をデフォルト値とし、`$base_volume + $req_volume_offset` を `set_volume()` に渡すよう修正。
- mpcctrl_bs5.php：`songnext()` 実行後に `startvolume50==1` の場合、`$base`（デフォルト50）を計算して `set_volume($base)` を呼び、曲送りの度に音量をベースラインへリセット。

## 影響範囲

- manage-mpc.php（音量設定ブロックのみ）
- mpcctrl_bs5.php（songnext ハンドラの音量リセット追加のみ）

## 確認方法

1. 設定で音量オフセット機能・`startvolume50` を有効化する。
2. 曲を複数回送り、都度音量がベースライン（設定値）を基準に一定であることを確認する（オフセットが累積しないこと）。
3. `startvolume50` を無効化した状態で、音量設定処理に影響がないことを確認する。

## 関連Issue

本家Issue作成権限がないため、fork側Issueを修正依頼の整理用Issueとして作成しています。このPR本文を本家向けの修正依頼として提出します。

fork側Issue: https://github.com/hachi515tennis3-glitch/KaraokeRequestorWeb/issues/3
