### PR TITLE
iPhoneスクロール時に背景壁紙が拡大縮小される問題

### DIFF
--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1017,7 +1017,8 @@ function print_meta_header(){
     print "\n";
     print '<meta http-equiv="Content-Script-Type" content="text/javascript" />';
     print "\n";
-    print '<meta name="viewport" content="width=device-width,initial-scale=1.0" />';
+    // iPhone の safe area まで背景・UI を拡張できるよう viewport-fit=cover を付与する。
+    print '<meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover" />';
     print "\n";
 }
 
@@ -1920,10 +1921,23 @@ function print_bg_style_block($is_bs5 = false) {
         // html::before = 固定背景画像レイヤー。
         // iOS Safari は body の background-attachment:fixed をサポートしていないため、
         // position:fixed の疑似要素で代替することで全ブラウザ・全デバイスで背景を固定する。
-        print 'html,body{background-color:transparent !important;}';
-        print 'html::before{content:"";position:fixed;inset:0;z-index:-2;pointer-events:none;'
-            . 'filter:none !important;'
-            . 'background-image:var(--bg-page-image);background-size:cover;background-position:center;}';
+        // iPhone Safari はブラウザUI背面に root 背景色を使うことがあるため、
+        // html 側には常にページ背景色を持たせて白抜けを防ぐ。body は透過のままにする。
+        print 'html{background-color:var(--bg-page, #F8ECE0) !important;}body{background-color:transparent !important;}';
+        // iOS Safari は visual viewport の高さ変化(URLバー表示/非表示)に合わせて
+        // inset:0 の fixed 要素を伸縮させるため、background-size:cover が再計算されて
+        // 背景が拡大縮小して見える。100lvh ベースの固定高に切り替え、さらに safe area と
+        // オーバースキャン分だけ大きめに描画して、iPhone 下端の白い帯露出も防ぐ。
+        print 'html::before{content:"";position:fixed;'
+            . 'top:calc(-24px - env(safe-area-inset-top, 0px));left:calc(-24px - env(safe-area-inset-left, 0px));'
+            . 'width:calc(100vw + env(safe-area-inset-left, 0px) + env(safe-area-inset-right, 0px) + 48px);'
+            . 'height:calc(100vh + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px) + 120px);'
+            . 'height:calc(100lvh + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px) + 120px);'
+            . 'z-index:-2;pointer-events:none;filter:none !important;'
+            . 'background-image:var(--bg-page-image);background-repeat:no-repeat;'
+            . 'background-size:cover;background-position:center center;'
+            . 'transform:translate3d(0,0,0);-webkit-transform:translate3d(0,0,0);'
+            . '-webkit-backface-visibility:hidden;backface-visibility:hidden;}';
         // スマホ縦持ち(縦長表示)のときだけ専用画像に切り替える。
         // orientation:portrait を条件に加えることで、小型端末を横持ちにした際
         // (幅が 768px 以下のままでも)は PC 用の横長画像が使われるようにする。
@@ -1934,8 +1948,12 @@ function print_bg_style_block($is_bs5 = false) {
         print 'body{background-image:none !important;}';
         // body::before = オーバーレイ色レイヤー。画像レイヤー(z-index:-2)の上に重ねる。
         // ダークモードの brightness フィルタが背景画像に影響しないよう filter:none を指定。
-        print 'body::before{content:"";position:fixed;inset:0;z-index:-1;pointer-events:none;'
-            . 'background-image:none !important;'
+        print 'body::before{content:"";position:fixed;'
+            . 'top:calc(-24px - env(safe-area-inset-top, 0px));left:calc(-24px - env(safe-area-inset-left, 0px));'
+            . 'width:calc(100vw + env(safe-area-inset-left, 0px) + env(safe-area-inset-right, 0px) + 48px);'
+            . 'height:calc(100vh + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px) + 120px);'
+            . 'height:calc(100lvh + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px) + 120px);'
+            . 'z-index:-1;pointer-events:none;background-image:none !important;'
             . 'background-color:rgba(var(--bg-page-rgb, 248, 236, 224), var(--bg-overlay-alpha, 1));'
             . 'filter:none !important;}';
         // ダークモード時はユーザー指定の明るい bgcolor をそのままオーバーレイに使うと

--- a/css/themes/theme-toggle.css
+++ b/css/themes/theme-toggle.css
@@ -21,7 +21,8 @@ body {
   background-color: var(--bg-page);
   background-image: var(--bg-page-image);
   background-size: cover;
-  background-attachment: fixed;
+  /* background-attachment:fixed は iOS Safari 非対応のため削除。
+     背景画像固定は html::before (position:fixed + GPU layer) が担当。 */
   padding-top: 70px;
   color: var(--color-text);
 }
@@ -34,7 +35,7 @@ body::before {
   background-color: var(--bg-page, #F8ECE0);
   background-image: var(--bg-page-image, none);
   background-size: cover;
-  background-attachment: fixed;
+  /* background-attachment:fixed 削除: position:fixed 済みで不要かつ iOS でズーム原因になる */
 }
 
 /* ============================================================


### PR DESCRIPTION
﻿## 概要

iPhone（iOS Safari）でページをスクロールした際、固定表示しているはずの背景壁紙が拡大縮小して見える問題を修正します。

## 現状の問題

iOS Safari では、アドレスバーの表示・非表示に応じてビューポートの高さが変化しますが、`inset:0` を使った `position:fixed` の背景疑似要素がその高さ変化に追従して伸縮してしまい、`background-size:cover` の再計算により背景画像が拡大縮小して見えてしまいます。また、safe area（ノッチ・ホームインジケーター等）分の余白で下端に白い帯が露出することもあります。

## 原因

commonfunc.php の `print_bg_style_block()` で、背景固定用の `html::before` 疑似要素が `inset:0` を用いた単純な固定サイズで実装されており、iOS Safari の visual viewport 変化やsafe areaを考慮していませんでした。また `print_meta_header()` の viewport メタタグに `viewport-fit=cover` が指定されておらず、safe area 領域が正しく扱えていませんでした。

## 修正内容

- `print_meta_header()`：viewport メタタグに `viewport-fit=cover` を追加。
- `print_bg_style_block()`：`html::before` を `top`/`left`/`width`/`height` ベースの指定に変更し、`env(safe-area-inset-*)` とオーバースキャン分の余白、`100lvh`（large viewport height）を用いて算出。加えて `transform:translate3d(0,0,0)` と `backface-visibility:hidden` を指定し、GPUレイヤー化により再描画時のちらつき・拡縮を抑制。
- css/themes/theme-toggle.css：`body` および `body::before` から `background-attachment: fixed;` を削除（iOS Safari非対応かつ、GPU合成と競合するため）。

## 影響範囲

- commonfunc.php（`print_meta_header()`、`print_bg_style_block()` のみ）
- css/themes/theme-toggle.css（`background-attachment: fixed` の削除のみ）

## 確認方法

1. iPhone（iOS Safari）で背景壁紙を設定した状態でページを開く。
2. スクロールしてアドレスバーが表示・非表示になる際、背景画像が拡大縮小せず固定表示されることを確認する。
3. ノッチ・ホームインジケーター周辺に白い帯が出ないことを確認する。
4. Android Chrome・デスクトップブラウザで背景表示に不具合がないことを確認する。

## 関連Issue

本家Issue作成権限がないため、fork側Issueを修正依頼の整理用Issueとして作成しています。このPR本文を本家向けの修正依頼として提出します。

fork側Issue: https://github.com/hachi515tennis3-glitch/KaraokeRequestorWeb/issues/4
