### PR TITLE
BS5画面向け外観プリセット設定の追加と改善

### DIFF
--- a/comment.php
+++ b/comment.php
@@ -14,7 +14,7 @@ require_once 'commonfunc.php';
 <title>コメントポスト</title>
 <?php print_bs5_search_head(); ?>
 </head>
-<body>
+<body<?php echo bs5_skin_data_attr(); ?>>
 <?php shownavigatioinbar_bs5('comment.php'); ?>
 
 <div class="container py-3">

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1396,6 +1396,67 @@ function print_bs5_search_head($extra_css = ''){
     print_bs5_head_core($page_css, ['jquery' => true]);
 }
 
+function get_ui_skin_preset($value = null){
+    static $allowed = ['default', 'glass', 'live', 'wa', 'minimal', 'oshi'];
+
+    if ($value === null) {
+        global $config_ini;
+        $value = $config_ini['ui_skin_preset'] ?? 'default';
+    }
+
+    if (is_array($value)) {
+        return 'default';
+    }
+
+    $preset = trim(urldecode((string)$value));
+    if ($preset === '' || !in_array($preset, $allowed, true)) {
+        return 'default';
+    }
+
+    return $preset;
+}
+
+function get_ui_skin_shape($value = null){
+    static $allowed = ['preset', 'default'];
+
+    if ($value === null) {
+        global $config_ini;
+        $value = $config_ini['ui_skin_shape'] ?? 'preset';
+    }
+
+    if (is_array($value)) {
+        return 'preset';
+    }
+
+    $shape = trim(urldecode((string)$value));
+    if ($shape === '' || !in_array($shape, $allowed, true)) {
+        return 'preset';
+    }
+
+    return $shape;
+}
+
+function get_ui_skin_card_opacity($value = null){
+    if ($value === null) {
+        global $config_ini;
+        $value = $config_ini['ui_skin_card_opacity'] ?? 100;
+    }
+
+    if (is_array($value) || $value === '') {
+        return 100;
+    }
+
+    $opacity = (int)$value;
+    if ($opacity < 0) $opacity = 0;
+    if ($opacity > 100) $opacity = 100;
+    return $opacity;
+}
+
+function bs5_skin_data_attr(){
+    return ' data-ykr-skin="' . htmlspecialchars(get_ui_skin_preset(), ENT_QUOTES, 'UTF-8') . '"'
+        . ' data-ykr-shape="' . htmlspecialchars(get_ui_skin_shape(), ENT_QUOTES, 'UTF-8') . '"';
+}
+
 /**
  * BS5ページ共通の <head> 核を出力する。
  * テーマ初期化スクリプト（FOUC防止）+ Bootstrap5 + テーマ変数 + テーマ切替 を
@@ -1410,10 +1471,12 @@ function print_bs5_head_core($page_css = [], $opts = []){
     print '<script>(function(){if(window.__ykThemeInit)return;window.__ykThemeInit=true;try{var t=localStorage.getItem("ykari-theme")||"light",f=localStorage.getItem("ykari-fontsize")||"normal";document.documentElement.setAttribute("data-theme",t);document.documentElement.setAttribute("data-fontsize",f);}catch(e){}})();</script>';
     print '<link rel="stylesheet" href="css/bootstrap5/bootstrap.min.css">';
     print '<link rel="stylesheet" href="css/themes/_variables.css">';
+    print '<style>:root{--ykr-skin-card-opacity:' . (get_ui_skin_card_opacity() / 100) . ';}</style>';
     foreach ((array)$page_css as $href){
         if($href === '') continue;
         print '<link rel="stylesheet" href="' . htmlspecialchars($href, ENT_QUOTES, 'UTF-8') . '">';
     }
+    print '<link rel="stylesheet" href="css/themes/skin-presets.css">';
     print '<link rel="stylesheet" href="css/themes/theme-toggle.css">';
     if(!empty($opts['jquery'])){
         print '<script src="js/jquery.js"></script>';

--- a/css/themes/skin-presets.css
+++ b/css/themes/skin-presets.css
@@ -1,0 +1,499 @@
+﻿/* ==========================================================
+   BS5 UI skin presets
+   既存レイアウトは維持し、CSS変数と軽い見た目の上書きで切り替える。
+   ========================================================== */
+
+[data-ykr-skin="default"] {
+  --ykr-request-card-radius: 6px;
+  --ykr-request-chip-radius: 6px;
+  --ykr-request-card-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  --ykr-card-border: rgba(0, 0, 0, 0);
+  --ykr-card-border-strong: var(--color-border);
+  --ykr-card-gradient: none;
+  --ykr-card-header-gradient: none;
+  --ykr-navbar-bg: #222222;
+  --ykr-navbar-border: rgba(255, 255, 255, 0.06);
+  --ykr-input-shadow: none;
+  --ykr-accent-glow: none;
+}
+
+[data-ykr-shape="default"] {
+  --radius-card: 12px;
+  --radius-button: 8px;
+  --radius-input: 6px;
+  --ykr-request-card-radius: 6px;
+  --ykr-request-chip-radius: 6px;
+}
+
+[data-ykr-shape="default"] .btn,
+[data-ykr-shape="default"] .btn-primary,
+[data-ykr-shape="default"] .btn-secondary,
+[data-ykr-shape="default"] .btn-outline-secondary,
+[data-ykr-shape="default"] .btn-search-submit,
+[data-ykr-shape="default"] .btn-request,
+[data-ykr-shape="default"] .btn-secondary-themed,
+[data-ykr-shape="default"] .reservation-tab-btn,
+[data-ykr-shape="default"] .search-mode-btn,
+[data-ykr-shape="default"] .page-btn,
+[data-ykr-shape="default"] .index-btn,
+[data-ykr-shape="default"] .player-btn,
+[data-ykr-shape="default"] .player-key-display {
+  --bs-btn-border-radius: var(--radius-button);
+  border-radius: var(--radius-button) !important;
+}
+
+[data-ykr-skin="glass"] {
+  --bg-card-rgb: 255, 251, 255;
+  --bg-card-alt-rgb: 244, 236, 247;
+  --bg-input: #fffafc;
+  --color-text: #2f2238;
+  --color-text-muted: #6c5a72;
+  --color-text-on-accent: #ffffff;
+  --color-accent: #ff4fa1;
+  --color-accent-hover: #ff2f92;
+  --color-accent-secondary: #8a6cff;
+  --color-accent-secondary-hover: #7656f5;
+  --color-border: rgba(154, 44, 156, 0.28);
+  --color-border-active: #ff79bc;
+  --bg-index-btn: #f7eff8;
+  --bg-index-btn-hover: #efe2f2;
+  --bg-index-btn-has-data: #ff66ba;
+  --bg-index-btn-has-data-hover: #ff4fa1;
+  --color-index-btn: #5a465d;
+  --radius-card: 22px;
+  --radius-button: 12px;
+  --radius-input: 16px;
+  --shadow-card: 0 12px 28px rgba(94, 52, 110, 0.14);
+  --shadow-card-hover: 0 18px 38px rgba(94, 52, 110, 0.18);
+  --shadow-navbar: 0 8px 24px rgba(58, 28, 72, 0.22);
+  --ykr-request-card-radius: 22px;
+  --ykr-request-chip-radius: 12px;
+  --ykr-request-card-shadow: 0 12px 28px rgba(94, 52, 110, 0.14);
+  --ykr-card-border: rgba(205, 162, 208, 0.56);
+  --ykr-card-border-strong: rgba(205, 162, 208, 0.78);
+  --ykr-card-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.84), rgba(255, 255, 255, 0.60));
+  --ykr-card-header-gradient: linear-gradient(90deg, rgba(255, 79, 161, 0.08), rgba(138, 108, 255, 0.08));
+  --ykr-navbar-bg: rgba(92, 62, 108, 0.90);
+  --ykr-navbar-border: rgba(255, 255, 255, 0.18);
+  --ykr-input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  --ykr-accent-glow: 0 0 22px rgba(255, 79, 161, 0.32);
+}
+
+[data-ykr-skin="live"] {
+  --bg-card-rgb: 253, 250, 247;
+  --bg-card-alt-rgb: 246, 239, 243;
+  --bg-input: #fffdfd;
+  --color-text: #2c1f2c;
+  --color-text-muted: #6a5d6b;
+  --color-text-on-accent: #ffffff;
+  --color-accent: #ff4f9a;
+  --color-accent-hover: #ea327f;
+  --color-accent-secondary: #2dc9ff;
+  --color-accent-secondary-hover: #18b1e7;
+  --color-border: rgba(145, 110, 144, 0.28);
+  --color-border-active: #ff4f9a;
+  --bg-index-btn: #f8f0f5;
+  --bg-index-btn-hover: #f0e3ec;
+  --bg-index-btn-has-data: #22b7ef;
+  --bg-index-btn-has-data-hover: #10a4db;
+  --color-index-btn: #594d5b;
+  --radius-card: 18px;
+  --radius-button: 14px;
+  --radius-input: 14px;
+  --shadow-card: 0 10px 26px rgba(83, 48, 88, 0.14);
+  --shadow-card-hover: 0 16px 36px rgba(83, 48, 88, 0.18);
+  --shadow-navbar: 0 8px 26px rgba(44, 26, 52, 0.24);
+  --ykr-request-card-radius: 18px;
+  --ykr-request-chip-radius: 14px;
+  --ykr-request-card-shadow: 0 10px 26px rgba(83, 48, 88, 0.14);
+  --ykr-card-border: rgba(201, 155, 184, 0.44);
+  --ykr-card-border-strong: rgba(201, 155, 184, 0.64);
+  --ykr-card-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(255, 255, 255, 0.66));
+  --ykr-card-header-gradient: linear-gradient(90deg, rgba(255, 79, 154, 0.08), rgba(45, 201, 255, 0.08));
+  --ykr-navbar-bg: rgba(84, 50, 80, 0.92);
+  --ykr-navbar-border: rgba(255, 255, 255, 0.16);
+  --ykr-input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.42);
+  --ykr-accent-glow: 0 0 16px rgba(255, 79, 154, 0.22);
+}
+
+[data-ykr-skin="wa"] {
+  --bg-card-rgb: 251, 245, 235;
+  --bg-card-alt-rgb: 244, 232, 213;
+  --bg-input: #fffaf3;
+  --color-text: #2f1b16;
+  --color-text-muted: #71584a;
+  --color-text-on-accent: #fff8ef;
+  --color-accent: #a53a2b;
+  --color-accent-hover: #8d2f22;
+  --color-accent-secondary: #b48a3a;
+  --color-accent-secondary-hover: #9d762f;
+  --color-border: rgba(120, 45, 35, 0.24);
+  --color-border-active: #a53a2b;
+  --bg-index-btn: #f5e8d7;
+  --bg-index-btn-hover: #edd9bf;
+  --bg-index-btn-has-data: #8e3124;
+  --bg-index-btn-has-data-hover: #79281d;
+  --color-index-btn: #4a3123;
+  --radius-card: 16px;
+  --radius-button: 10px;
+  --radius-input: 10px;
+  --shadow-card: 0 10px 24px rgba(58, 29, 20, 0.14);
+  --shadow-card-hover: 0 16px 30px rgba(58, 29, 20, 0.18);
+  --shadow-navbar: 0 6px 20px rgba(35, 18, 12, 0.28);
+  --ykr-request-card-radius: 16px;
+  --ykr-request-chip-radius: 10px;
+  --ykr-request-card-shadow: 0 10px 24px rgba(58, 29, 20, 0.14);
+  --ykr-card-border: rgba(149, 89, 57, 0.28);
+  --ykr-card-border-strong: rgba(149, 89, 57, 0.42);
+  --ykr-card-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.52), rgba(255, 255, 255, 0.12));
+  --ykr-card-header-gradient: linear-gradient(90deg, rgba(165, 58, 43, 0.08), rgba(180, 138, 58, 0.12));
+  --ykr-navbar-bg: rgba(36, 24, 18, 0.90);
+  --ykr-navbar-border: rgba(210, 174, 97, 0.22);
+  --ykr-input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.52);
+  --ykr-accent-glow: 0 0 0 rgba(0, 0, 0, 0);
+}
+
+[data-ykr-skin="minimal"] {
+  --bg-card-rgb: 255, 255, 255;
+  --bg-card-alt-rgb: 246, 248, 250;
+  --bg-input: #ffffff;
+  --color-text: #1f2937;
+  --color-text-muted: #667085;
+  --color-text-on-accent: #ffffff;
+  --color-accent: #3559a8;
+  --color-accent-hover: #29488a;
+  --color-accent-secondary: #4b5563;
+  --color-accent-secondary-hover: #374151;
+  --color-border: rgba(100, 116, 139, 0.24);
+  --color-border-active: #3559a8;
+  --bg-index-btn: #f6f8fb;
+  --bg-index-btn-hover: #edf1f6;
+  --bg-index-btn-has-data: #3559a8;
+  --bg-index-btn-has-data-hover: #29488a;
+  --color-index-btn: #475467;
+  --radius-card: 12px;
+  --radius-button: 10px;
+  --radius-input: 10px;
+  --shadow-card: 0 4px 14px rgba(15, 23, 42, 0.08);
+  --shadow-card-hover: 0 8px 18px rgba(15, 23, 42, 0.10);
+  --shadow-navbar: 0 4px 16px rgba(15, 23, 42, 0.14);
+  --ykr-request-card-radius: 12px;
+  --ykr-request-chip-radius: 10px;
+  --ykr-request-card-shadow: 0 4px 14px rgba(15, 23, 42, 0.08);
+  --ykr-card-border: rgba(100, 116, 139, 0.18);
+  --ykr-card-border-strong: rgba(100, 116, 139, 0.28);
+  --ykr-card-gradient: none;
+  --ykr-card-header-gradient: none;
+  --ykr-navbar-bg: rgba(28, 33, 42, 0.96);
+  --ykr-navbar-border: rgba(255, 255, 255, 0.08);
+  --ykr-input-shadow: none;
+  --ykr-accent-glow: none;
+}
+
+[data-ykr-skin="oshi"] {
+  --bg-card-rgb: 255, 248, 252;
+  --bg-card-alt-rgb: 250, 240, 248;
+  --bg-input: #fffafd;
+  --color-text: #35122f;
+  --color-text-muted: #6f4168;
+  --color-text-on-accent: #ffffff;
+  --color-accent: #ff4aa7;
+  --color-accent-hover: #f72b95;
+  --color-accent-secondary: #6f5df8;
+  --color-accent-secondary-hover: #5b49e6;
+  --color-border: rgba(187, 87, 146, 0.34);
+  --color-border-active: #ff62b0;
+  --bg-index-btn: #f8f0ff;
+  --bg-index-btn-hover: #f1e3fb;
+  --bg-index-btn-has-data: #54c5ff;
+  --bg-index-btn-has-data-hover: #32b7fb;
+  --color-index-btn: #60335b;
+  --color-index-btn-has-data: #10263c;
+  --radius-card: 20px;
+  --radius-button: 12px;
+  --radius-input: 16px;
+  --shadow-card: 0 14px 34px rgba(161, 88, 162, 0.22);
+  --shadow-card-hover: 0 20px 42px rgba(161, 88, 162, 0.28);
+  --shadow-navbar: 0 8px 26px rgba(72, 34, 96, 0.28);
+  --ykr-request-card-radius: 20px;
+  --ykr-request-chip-radius: 12px;
+  --ykr-request-card-shadow: 0 14px 34px rgba(161, 88, 162, 0.22);
+  --ykr-card-border: rgba(224, 122, 186, 0.54);
+  --ykr-card-border-strong: rgba(224, 122, 186, 0.74);
+  --ykr-card-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.78), rgba(255, 255, 255, 0.44));
+  --ykr-card-header-gradient: linear-gradient(90deg, rgba(255, 74, 167, 0.18), rgba(84, 197, 255, 0.18));
+  --ykr-navbar-bg: rgba(74, 38, 87, 0.92);
+  --ykr-navbar-border: rgba(255, 197, 228, 0.34);
+  --ykr-input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.68);
+  --ykr-accent-glow: 0 0 18px rgba(255, 98, 176, 0.24);
+}
+
+[data-ykr-skin]:not([data-ykr-skin="default"]) .navbar.bg-dark {
+  background: var(--ykr-navbar-bg) !important;
+  border-bottom: 1px solid var(--ykr-navbar-border);
+  box-shadow: var(--shadow-navbar);
+}
+
+[data-ykr-skin]:not([data-ykr-skin="default"]) .search-hero,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .search-section,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .player-nowplaying,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .player-controls-card,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .cfg-card,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .card,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .accordion-item,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .dropdown-menu,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .modal-content,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .swap-banner,
+[data-ykr-skin]:not([data-ykr-skin="default"]) #stats-bar,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .list-toolbar {
+  border: 1px solid var(--ykr-card-border);
+  background-image: var(--ykr-card-gradient);
+  background-color: rgba(var(--bg-card-rgb, 255, 255, 255), calc(var(--bg-card-alpha, 1) * var(--ykr-skin-card-opacity, 1)));
+  box-shadow: var(--shadow-card);
+}
+
+[data-ykr-skin]:not([data-ykr-skin="default"]) .list-toolbar {
+  border-radius: var(--radius-card);
+  padding: 10px 12px;
+}
+
+[data-ykr-skin]:not([data-ykr-skin="default"]) .search-section-header,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .card-header,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .accordion-button,
+[data-ykr-skin]:not([data-ykr-skin="default"]) #stats-bar {
+  background-image: var(--ykr-card-header-gradient);
+  background-color: rgba(var(--bg-card-alt-rgb, 248, 244, 240), calc(var(--bg-card-alpha, 1) * var(--ykr-skin-card-opacity, 1)));
+}
+
+[data-ykr-skin]:not([data-ykr-skin="default"]) .accordion-button:not(.collapsed) {
+  background-image: var(--ykr-card-header-gradient);
+  color: var(--color-accent-secondary);
+}
+
+[data-ykr-skin]:not([data-ykr-skin="default"]) .form-control,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .form-select,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .input-group-text {
+  border-color: var(--ykr-card-border-strong);
+  background-color: rgba(var(--bg-card-rgb, 255, 255, 255), calc(var(--bg-card-alpha, 1) * var(--ykr-skin-card-opacity, 1)));
+  box-shadow: var(--ykr-input-shadow);
+}
+
+[data-ykr-skin] .notice-embedded-html,
+[data-ykr-skin] .ykr-notice-embedded {
+  color: var(--color-text);
+  border: 1px solid var(--ykr-card-border, var(--color-border));
+  border-radius: var(--radius-card);
+  background-image: var(--ykr-card-gradient, none);
+  background-color: rgba(var(--bg-card-rgb, 255, 255, 255), calc(var(--bg-card-alpha, 1) * var(--ykr-skin-card-opacity, 1)));
+  box-shadow: var(--shadow-card);
+}
+
+[data-ykr-skin] .notice-embedded-html :where(h1, h2, h3, h4, h5, h6, p, ul, ol, li, dl, dt, dd, span, small, strong, em, div, label, th, td, blockquote, code, pre) {
+  color: inherit;
+}
+
+[data-ykr-skin] .notice-embedded-html a {
+  color: var(--color-accent-secondary);
+}
+
+[data-ykr-skin] .notice-embedded-html :where(.card, .alert, .well, .accordion-item, .accordion-button, .accordion-body, .list-group-item, .dropdown-menu, .bg-light, .bg-white, .bg-info:not(.badge)) {
+  border-color: var(--ykr-card-border-strong, var(--color-border));
+  background-image: var(--ykr-card-gradient, none);
+  background-color: rgba(var(--bg-card-alt-rgb, 248, 244, 240), calc(var(--bg-card-alpha, 1) * var(--ykr-skin-card-opacity, 1)));
+  color: var(--color-text);
+}
+
+[data-ykr-skin] .notice-embedded-html :where(.btn, .btn-primary, .btn-secondary, .btn-outline-secondary) {
+  --bs-btn-border-radius: var(--radius-button);
+  border-radius: var(--radius-button);
+}
+
+[data-ykr-skin]:not([data-ykr-skin="default"]) .search-history-wrap,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .search-history-word,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .search-history-del,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .search-history-footer,
+[data-ykr-skin]:not([data-ykr-skin="default"]) #search-history-clear,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .card-comment-area {
+  background-color: rgba(var(--bg-card-alt-rgb, 248, 244, 240), calc(var(--bg-card-alpha, 1) * var(--ykr-skin-card-opacity, 1)));
+}
+
+[data-ykr-skin]:not([data-ykr-skin="default"]) .btn,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .reservation-tab-btn,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .index-btn,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .card-comment-area,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .player-key-display {
+  border-radius: var(--radius-button);
+}
+
+[data-ykr-skin] .btn-primary {
+  --bs-btn-bg: var(--color-accent);
+  --bs-btn-border-color: var(--color-accent);
+  --bs-btn-hover-bg: var(--color-accent-hover);
+  --bs-btn-hover-border-color: var(--color-accent-hover);
+  --bs-btn-active-bg: var(--color-accent-hover);
+  --bs-btn-active-border-color: var(--color-accent-hover);
+}
+
+[data-ykr-skin] .btn-secondary {
+  --bs-btn-border-radius: var(--radius-button);
+}
+
+[data-ykr-skin] .btn-outline-secondary {
+  --bs-btn-border-radius: var(--radius-button);
+}
+
+[data-ykr-skin]:not([data-ykr-skin="default"]) .btn-primary,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .search-hero .btn-search-submit,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .btn-request,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .reservation-tab-btn.active,
+[data-ykr-skin]:not([data-ykr-skin="default"]) .index-btn.has-data {
+  box-shadow: var(--ykr-accent-glow);
+}
+
+[data-ykr-skin="oshi"] .search-section,
+[data-ykr-skin="oshi"] .search-hero,
+[data-ykr-skin="oshi"] .player-nowplaying,
+[data-ykr-skin="oshi"] .player-controls-card,
+[data-ykr-skin="oshi"] .card,
+[data-ykr-skin="oshi"] .cfg-card,
+[data-ykr-skin="oshi"] #stats-bar,
+[data-ykr-skin="oshi"] .list-toolbar,
+[data-ykr-skin="oshi"] .request-card {
+  color: var(--color-text);
+}
+
+[data-ykr-skin="oshi"] .search-section-header,
+[data-ykr-skin="oshi"] .card-header,
+[data-ykr-skin="oshi"] .accordion-button,
+[data-ykr-skin="oshi"] .search-hero label,
+[data-ykr-skin="oshi"] .search-result-count,
+[data-ykr-skin="oshi"] .search-tips,
+[data-ykr-skin="oshi"] .index-section-label,
+[data-ykr-skin="oshi"] .card-label,
+[data-ykr-skin="oshi"] .card-meta {
+  color: var(--color-text) !important;
+}
+
+[data-ykr-skin="oshi"] .reservation-tab-btn,
+[data-ykr-skin="oshi"] .page-btn,
+[data-ykr-skin="oshi"] .search-history-word,
+[data-ykr-skin="oshi"] .search-history-del,
+[data-ykr-skin="oshi"] #search-history-clear,
+[data-ykr-skin="oshi"] .index-btn {
+  color: var(--color-text);
+}
+
+[data-ykr-skin="oshi"] .btn,
+[data-ykr-skin="oshi"] .btn-outline-secondary,
+[data-ykr-skin="oshi"] .btn-secondary,
+[data-ykr-skin="oshi"] .notice-embedded-html :where(.btn, .btn-secondary, .btn-outline-secondary, .bg-light, .bg-white, .card, .alert, .well),
+[data-ykr-skin="oshi"] .notice-embedded-html :where(h1, h2, h3, h4, h5, h6, p, li, span, small, strong, em, div, label, th, td, code, pre) {
+  color: var(--color-text);
+}
+
+[data-ykr-skin="glass"] .search-hero {
+  position: relative;
+}
+
+[data-ykr-skin="glass"] .search-hero:focus-within {
+  z-index: 1202;
+}
+
+[data-ykr-skin="glass"] .search-section {
+  position: relative;
+  z-index: 1;
+}
+
+[data-ykr-skin="glass"] .search-history-wrap {
+  isolation: isolate;
+}
+
+[data-ykr-skin="glass"] #search-history-dropdown {
+  z-index: 1203;
+}
+
+[data-theme="dark"] [data-ykr-skin="glass"] {
+  --bg-card-rgb: 34, 26, 58;
+  --bg-card-alt-rgb: 48, 38, 78;
+  --bg-input: rgba(30, 24, 54, 0.92);
+  --color-text: #f7efff;
+  --color-text-muted: #d9c7f4;
+  --color-border: rgba(255, 255, 255, 0.20);
+  --bg-index-btn: rgba(255, 255, 255, 0.08);
+  --bg-index-btn-hover: rgba(255, 255, 255, 0.16);
+  --color-index-btn: #f7efff;
+  --shadow-card: 0 16px 40px rgba(20, 12, 38, 0.30);
+  --shadow-card-hover: 0 24px 52px rgba(20, 12, 38, 0.40);
+  --shadow-navbar: 0 8px 30px rgba(8, 8, 20, 0.35);
+  --ykr-request-card-shadow: 0 16px 40px rgba(20, 12, 38, 0.30);
+  --ykr-card-border: rgba(255, 255, 255, 0.20);
+  --ykr-card-border-strong: rgba(255, 255, 255, 0.24);
+  --ykr-card-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.05));
+  --ykr-card-header-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.04));
+  --ykr-navbar-bg: rgba(14, 12, 24, 0.86);
+  --ykr-navbar-border: rgba(255, 255, 255, 0.14);
+  --ykr-input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.10);
+}
+
+[data-theme="dark"] [data-ykr-skin="live"] {
+  --bg-card-rgb: 18, 20, 32;
+  --bg-card-alt-rgb: 27, 30, 48;
+  --bg-input: #171b2a;
+  --color-text: #f8fbff;
+  --color-text-muted: #aeb6ca;
+  --color-border: rgba(80, 110, 164, 0.45);
+  --bg-index-btn: #151a29;
+  --bg-index-btn-hover: #1d2337;
+  --bg-index-btn-has-data: #204f7d;
+  --bg-index-btn-has-data-hover: #276494;
+  --color-index-btn: #dce7ff;
+  --shadow-card: 0 10px 26px rgba(0, 0, 0, 0.32);
+  --shadow-card-hover: 0 16px 36px rgba(0, 0, 0, 0.42);
+  --shadow-navbar: 0 8px 26px rgba(0, 0, 0, 0.40);
+  --ykr-request-card-shadow: 0 10px 26px rgba(0, 0, 0, 0.32);
+  --ykr-card-border: rgba(61, 92, 141, 0.58);
+  --ykr-card-border-strong: rgba(69, 116, 177, 0.72);
+  --ykr-card-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  --ykr-card-header-gradient: linear-gradient(90deg, rgba(255, 79, 154, 0.15), rgba(45, 201, 255, 0.12));
+  --ykr-navbar-bg: rgba(9, 12, 20, 0.92);
+  --ykr-navbar-border: rgba(255, 79, 154, 0.18);
+  --ykr-input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+[data-theme="dark"] [data-ykr-skin="minimal"] {
+  --bg-card-rgb: 28, 31, 40;
+  --bg-card-alt-rgb: 36, 41, 53;
+  --bg-input: #1d2230;
+  --color-text: #eff3f8;
+  --color-text-muted: #b0b8c5;
+  --color-index-btn: #d7deea;
+  --ykr-card-border: rgba(148, 163, 184, 0.24);
+  --ykr-card-border-strong: rgba(148, 163, 184, 0.34);
+}
+
+[data-theme="dark"] [data-ykr-skin="wa"] {
+  --bg-card-rgb: 40, 26, 24;
+  --bg-card-alt-rgb: 58, 38, 34;
+  --bg-input: #2d1d1b;
+  --color-text: #f5e8d8;
+  --color-text-muted: #d0b49d;
+  --color-index-btn: #f5e8d8;
+  --ykr-card-border: rgba(212, 170, 116, 0.26);
+  --ykr-card-border-strong: rgba(212, 170, 116, 0.38);
+}
+
+[data-theme="dark"] [data-ykr-skin="oshi"] {
+  --bg-card-rgb: 58, 34, 62;
+  --bg-card-alt-rgb: 76, 48, 84;
+  --bg-input: #432849;
+  --color-text: #fff0fb;
+  --color-text-muted: #f2c8e8;
+  --bg-index-btn: #6d4d73;
+  --bg-index-btn-hover: #7b5980;
+  --ykr-card-gradient: linear-gradient(180deg, rgba(72, 40, 82, 0.82), rgba(52, 28, 60, 0.58));
+  --ykr-card-header-gradient: linear-gradient(90deg, rgba(255, 74, 167, 0.20), rgba(84, 197, 255, 0.14));
+  --color-index-btn: #fff0fb;
+  --color-index-btn-has-data: #13283a;
+  --ykr-card-border: rgba(255, 168, 223, 0.34);
+  --ykr-card-border-strong: rgba(255, 168, 223, 0.48);
+}

--- a/init.php
+++ b/init.php
@@ -25,6 +25,15 @@ $easyauth = new EasyAuth();
 $easyauth -> do_eashauthcheck();
 
 $newconfig = $_REQUEST;
+if (array_key_exists('ui_skin_preset', $newconfig)) {
+  $newconfig['ui_skin_preset'] = get_ui_skin_preset($newconfig['ui_skin_preset']);
+}
+if (array_key_exists('ui_skin_shape', $newconfig)) {
+  $newconfig['ui_skin_shape'] = get_ui_skin_shape($newconfig['ui_skin_shape']);
+}
+if (array_key_exists('ui_skin_card_opacity', $newconfig)) {
+  $newconfig['ui_skin_card_opacity'] = (string)get_ui_skin_card_opacity($newconfig['ui_skin_card_opacity']);
+}
 
 // 背景画像のアップロード/削除処理
 // クロップ済み画像はクライアントから data URL (base64) で送信される。
@@ -164,7 +173,7 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 </head>
-<body>
+<body<?php echo bs5_skin_data_attr(); ?>>
 <?php
 shownavigatioinbar_bs5('init.php');
 ?>
@@ -315,6 +324,9 @@ print '</pre>';
     </li>
     <li class="menu">
      <a href="#bgcolor_t" class="menulink" > ページ背景色 </a>
+    </li>
+    <li class="menu">
+     <a href="#ui_skin_preset_t" class="menulink" > 外観プリセット </a>
     </li>
     <li class="menu">
      <a href="#bgimage_t" class="menulink" > 背景画像 </a>
@@ -779,6 +791,9 @@ print ' value="10" ';
       if(array_key_exists("bgcolor",$config_ini)){
              $bgcolor=urldecode($config_ini["bgcolor"]);
       }
+      $current_ui_skin_preset = get_ui_skin_preset();
+            $current_ui_skin_shape = get_ui_skin_shape();
+            $current_ui_skin_card_opacity = get_ui_skin_card_opacity();
   ?>
 </div></div>
 
@@ -804,6 +819,58 @@ print ' value="10" ';
       }
       bgEl.addEventListener('input', applyBgColor);
       bgEl.addEventListener('change', applyBgColor);
+  })();
+  </script>
+
+  <div class="mb-3" style="margin-top:12px;">
+    <h3 id="ui_skin_preset_t" class="radio form-label menulink"> 外観プリセット </h3>
+    <label for="ui_skin_preset" class="form-label"><small>BS5画面のカード形状、影、枠線、アクセント色をまとめて切り替えます。既存の背景画像・背景色・透過度設定はそのまま併用されます。</small></label>
+    <select name="ui_skin_preset" id="ui_skin_preset" class="form-select" style="max-width:320px;">
+      <option value="default" <?php echo selectedcheck($current_ui_skin_preset, 'default'); ?>>標準</option>
+      <option value="glass" <?php echo selectedcheck($current_ui_skin_preset, 'glass'); ?>>ガラス</option>
+      <option value="live" <?php echo selectedcheck($current_ui_skin_preset, 'live'); ?>>ライブ</option>
+      <option value="wa" <?php echo selectedcheck($current_ui_skin_preset, 'wa'); ?>>和風</option>
+      <option value="minimal" <?php echo selectedcheck($current_ui_skin_preset, 'minimal'); ?>>ミニマル</option>
+      <option value="oshi" <?php echo selectedcheck($current_ui_skin_preset, 'oshi'); ?>>推し活</option>
+    </select>
+    <small>未設定・空欄・不正値は自動で標準になります。</small>
+  </div>
+  <div class="mb-3">
+    <label for="ui_skin_shape" class="form-label"><small>図形・ボタンの形状</small></label>
+    <select name="ui_skin_shape" id="ui_skin_shape" class="form-select" style="max-width:320px;">
+      <option value="preset" <?php echo selectedcheck($current_ui_skin_shape, 'preset'); ?>>プリセット準拠</option>
+      <option value="default" <?php echo selectedcheck($current_ui_skin_shape, 'default'); ?>>標準の図形</option>
+    </select>
+    <small>色や質感はプリセットを維持したまま、カードを標準寄りに戻せます。</small>
+  </div>
+  <div class="mb-3">
+    <label for="ui_skin_card_opacity"><small>プリセット面の透過度: <span id="ui_skin_card_opacity_val"><?php echo $current_ui_skin_card_opacity; ?></span>%</small></label>
+    <input type="range" name="ui_skin_card_opacity" id="ui_skin_card_opacity" min="0" max="100" step="1" value="<?php echo $current_ui_skin_card_opacity; ?>" style="max-width:320px;" />
+    <small>プリセットが加えるカード面・ヘッダー面の見え方だけを調整します。既存のカード透過度設定とも併用されます。</small>
+  </div>
+  <script>
+  (function(){
+      var skinEl = document.getElementById('ui_skin_preset');
+      var shapeEl = document.getElementById('ui_skin_shape');
+      var opacityEl = document.getElementById('ui_skin_card_opacity');
+      var opacityLabel = document.getElementById('ui_skin_card_opacity_val');
+      if (!skinEl || !shapeEl || !opacityEl || !opacityLabel) return;
+      function applySkinPreview(){
+          var value = skinEl.value || 'default';
+          var shape = shapeEl.value || 'preset';
+          var opacity = Math.max(0, Math.min(100, parseInt(opacityEl.value, 10) || 0));
+          document.body.setAttribute('data-ykr-skin', value);
+          document.body.setAttribute('data-ykr-shape', shape);
+          document.documentElement.style.setProperty('--ykr-skin-card-opacity', String(opacity / 100));
+          opacityLabel.textContent = String(opacity);
+      }
+      skinEl.addEventListener('input', applySkinPreview);
+      skinEl.addEventListener('change', applySkinPreview);
+      shapeEl.addEventListener('input', applySkinPreview);
+      shapeEl.addEventListener('change', applySkinPreview);
+      opacityEl.addEventListener('input', applySkinPreview);
+      opacityEl.addEventListener('change', applySkinPreview);
+      applySkinPreview();
   })();
   </script>
 

--- a/kara_config.php
+++ b/kara_config.php
@@ -147,6 +147,15 @@ function readconfig_array()
     if(!array_key_exists("usenewrequestlist", $config_ini)){
         $config_ini = array_merge($config_ini,array("usenewrequestlist" => 1));
     }
+    if(!array_key_exists("ui_skin_preset", $config_ini)){
+        $config_ini["ui_skin_preset"] = urlencode("default");
+    }
+    if(!array_key_exists("ui_skin_shape", $config_ini)){
+        $config_ini["ui_skin_shape"] = urlencode("preset");
+    }
+    if(!array_key_exists("ui_skin_card_opacity", $config_ini)){
+        $config_ini["ui_skin_card_opacity"] = 100;
+    }
     if(!array_key_exists("secret_display_text", $config_ini)){
         $config_ini["secret_display_text"] = urlencode("ヒ・ミ・ツ♪(シークレットリクエスト)");
     }

--- a/playerctrl_portal_bs5.php
+++ b/playerctrl_portal_bs5.php
@@ -20,7 +20,7 @@ if (!empty($config_ini['roomurl'])) {
 ?>プレイヤーコントローラー</title>
 <?php print_bs5_head_core(['css/themes/player.css'], ['jquery' => true]); ?>
 </head>
-<body>
+<body<?php echo bs5_skin_data_attr(); ?>>
 <?php shownavigatioinbar_bs5('playerctrl_portal_bs5.php'); ?>
 
 <div class="container pt-3 pb-4" style="max-width:540px;">

--- a/request_confirm_bs5.php
+++ b/request_confirm_bs5.php
@@ -183,9 +183,8 @@ function extention_musiccheck($fn){
 <html lang="ja">
 <head>
 <?php print_meta_header(); ?>
-<?php print_bs5_head_core([], ['jquery' => true]); ?>
+<?php print_bs5_head_core(['css/style.css'], ['jquery' => true]); ?>
 <title>リクエスト確認画面</title>
-<link type="text/css" rel="stylesheet" href="css/style.css" />
 <script type="text/javascript">
 
 function check(selectf){
@@ -222,7 +221,7 @@ $nanasyname = $config_ini["nonameusername"];
 > </script>
 
 </head>
-<body>
+<body<?php echo bs5_skin_data_attr(); ?>>
 <?php
 $YkariUsername = "";
 if(array_key_exists("YkariUsername", $_COOKIE)) {

--- a/request_confirm_url_bs5.php
+++ b/request_confirm_url_bs5.php
@@ -110,9 +110,8 @@ function json_safe_encode($data){
 <html lang="ja">
 <head>
 <?php print_meta_header(); ?>
-<?php print_bs5_head_core([], ['jquery' => true]); ?>
+<?php print_bs5_head_core(['css/style.css'], ['jquery' => true]); ?>
 <title>リクエスト確認画面</title>
-<link type="text/css" rel="stylesheet" href="css/style.css" />
 <script type="text/javascript">
 
 function check(selectf){
@@ -148,7 +147,7 @@ $nanasyname = $config_ini["nonameusername"];
      data-nanasyflg ='<?php echo json_safe_encode($config_ini['nonamerequest']); ?>'
 > </script>
 </head>
-<body>
+<body<?php echo bs5_skin_data_attr(); ?>>
 <?php
 $YkariUsername = "";
 if(array_key_exists("YkariUsername", $_COOKIE)) {

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -29,13 +29,7 @@ $requestlist_num = isset($config_ini['requestlist_num']) ? (int)$config_ini['req
 <meta http-equiv="cache-control" content="no-cache">
 <meta http-equiv="expires"       content="0">
 <title><?php echo htmlspecialchars($titlePrefix, ENT_QUOTES, 'UTF-8'); ?>リクエスト一覧</title>
-<script>(function(){if(window.__ykThemeInit)return;window.__ykThemeInit=true;try{var t=localStorage.getItem("ykari-theme")||"light",f=localStorage.getItem("ykari-fontsize")||"normal";document.documentElement.setAttribute("data-theme",t);document.documentElement.setAttribute("data-fontsize",f);}catch(e){}})();</script>
-<link href="css/bootstrap5/bootstrap.min.css" rel="stylesheet">
-<link href="css/themes/_variables.css"         rel="stylesheet">
-<link href="css/style.css"                    rel="stylesheet">
-<link href="css/themes/theme-toggle.css"      rel="stylesheet">
-<script src="js/bootstrap5/bootstrap.bundle.min.js"></script>
-<script src="js/theme-toggle.js"></script>
+<?php print_bs5_head_core(['css/style.css']); ?>
 <!-- SortableJS: js/Sortable.min.js に配置してください。取得先: https://cdn.jsdelivr.net/npm/sortablejs@1.15.3/Sortable.min.js -->
 <script src="js/Sortable.min.js"></script>
 <style>
@@ -59,9 +53,13 @@ $requestlist_num = isset($config_ini['requestlist_num']) ? (int)$config_ini['req
   position: relative;
   overflow: hidden;
   margin-bottom: 6px;
-  border-radius: 6px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+    border-radius: var(--ykr-request-card-radius, 6px);
+    box-shadow: var(--ykr-request-card-shadow, 0 1px 3px rgba(0,0,0,0.15));
   background: rgba(var(--bg-card-rgb, 255, 255, 255), var(--bg-card-alpha, 1));
+    background-image: var(--ykr-card-gradient, none);
+    border-top: 1px solid var(--ykr-card-border, rgba(0,0,0,0));
+    border-right: 1px solid var(--ykr-card-border, rgba(0,0,0,0));
+    border-bottom: 1px solid var(--ykr-card-border, rgba(0,0,0,0));
   border-left: 4px solid var(--color-border, #ced4da);
   -webkit-user-select: none;
   user-select: none;
@@ -222,9 +220,9 @@ $requestlist_num = isset($config_ini['requestlist_num']) ? (int)$config_ini['req
   padding: 4px 8px;
   min-height: 24px;
   margin-top: 5px;
-  background: var(--bg-card-alt, #f8f9fa);
-  border-radius: 6px;
-  border: 1px solid var(--color-border, #e9ecef);
+    background: rgba(var(--bg-card-alt-rgb, 248, 244, 240), var(--bg-card-alpha, 1));
+    border-radius: var(--ykr-request-chip-radius, 6px);
+    border: 1px solid var(--ykr-card-border, var(--color-border, #e9ecef));
   transition: border-color 0.15s, color 0.15s;
 }
 .card-comment-area:hover { color: var(--bs-primary); border-color: var(--bs-primary); }
@@ -411,14 +409,14 @@ $requestlist_num = isset($config_ini['requestlist_num']) ? (int)$config_ini['req
 [data-theme="dark"] .sortable-ghost { background: #1a2a4a !important; }
 </style>
 </head>
-<body>
+<body<?php echo bs5_skin_data_attr(); ?>>
 <?php shownavigatioinbar_bs5(); ?>
 <div class="container">
 <?php
 showmode();
 
 if (!empty($config_ini['noticeof_listpage'])) {
-    echo '<div class="p-3 mb-3 border rounded bg-light notice-embedded-html">';
+  echo '<div class="p-3 mb-3 notice-embedded-html ykr-notice-embedded">';
     echo str_replace('#yukarihost#', $_SERVER['HTTP_HOST'], urldecode($config_ini['noticeof_listpage']));
     echo '</div>';
 }

--- a/search_anisoninfo_list_bs5.php
+++ b/search_anisoninfo_list_bs5.php
@@ -113,7 +113,7 @@ mypage_action_script();
 <title>anison.info検索</title>
 <?php print_bs5_search_head(); ?>
 </head>
-<body>
+<body<?php echo bs5_skin_data_attr(); ?>>
 <?php shownavigatioinbar_bs5('searchreserve.php'); ?>
 <?php showuppermenu('', $linkoption); ?>
 

--- a/search_bs5.php
+++ b/search_bs5.php
@@ -453,7 +453,7 @@ if (!empty($config_ini['roomurl'])) {
 ?>動画検索</title>
 <?php print_bs5_search_head(); ?>
 </head>
-<body>
+<body<?php echo bs5_skin_data_attr(); ?>>
 
 <?php shownavigatioinbar_bs5('searchreserve.php'); ?>
 
@@ -530,15 +530,16 @@ else:
                         print_listerdb_fileonly();
                     }
                     break;
-                case 1:
-                    if (checkbox_check($config_ini['searchitem'], "listerDB")) {
-                        // 作品名インデックス検索は常時開いた状態にする
-                        _section_open('sec-listerdb', '作品名インデックス検索', true);
-                        print_listerdb_search();
-                        _section_close();
-                        $first = false;
-                    }
-                    break;
+case 1:
+    if (checkbox_check($config_ini['searchitem'], "listerDB")) {
+        // 作品名インデックス検索は他セクションと同様に先頭時だけ展開する
+        _section_open('sec-listerdb', '作品名インデックス検索', $first);
+        print_listerdb_search();
+        _section_close();
+
+        $first = false;
+    }
+    break;
                 case 2:
                     if (checkbox_check($config_ini['searchitem'], "filesearch_e")) {
                         print_everything_filenamesearch($first);

--- a/search_listerdb_anysearch_index_bs5.php
+++ b/search_listerdb_anysearch_index_bs5.php
@@ -32,7 +32,7 @@ if (empty($includepage)) {
     print_meta_header();
     print_bs5_search_head();
     print '<title>りすたーDB検索</title>';
-    print '</head><body>';
+    print '</head><body' . bs5_skin_data_attr() . '>';
     if (empty($filesearch)) {
         shownavigatioinbar_bs5('searchreserve.php');
     }

--- a/search_listerdb_column_index_bs5.php
+++ b/search_listerdb_column_index_bs5.php
@@ -98,7 +98,7 @@ if (!$json) {
 <title><?php echo htmlspecialchars($searchitem, ENT_QUOTES, 'UTF-8'); ?>検索</title>
 <?php print_bs5_search_head(); ?>
 </head>
-<body>
+<body<?php echo bs5_skin_data_attr(); ?>>
 <?php shownavigatioinbar_bs5('searchreserve.php'); ?>
 <?php showuppermenu($target, $linkoption); ?>
 

--- a/search_listerdb_column_list_bs5.php
+++ b/search_listerdb_column_list_bs5.php
@@ -107,7 +107,7 @@ if (!empty($maker_name)) {
 <title><?php echo htmlspecialchars($searchitem, ENT_QUOTES, 'UTF-8'); ?>一覧</title>
 <?php print_bs5_search_head(); ?>
 </head>
-<body>
+<body<?php echo bs5_skin_data_attr(); ?>>
 <?php shownavigatioinbar_bs5('searchreserve.php'); ?>
 <?php showuppermenu($searchcolumn, $linkoption); ?>
 

--- a/search_listerdb_filelist_bs5.php
+++ b/search_listerdb_filelist_bs5.php
@@ -293,7 +293,7 @@ mypage_action_script();
 <title>ファイル一覧</title>
 <?php print_bs5_search_head(); ?>
 </head>
-<body>
+<body<?php echo bs5_skin_data_attr(); ?>>
 <?php shownavigatioinbar_bs5('searchreserve.php'); ?>
 <?php showuppermenu('filename', $linkoptionbare); ?>
 

--- a/search_listerdb_program_index_bs5.php
+++ b/search_listerdb_program_index_bs5.php
@@ -170,7 +170,7 @@ if (empty($includepage)) {
     print_meta_header();
     print_bs5_search_head();
     print '<title>作品名インデックス検索</title>';
-    print '</head><body>';
+    print '</head><body' . bs5_skin_data_attr() . '>';
     shownavigatioinbar_bs5('searchreserve.php');
 }
 showuppermenu('program_name', $linkoption);

--- a/search_listerdb_programlist_fromhead_bs5.php
+++ b/search_listerdb_programlist_fromhead_bs5.php
@@ -52,7 +52,7 @@ if (!empty($header)) {
 <title>作品名一覧</title>
 <?php print_bs5_search_head(); ?>
 </head>
-<body>
+<body<?php echo bs5_skin_data_attr(); ?>>
 <?php shownavigatioinbar_bs5('searchreserve.php'); ?>
 <?php showuppermenu('program_name', ltrim($linkoption, '&')); ?>
 

--- a/search_listerdb_songlist_bs5.php
+++ b/search_listerdb_songlist_bs5.php
@@ -127,7 +127,7 @@ mypage_action_script();
 <title>曲名一覧</title>
 <?php print_bs5_search_head(); ?>
 </head>
-<body>
+<body<?php echo bs5_skin_data_attr(); ?>>
 <?php shownavigatioinbar_bs5('searchreserve.php'); ?>
 <?php showuppermenu('', $linkoptionbare); ?>
 

--- a/searchbandit_bs5.php
+++ b/searchbandit_bs5.php
@@ -20,7 +20,7 @@ $linkoption = !empty($selectid) ? 'selectid=' . rawurlencode($selectid) : '';
 <script src="js/jquery.dataTables.js"></script>
 <script src="js/currency.js"></script>
 </head>
-<body>
+<body<?php echo bs5_skin_data_attr(); ?>>
 <?php shownavigatioinbar_bs5('searchreserve.php'); ?>
 <?php showuppermenu('', $linkoption); ?>
 

--- a/searchreserve_bs5.php
+++ b/searchreserve_bs5.php
@@ -14,7 +14,7 @@ if (array_key_exists("id", $_REQUEST)) $selectid = $_REQUEST["id"];
 <title>検索＆リクエストTOP</title>
 <?php print_bs5_search_head(); ?>
 </head>
-<body>
+<body<?php echo bs5_skin_data_attr(); ?>>
 <?php shownavigatioinbar_bs5('searchreserve.php'); ?>
 <div class="container py-4">
 <?php


### PR DESCRIPTION
﻿## 概要

BS5画面（Bootstrap5系UI）向けに、外観（見た目）をプリセットから選択・カスタマイズできる「外観プリセット設定」機能を追加・改善します。

## 現状の問題

これまでBS5画面の見た目（カード形状・角丸・影・背景の透過度など）はテーマ（ライト/ダーク）以外にカスタマイズする手段がなく、利用者の好みに合わせた外観変更ができませんでした。

## 修正内容

- commonfunc.php：`get_ui_skin_preset()`／`get_ui_skin_shape()`／`get_ui_skin_card_opacity()`／`bs5_skin_data_attr()` を新規追加。`print_bs5_head_core()` に `css/themes/skin-presets.css` の読み込みと、カード透過度用CSS変数（`--ykr-skin-card-opacity`）の出力を追加。
- css/themes/skin-presets.css（新規）：`default`／`glass`／`live`／`wa`／`minimal`／`oshi` の6種類の外観プリセットを定義。
- kara_config.php：`ui_skin_preset`／`ui_skin_shape`／`ui_skin_card_opacity` の設定項目のデフォルト値を追加。
- init.php：設定画面に外観プリセット選択（ドロップダウン）、カード形状選択、カード透過度スライダー、ライブプレビューを追加。
- 各BS5画面（search_bs5.php ほか）：`<body>` タグに `bs5_skin_data_attr()` を付与し、プリセットに応じた `data-ykr-skin` 属性を反映。
- requestlist_swipe.php：`.request-card`／`.card-comment-area` の見た目をCSS変数化し、プリセットに応じたスタイルを反映できるよう変更。
- search_bs5.php：「作品名インデックス検索」セクションの初期展開状態の改善。

## 影響範囲

対象ファイル（全20ファイル）：
commonfunc.php, kara_config.php, init.php, css/themes/skin-presets.css（新規）, search_bs5.php, requestlist_swipe.php, playerctrl_portal_bs5.php, comment.php, request_confirm_bs5.php, request_confirm_url_bs5.php, searchreserve_bs5.php, search_anisoninfo_list_bs5.php, search_listerdb_anysearch_index_bs5.php, search_listerdb_column_index_bs5.php, search_listerdb_column_list_bs5.php, search_listerdb_filelist_bs5.php, search_listerdb_program_index_bs5.php, search_listerdb_programlist_fromhead_bs5.php, search_listerdb_songlist_bs5.php, searchbandit_bs5.php

## 確認方法

1. 設定画面（init.php）で外観プリセットを切り替え、各BS5画面の見た目（カード形状・角丸・影・透過度）がプリセットに応じて変化することを確認する。
2. カード透過度スライダーを操作し、リアルタイムでプレビューに反映されることを確認する。
3. search_bs5.php の「作品名インデックス検索」セクションの初期展開状態が改善されていることを確認する。
4. 既存のテーマ切り替え（ライト/ダーク）機能に影響がないことを確認する。

## 関連Issue

本家Issue作成権限がないため、fork側Issueを修正依頼の整理用Issueとして作成しています。このPR本文を本家向けの修正依頼として提出します。

fork側Issue: https://github.com/hachi515tennis3-glitch/KaraokeRequestorWeb/issues/5
