### PR TITLE
fix: PR #190 提案の①〜④を採用(周回順序/MPC音量/iOS壁紙/曲停止確認)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ updatenotice.db
 # プレイヤー画面の永続化設定（TV依存のため環境ごと）
 player_compensation.json
 
+# 曲別音量オフセットの適用状態（実行時に生成）
+volume_offset_state.json
+
 # ゆかりすたー 4 NEBULA により生成されるフォルダー
 list/
 

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1926,13 +1926,15 @@ function print_bg_style_block($is_bs5 = false) {
         print 'html{background-color:var(--bg-page, #F8ECE0) !important;}body{background-color:transparent !important;}';
         // iOS Safari は visual viewport の高さ変化(URLバー表示/非表示)に合わせて
         // inset:0 の fixed 要素を伸縮させるため、background-size:cover が再計算されて
-        // 背景が拡大縮小して見える。100lvh ベースの固定高に切り替え、さらに safe area と
-        // オーバースキャン分だけ大きめに描画して、iPhone 下端の白い帯露出も防ぐ。
+        // 背景が拡大縮小して見える。100lvh ベースの固定高に切り替える。
+        // 注意: env(safe-area-inset-bottom) はバー表示中=0px ↔ 格納時=約34px と
+        // 動的に変わるため、サイズ計算に含めると伸縮が再発する。オーバースキャン分は
+        // env() を使わず固定マージン(上下80px/左右40px)で確保する。
         print 'html::before{content:"";position:fixed;'
-            . 'top:calc(-24px - env(safe-area-inset-top, 0px));left:calc(-24px - env(safe-area-inset-left, 0px));'
-            . 'width:calc(100vw + env(safe-area-inset-left, 0px) + env(safe-area-inset-right, 0px) + 48px);'
-            . 'height:calc(100vh + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px) + 120px);'
-            . 'height:calc(100lvh + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px) + 120px);'
+            . 'top:-80px;left:-40px;'
+            . 'width:calc(100vw + 80px);'
+            . 'height:calc(100vh + 160px);'
+            . 'height:calc(100lvh + 160px);'
             . 'z-index:-2;pointer-events:none;filter:none !important;'
             . 'background-image:var(--bg-page-image);background-repeat:no-repeat;'
             . 'background-size:cover;background-position:center center;'
@@ -1949,10 +1951,10 @@ function print_bg_style_block($is_bs5 = false) {
         // body::before = オーバーレイ色レイヤー。画像レイヤー(z-index:-2)の上に重ねる。
         // ダークモードの brightness フィルタが背景画像に影響しないよう filter:none を指定。
         print 'body::before{content:"";position:fixed;'
-            . 'top:calc(-24px - env(safe-area-inset-top, 0px));left:calc(-24px - env(safe-area-inset-left, 0px));'
-            . 'width:calc(100vw + env(safe-area-inset-left, 0px) + env(safe-area-inset-right, 0px) + 48px);'
-            . 'height:calc(100vh + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px) + 120px);'
-            . 'height:calc(100lvh + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px) + 120px);'
+            . 'top:-80px;left:-40px;'
+            . 'width:calc(100vw + 80px);'
+            . 'height:calc(100vh + 160px);'
+            . 'height:calc(100lvh + 160px);'
             . 'z-index:-1;pointer-events:none;background-image:none !important;'
             . 'background-color:rgba(var(--bg-page-rgb, 248, 236, 224), var(--bg-overlay-alpha, 1));'
             . 'filter:none !important;}';

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1962,6 +1962,10 @@ function print_bg_style_block($is_bs5 = false) {
         // 違和感が出るため、暗色オーバーレイに置き換える。透過率は --bg-overlay-alpha を共用。
         print '[data-theme="dark"] body::before{'
             . 'background-color:rgba(18, 18, 30, var(--bg-overlay-alpha, 1));}';
+        // 下記の計測スクリプトが固定px高を確定できた場合は vh/lvh 指定より優先する。
+        // (JS無効時は data-ykr-bgfix が付かず、上の lvh フォールバックがそのまま使われる)
+        print 'html[data-ykr-bgfix="1"]::before{height:var(--ykr-bg-fixed-h);}';
+        print 'html[data-ykr-bgfix="1"] body::before{height:var(--ykr-bg-fixed-h);}';
     }
 
     if ($has_bgimage && $card_alpha < 1.0) {
@@ -2022,6 +2026,32 @@ function print_bg_style_block($is_bs5 = false) {
     }
 
     print '</style>';
+
+    if ($has_bgimage) {
+        // Chrome iOS(CriOS)や各種アプリ内ブラウザは、ツールバー開閉時に WebView
+        // 自体をリサイズするため、vh も lvh もすべて動的に変わり、CSS 単体では
+        // 背景疑似要素の伸縮(=cover 再計算によるズーム)を止められない。
+        // (Safari はレイアウトビューポート固定方式なので lvh 指定だけで足りる)
+        // そこで実測した最大ビューポート高を固定 px として CSS 変数に焼き付け、
+        // ビューポート単位の再計算そのものを背景の高さから排除する。
+        // - 同一幅の間は「観測した最大の高さ」のみ採用(ツールバー格納時の値に収束)
+        // - 幅が変わったとき(画面回転・ウィンドウリサイズ)は測り直す
+        // - キーボード表示などの高さ減少では更新しない
+        print '<script>(function(){'
+            . 'var doc=document.documentElement,maxH=0,lastW=0;'
+            . 'function apply(){'
+            . 'var w=window.innerWidth,h=window.innerHeight;'
+            . 'if(!w||!h)return;'
+            . 'if(w!==lastW){lastW=w;maxH=0;}'
+            . 'if(h>maxH){maxH=h;'
+            . 'doc.style.setProperty("--ykr-bg-fixed-h",(maxH+160)+"px");'
+            . 'doc.setAttribute("data-ykr-bgfix","1");}'
+            . '}'
+            . 'apply();'
+            . 'window.addEventListener("resize",apply);'
+            . 'window.addEventListener("orientationchange",function(){setTimeout(apply,350);});'
+            . '})();</script>';
+    }
 }
 
 function writeconfig2ini($config_ini,$configfile)

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1970,9 +1970,9 @@ function print_bg_style_block($is_bs5 = false) {
         //     アンカー辺を UA に応じて切り替える(下記スクリプトが属性を付与) ===
         // - iOS Safari: 下辺のみ動く → 上端アンカー(既定)で完全静止
         // - Android Chrome 等: 上辺のみ動く(下端=画面下端で不動) → 下端アンカーで静止
-        // - iOS Chrome 系: 上下両方動く → どのアンカーでも数十px残る。中央なら
-        //   ずれ=上下の変化量の差の半分。実測比較用に ?bganchor=top|center|bottom で
-        //   上書き可能にしてある。
+        // - iOS Chrome 系: 上下両方動くためどのアンカーでも多少残る。実機比較の結果、
+        //   上端アンカー(既定)が最小だったため専用分岐は持たない。
+        //   ?bganchor=top|center|bottom で上書きして再比較できる。
         print 'html[data-ykr-bganchor="center"]::before,'
             . 'html[data-ykr-bganchor="center"] body::before{'
             . 'top:50%;'
@@ -2055,7 +2055,6 @@ function print_bg_style_block($is_bs5 = false) {
             . 'var doc=document.documentElement,maxH=0,lastW=0;'
             . 'var ua=navigator.userAgent,anchor="";'
             . 'if(/Android/i.test(ua)){anchor="bottom";}'
-            . 'else if(/CriOS|FxiOS|EdgiOS/.test(ua)){anchor="center";}'
             . 'var am=location.search.match(/[?&]bganchor=(top|center|bottom)/);'
             . 'if(am){anchor=(am[1]==="top")?"":am[1];}'
             . 'if(anchor){doc.setAttribute("data-ykr-bganchor",anchor);}'

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1966,6 +1966,15 @@ function print_bg_style_block($is_bs5 = false) {
         // (JS無効時は data-ykr-bgfix が付かず、上の lvh フォールバックがそのまま使われる)
         print 'html[data-ykr-bgfix="1"]::before{height:var(--ykr-bg-fixed-h);}';
         print 'html[data-ykr-bgfix="1"] body::before{height:var(--ykr-bg-fixed-h);}';
+        // WebViewリサイズ型ブラウザ(Chrome iOS 等)は上下両方のバーが開閉して
+        // ビューポートの上端も動くため、上端アンカーだと背景が上バーの変化量ぶん
+        // 縦にずれる。中央アンカーなら、ずれは上下バーの変化量の差の半分(数px)まで
+        // 縮み実質静止して見える。Safari は上端が動かず現行の上端アンカーが完全
+        // 静止のため対象外(下記スクリプトが UA で切り替える)。
+        print 'html[data-ykr-bganchor="center"]::before,'
+            . 'html[data-ykr-bganchor="center"] body::before{'
+            . 'top:50%;'
+            . 'transform:translate3d(0,-50%,0);-webkit-transform:translate3d(0,-50%,0);}';
     }
 
     if ($has_bgimage && $card_alpha < 1.0) {
@@ -2039,6 +2048,7 @@ function print_bg_style_block($is_bs5 = false) {
         // - キーボード表示などの高さ減少では更新しない
         print '<script>(function(){'
             . 'var doc=document.documentElement,maxH=0,lastW=0;'
+            . 'if(/CriOS|FxiOS|EdgiOS/.test(navigator.userAgent)){doc.setAttribute("data-ykr-bganchor","center");}'
             . 'function apply(){'
             . 'var w=window.innerWidth,h=window.innerHeight;'
             . 'if(!w||!h)return;'

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1017,7 +1017,8 @@ function print_meta_header(){
     print "\n";
     print '<meta http-equiv="Content-Script-Type" content="text/javascript" />';
     print "\n";
-    print '<meta name="viewport" content="width=device-width,initial-scale=1.0" />';
+    // iPhone の safe area まで背景・UI を拡張できるよう viewport-fit=cover を付与する。
+    print '<meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover" />';
     print "\n";
 }
 
@@ -1920,10 +1921,23 @@ function print_bg_style_block($is_bs5 = false) {
         // html::before = 固定背景画像レイヤー。
         // iOS Safari は body の background-attachment:fixed をサポートしていないため、
         // position:fixed の疑似要素で代替することで全ブラウザ・全デバイスで背景を固定する。
-        print 'html,body{background-color:transparent !important;}';
-        print 'html::before{content:"";position:fixed;inset:0;z-index:-2;pointer-events:none;'
-            . 'filter:none !important;'
-            . 'background-image:var(--bg-page-image);background-size:cover;background-position:center;}';
+        // iPhone Safari はブラウザUI背面に root 背景色を使うことがあるため、
+        // html 側には常にページ背景色を持たせて白抜けを防ぐ。body は透過のままにする。
+        print 'html{background-color:var(--bg-page, #F8ECE0) !important;}body{background-color:transparent !important;}';
+        // iOS Safari は visual viewport の高さ変化(URLバー表示/非表示)に合わせて
+        // inset:0 の fixed 要素を伸縮させるため、background-size:cover が再計算されて
+        // 背景が拡大縮小して見える。100lvh ベースの固定高に切り替え、さらに safe area と
+        // オーバースキャン分だけ大きめに描画して、iPhone 下端の白い帯露出も防ぐ。
+        print 'html::before{content:"";position:fixed;'
+            . 'top:calc(-24px - env(safe-area-inset-top, 0px));left:calc(-24px - env(safe-area-inset-left, 0px));'
+            . 'width:calc(100vw + env(safe-area-inset-left, 0px) + env(safe-area-inset-right, 0px) + 48px);'
+            . 'height:calc(100vh + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px) + 120px);'
+            . 'height:calc(100lvh + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px) + 120px);'
+            . 'z-index:-2;pointer-events:none;filter:none !important;'
+            . 'background-image:var(--bg-page-image);background-repeat:no-repeat;'
+            . 'background-size:cover;background-position:center center;'
+            . 'transform:translate3d(0,0,0);-webkit-transform:translate3d(0,0,0);'
+            . '-webkit-backface-visibility:hidden;backface-visibility:hidden;}';
         // スマホ縦持ち(縦長表示)のときだけ専用画像に切り替える。
         // orientation:portrait を条件に加えることで、小型端末を横持ちにした際
         // (幅が 768px 以下のままでも)は PC 用の横長画像が使われるようにする。
@@ -1934,8 +1948,12 @@ function print_bg_style_block($is_bs5 = false) {
         print 'body{background-image:none !important;}';
         // body::before = オーバーレイ色レイヤー。画像レイヤー(z-index:-2)の上に重ねる。
         // ダークモードの brightness フィルタが背景画像に影響しないよう filter:none を指定。
-        print 'body::before{content:"";position:fixed;inset:0;z-index:-1;pointer-events:none;'
-            . 'background-image:none !important;'
+        print 'body::before{content:"";position:fixed;'
+            . 'top:calc(-24px - env(safe-area-inset-top, 0px));left:calc(-24px - env(safe-area-inset-left, 0px));'
+            . 'width:calc(100vw + env(safe-area-inset-left, 0px) + env(safe-area-inset-right, 0px) + 48px);'
+            . 'height:calc(100vh + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px) + 120px);'
+            . 'height:calc(100lvh + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px) + 120px);'
+            . 'z-index:-1;pointer-events:none;background-image:none !important;'
             . 'background-color:rgba(var(--bg-page-rgb, 248, 236, 224), var(--bg-overlay-alpha, 1));'
             . 'filter:none !important;}';
         // ダークモード時はユーザー指定の明るい bgcolor をそのままオーバーレイに使うと

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1966,15 +1966,20 @@ function print_bg_style_block($is_bs5 = false) {
         // (JS無効時は data-ykr-bgfix が付かず、上の lvh フォールバックがそのまま使われる)
         print 'html[data-ykr-bgfix="1"]::before{height:var(--ykr-bg-fixed-h);}';
         print 'html[data-ykr-bgfix="1"] body::before{height:var(--ykr-bg-fixed-h);}';
-        // WebViewリサイズ型ブラウザ(Chrome iOS 等)は上下両方のバーが開閉して
-        // ビューポートの上端も動くため、上端アンカーだと背景が上バーの変化量ぶん
-        // 縦にずれる。中央アンカーなら、ずれは上下バーの変化量の差の半分(数px)まで
-        // 縮み実質静止して見える。Safari は上端が動かず現行の上端アンカーが完全
-        // 静止のため対象外(下記スクリプトが UA で切り替える)。
+        // === バー開閉時に動くビューポート辺はブラウザごとに異なるため、
+        //     アンカー辺を UA に応じて切り替える(下記スクリプトが属性を付与) ===
+        // - iOS Safari: 下辺のみ動く → 上端アンカー(既定)で完全静止
+        // - Android Chrome 等: 上辺のみ動く(下端=画面下端で不動) → 下端アンカーで静止
+        // - iOS Chrome 系: 上下両方動く → どのアンカーでも数十px残る。中央なら
+        //   ずれ=上下の変化量の差の半分。実測比較用に ?bganchor=top|center|bottom で
+        //   上書き可能にしてある。
         print 'html[data-ykr-bganchor="center"]::before,'
             . 'html[data-ykr-bganchor="center"] body::before{'
             . 'top:50%;'
             . 'transform:translate3d(0,-50%,0);-webkit-transform:translate3d(0,-50%,0);}';
+        print 'html[data-ykr-bganchor="bottom"]::before,'
+            . 'html[data-ykr-bganchor="bottom"] body::before{'
+            . 'top:auto;bottom:-80px;}';
     }
 
     if ($has_bgimage && $card_alpha < 1.0) {
@@ -2048,7 +2053,12 @@ function print_bg_style_block($is_bs5 = false) {
         // - キーボード表示などの高さ減少では更新しない
         print '<script>(function(){'
             . 'var doc=document.documentElement,maxH=0,lastW=0;'
-            . 'if(/CriOS|FxiOS|EdgiOS/.test(navigator.userAgent)){doc.setAttribute("data-ykr-bganchor","center");}'
+            . 'var ua=navigator.userAgent,anchor="";'
+            . 'if(/Android/i.test(ua)){anchor="bottom";}'
+            . 'else if(/CriOS|FxiOS|EdgiOS/.test(ua)){anchor="center";}'
+            . 'var am=location.search.match(/[?&]bganchor=(top|center|bottom)/);'
+            . 'if(am){anchor=(am[1]==="top")?"":am[1];}'
+            . 'if(anchor){doc.setAttribute("data-ykr-bganchor",anchor);}'
             . 'function apply(){'
             . 'var w=window.innerWidth,h=window.innerHeight;'
             . 'if(!w||!h)return;'

--- a/css/themes/theme-toggle.css
+++ b/css/themes/theme-toggle.css
@@ -21,7 +21,8 @@ body {
   background-color: var(--bg-page);
   background-image: var(--bg-page-image);
   background-size: cover;
-  background-attachment: fixed;
+  /* background-attachment:fixed は iOS Safari 非対応のため削除。
+     背景画像固定は html::before (position:fixed + GPU layer) が担当。 */
   padding-top: 70px;
   color: var(--color-text);
 }
@@ -34,7 +35,7 @@ body::before {
   background-color: var(--bg-page, #F8ECE0);
   background-image: var(--bg-page-image, none);
   background-size: cover;
-  background-attachment: fixed;
+  /* background-attachment:fixed 削除: position:fixed 済みで不要かつ iOS でズーム原因になる */
 }
 
 /* ============================================================

--- a/foobarctl.php
+++ b/foobarctl.php
@@ -76,7 +76,7 @@
             <button type="submit" value="再生開始" name="songstart" class="pcbuttom btn btn-default" onClick="song_play()" /> 再生開始 </button>
             </div >
             <div class="col-xs-4">
-            <button type="submit" value="曲終了" name="songnext" class="pcbuttom  btn btn-default" onClick="song_next()" />曲終了</button>
+            <button type="submit" value="曲終了" name="songnext" class="pcbuttom  btn btn-default" onClick="if(!confirm('曲を停止しますか？'))return false; song_next();" />曲終了</button>
             </div >
         </div>
     </div>

--- a/function_moveitem.php
+++ b/function_moveitem.php
@@ -17,6 +17,9 @@ function getallrequest_fromdb($db) {
  *  - 同一人物が2つ入れていても別の人は1周目扱い（ターン[0]末尾）
  *  - 2周目以降: 1つ前の周と同じ順番
  *  - 2周目以降の新規参加者: 未再生先頭へ
+ *  - 途中参加者の2曲目以降: 最後に登場した周の次へ（標準）
+ *    request_automove_midjoin_first=1 時は旧動作（本人を含まない最初の周へ割り込み =
+ *    途中参加者ができるだけ早い周で歌える）
  *  - reset_on_pause=true時: 最後の小休止以降を1周目扱いに
  */
 class MoveItem {
@@ -26,12 +29,16 @@ class MoveItem {
     public $max_reqorder = 0;
     public $db = null;
     private $reset_on_pause = false;
+    private $midjoin_first = false;
 
     public function getturnlist($db) {
         $this->db = $db;
         global $config_ini;
         if (array_key_exists('request_automove_reset', $config_ini)) {
             $this->reset_on_pause = ($config_ini['request_automove_reset'] == 1);
+        }
+        if (array_key_exists('request_automove_midjoin_first', $config_ini)) {
+            $this->midjoin_first = ($config_ini['request_automove_midjoin_first'] == 1);
         }
         $this->allrequest = getallrequest_fromdb($db);
         $this->allrequest_new = $this->allrequest;
@@ -139,17 +146,35 @@ class MoveItem {
             $rounds[] = $cur_round;
         }
 
-        // 挿入ラウンド: 新歌い手を含まない最初のラウンド
-        $target_idx = count($rounds);
-        foreach ($rounds as $idx => $round) {
-            $has = false;
-            foreach ($round as $r) {
-                if ($r['singer'] === $newsinger) { $has = true; break; }
+        // 挿入ラウンドの決定
+        if ($this->midjoin_first) {
+            // 旧動作: 新歌い手を含まない最初のラウンドへ割り込む
+            // （途中参加者ができるだけ早い周で歌える）
+            $target_idx = count($rounds);
+            foreach ($rounds as $idx => $round) {
+                $has = false;
+                foreach ($round as $r) {
+                    if ($r['singer'] === $newsinger) { $has = true; break; }
+                }
+                if (!$has) {
+                    $target_idx = $idx;
+                    break;
+                }
             }
-            if (!$has) {
-                $target_idx = $idx;
-                break;
+        } else {
+            // 標準: 歌い手が最後に登場したラウンドの次
+            // （初回参加は last=-1+1=0 となり新規参加者ルールが適用される。
+            //   途中参加者も次周以降は自分の最後の出現位置を基準に並ぶ）
+            $last_singer_idx = -1;
+            foreach ($rounds as $idx => $round) {
+                foreach ($round as $r) {
+                    if ($r['singer'] === $newsinger) {
+                        $last_singer_idx = $idx;
+                        break;
+                    }
+                }
             }
+            $target_idx = $last_singer_idx + 1;
         }
 
         // 全ラウンドに既に存在 → 末尾に追加
@@ -161,6 +186,7 @@ class MoveItem {
 
         if ($target_idx == 0) {
             // 新歌い手（どのラウンドにも存在しない）
+            // ※旧動作(midjoin_first)時は先頭ラウンド未登場の途中参加者もここに来る
             if (!$this->reset_on_pause && $this->_turn_has_veteran($rounds[0])) {
                 // rule5: 2周目以降の新規参加者 → 未再生先頭へ
                 return $this->_first_unplayed_reqorder_after($history, $insert_floor);

--- a/init.php
+++ b/init.php
@@ -1712,6 +1712,32 @@ if(array_key_exists("request_automove_reset",$config_ini)) {
     </label>
   </div>
 
+  <div class="mb-3">
+    <h3 class="radio form-label"  > <span data-bs-toggle="tooltip" data-bs-placement="top" title="有効にすると、途中参加した人のリクエストをできるだけ早い周に割り込ませます。無効(標準)では、その人が最後に歌った周の次に配置されます" >ピッタリ移動_途中参加者を早い周へ </span ></h3>
+    <label class="checkbox-inline">
+      <input type="radio" name="request_automove_midjoin_first" value="1"
+<?php
+if(array_key_exists("request_automove_midjoin_first",$config_ini)) {
+  print ($config_ini["request_automove_midjoin_first"]==1)?'checked':' ' ;
+}
+?>
+ />
+      有効
+    </label>
+    <label class="checkbox-inline">
+      <input type="radio" name="request_automove_midjoin_first" value="2"
+<?php
+if(array_key_exists("request_automove_midjoin_first",$config_ini)) {
+  print ($config_ini["request_automove_midjoin_first"]!=1)?'checked':' ' ;
+}else{
+  print 'checked';
+}
+?>
+ />
+      無効
+    </label>
+  </div>
+
 
 <!---- 縛り曲リストの設定 ----->
   <h3> <span data-bs-toggle="tooltip" data-bs-placement="top" title="検索リクエストメニューの中に特定の曲をピックアップした一覧を表示させることができます" > ピックアップ曲リスト </span> </h3>

--- a/js/player_bs5.js
+++ b/js/player_bs5.js
@@ -20,6 +20,7 @@ function _sendCmd(url) {
 
 /* 曲終了 (DB更新 + UI更新) */
 function cmd_songnext() {
+    if (!confirm('曲を停止しますか？')) return;
     _sendCmd(_playerCtrlUrl + '?songnext=1').then(function () {
         setTimeout(function () {
             var pg = document.getElementById('proglessbase');
@@ -61,6 +62,7 @@ function comp_apply() { _compFetch('comp_apply'); }
 
 /* foobar 曲終了 */
 function foobar_cmd_songnext() {
+    if (!confirm('曲を停止しますか？')) return;
     _sendCmd(_foobarCtrlUrl + '?songnext=1').then(function () {
         setTimeout(function () { location.reload(); }, 400);
     });

--- a/js/requsetlist_ctrl.js
+++ b/js/requsetlist_ctrl.js
@@ -149,8 +149,9 @@ function changerequeststatus(myel){
 
 function song_end(myel, id){
   var url;
+  if (!confirm('曲を停止しますか？')) return false;
   var table = $('#request_table').DataTable();
-  
+
   myel.setAttribute('disabled', true);
   url = "playerctrl_portal.php?songnext=1";
   var request = createXMLHttpRequest();

--- a/manage-mpc.php
+++ b/manage-mpc.php
@@ -1017,28 +1017,9 @@ function start_song($db,$id,$addplaytimes = 0){
                     pclose($fp);
                     }  //★
 
-            //★ MPCの再生開始時に音量を指定値に戻す（設定で有効にしている場合）
-            //   制作者別音量増減（requesttable.volume != 0）が設定されている場合は
-            //   startvolume にオフセットを加算した値を設定する。
-            $req_volume_offset = 0;
-            if(array_key_exists("volume" , $row) && $row["volume"] !== null && $row["volume"] !== ''){
-                $v = intval($row["volume"]);
-                if($v >= -100 && $v <= 100) $req_volume_offset = $v;
-            }
-            if($req_volume_offset !== 0){
-                $base_volume = array_key_exists('startvolume', $config_ini) ? intval($config_ini['startvolume']) : 50;
-                $applied_volume = max(0, min(100, $base_volume + $req_volume_offset));
-                set_volume($applied_volume);
-            }else{
-                if(array_key_exists('startvolume50',$config_ini)){	//★
-                    if($config_ini['startvolume50'] != 1)  {	//★
-                    }else{	//★
-                        set_volume($config_ini["startvolume"]);	//★
-                    }	//★
-                }else{	//★
-                    set_volume($config_ini["startvolume"]);	//★
-                }	//★
-            }
+            //★ MPCの再生開始時の音量制御（基準音量への復帰 + 制作者別音量増減の相対適用）
+            //   実体は mpcctrl_func.php の apply_start_volume() を参照。
+            apply_start_volume($row);
             //★ 音声トラックの切替が無いor１回の場合、再生開始を遅延させる。
             if($row["track"] == 0){  //★
               sleep(1);  //★

--- a/mpcctrl.php
+++ b/mpcctrl.php
@@ -221,7 +221,7 @@ print '</div >';
                 </div >
                 <div class="col-xs-6">
                     <form method="post"action="playerctrl_portal.php" style="display: inline" >
-                        <input type="submit" value="曲終了" name="songnext" class=" pcbuttom btn btn-default" onClick="song_next()" />
+                        <input type="submit" value="曲終了" name="songnext" class=" pcbuttom btn btn-default" onClick="if(!confirm('曲を停止しますか？'))return false; song_next();" />
                     </form>
                 </div >
             </div>

--- a/mpcctrl_bs5.php
+++ b/mpcctrl_bs5.php
@@ -18,9 +18,14 @@ function reset_initial_volume_bs5() {
             }
         }
     } catch (Exception $e) { /* silent */ }
-    $base = isset($config_ini['startvolume']) ? intval($config_ini['startvolume']) : 50;
+    $base = 50;
+    if (array_key_exists('startvolume', $config_ini) && is_numeric(trim(urldecode((string)$config_ini['startvolume'])))) {
+        $base = max(0, min(100, intval(urldecode((string)$config_ini['startvolume']))));
+    }
     $applied = max(0, min(100, $base + $offset));
     set_volume($applied);
+    // 手動リセット後も曲終了時の差し戻しが正しく効くよう適用量を記録する
+    save_applied_volume_offset($applied - $base);
     print $applied;
     return $applied;
 }

--- a/mpcctrl_func.php
+++ b/mpcctrl_func.php
@@ -38,6 +38,8 @@ function songnext(){
           $ret = $db->exec($sql);
           $db->commit();
       }
+      // 曲別音量オフセットが適用されたままなら現在音量から差し戻す
+      revert_song_volume_offset();
 }
 
 function songstart(){
@@ -153,6 +155,81 @@ function get_volume(){
     $status_array = explode(',', $status);
     // var_dump($status_array);
     return $status_array[7];
+}
+
+/* ==== 制作者別音量増減（曲別オフセット）の適用状態管理 ====
+   オフセットは「適用時点の音量」への相対値として扱い、実際に適用できた
+   増減量を状態ファイルへ記録する。曲終了(songnext)や次曲開始時に
+   現在音量から差し戻すことで、手元で調整した音量を壊さずに元へ戻す。 */
+function _volume_offset_state_file(){
+    return __DIR__ . '/volume_offset_state.json';
+}
+
+function get_applied_volume_offset(){
+    $f = _volume_offset_state_file();
+    if(!file_exists($f)) return 0;
+    $d = @json_decode(@file_get_contents($f), true);
+    if(!is_array($d) || !isset($d['delta'])) return 0;
+    return max(-100, min(100, intval($d['delta'])));
+}
+
+function save_applied_volume_offset($delta){
+    @file_put_contents(_volume_offset_state_file(), json_encode(['delta' => intval($delta)]));
+}
+
+/* 適用済みオフセットを現在音量から差し戻す。
+   MPC に到達できないときは状態を保持し、次の機会に差し戻す。 */
+function revert_song_volume_offset(){
+    $delta = get_applied_volume_offset();
+    if($delta === 0) return;
+    $cur = get_volume();
+    if($cur === FALSE) return;
+    set_volume(max(0, min(100, intval($cur) - $delta)));
+    save_applied_volume_offset(0);
+}
+
+/* 再生開始時の音量制御。
+   - startvolume50 有効時（キー未設定時も有効扱い = 設定画面の既定表示と一致）は
+     基準音量（startvolume。未設定・数値以外は 50）へ戻す。
+   - requesttable.volume（制作者別音量増減）は「その時点の音量」への相対オフセット
+     として適用し、適用量を記録する。startvolume50 無効時でも機能する。 */
+function apply_start_volume($row){
+    global $config_ini;
+
+    $sv50_on = true;
+    if(array_key_exists('startvolume50', $config_ini) && intval($config_ini['startvolume50']) !== 1){
+        $sv50_on = false;
+    }
+
+    $offset = 0;
+    if(is_array($row) && array_key_exists('volume', $row) && $row['volume'] !== null && $row['volume'] !== ''){
+        $v = intval($row['volume']);
+        if($v >= -100 && $v <= 100) $offset = $v;
+    }
+
+    $cur = null;
+    if($sv50_on){
+        $cur = 50;
+        if(array_key_exists('startvolume', $config_ini) && is_numeric(trim(urldecode((string)$config_ini['startvolume'])))){
+            $cur = max(0, min(100, intval(urldecode((string)$config_ini['startvolume']))));
+        }
+        // 基準音量へ強制リセットするため、前曲の未返済オフセットはここで消滅する
+        save_applied_volume_offset(0);
+    }else{
+        // 前曲のオフセットが残っていれば先に現在音量から差し戻す
+        revert_song_volume_offset();
+        if($offset !== 0){
+            $v = get_volume();
+            if($v !== FALSE) $cur = max(0, min(100, intval($v)));
+        }
+    }
+
+    // sv50 無効かつオフセット無し（または MPC 不達）なら音量に触らない
+    if($cur === null) return;
+
+    $applied = max(0, min(100, $cur + $offset));
+    set_volume($applied);
+    save_applied_volume_offset($applied - $cur);
 }
 
 function volume_fadeout(){

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -1096,6 +1096,7 @@ function changeItem(id, songfile) {
 
 // 曲終了
 function songEnd() {
+    if (!confirm('曲を停止しますか？')) return;
     fetch('playerctrl_portal.php?songnext=1').then(loadList);
 }
 


### PR DESCRIPTION
## 概要

つぼはちさん (@hachi515tennis3-glitch) の統合PR #190 のうち、①〜④を精査のうえ取り込むブランチです。③④は元コミットを cherry-pick(author 情報保持)、①②は検証結果を踏まえて再実装しています。⑤(外観プリセット)は実装方式の再検討を依頼するため本ブランチには含みません。

## 変更内容

- **① 途中参加者の周回順序修正**(`2a5f2d9`)
  挿入周を「最後に登場した周の次」に変更。新設定 `request_automove_midjoin_first=1` で旧動作(早い周へ割り込み)にも切替可
- **② MPC曲別音量オフセットの相対適用化**(`3e45bfc`)
  オフセットを「その時点の音量への相対適用」に変更し、適用量を記録して曲終了時に差し戻し。`songnext()` 本体に組み込み全経路(BS3/BS5/portal/一覧)で有効。`startvolume50` 未設定時は設定画面の表示と同じく有効扱いに統一
- **③ iOS壁紙の伸縮修正**(`3a5d247` cherry-pick + 追加修正 `204dd09` `bcca8a9` `8e9e689` `31af069`)
  env() 動的変化の排除 → JSによる背景高の固定px化 → ブラウザ別アンカー切替(Android=下端固定)。iOS Safari / Android Chrome はほぼ完全静止、iOS Chrome は実測比較で最小構成を確定
- **④ 曲停止確認ポップアップ**(`0105087` cherry-pick + `0b3c27c`)
  swipe一覧に加え、プレイヤー画面(BS3/BS5 × MPC/foobar)・旧リクエスト一覧にも展開し全UI経路で統一

## テスト

- ① MoveItem: インメモリSQLiteで7ケースの自動検証(新旧モード・新規参加者・キー未設定)
- ② MPC音量: モックMPCサーバー(HTTP)で20項目の実挙動検証(クランプ整合・手動調整保持・不達時の持ち越し)
- ③ 出力CSS/JSの自動テスト26項目 + iPhone Safari / iPhone Chrome / Android Chrome の実機確認
- 対象PHP/JSの構文チェック(php -l / node --check)すべてパス

関連: #190(取り込み報告とフィードバックはマージ後に別途コメント予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)