### PR TITLE
﻿feat: BS5外観プリセットをCSS変数ファイル方式に再設計

### DIFF
--- a/commonfunc.php
+++ b/commonfunc.php
@@ -1398,6 +1398,82 @@ function print_bs5_search_head($extra_css = ''){
 }
 
 /**
+ * css/themes/skins/ 配下の外観プリセット(テーマ)定義ファイルを走査し、一覧を返す。
+ * 各ファイルは CSS変数の上書きのみで構成する（詳細は css/themes/skins/*.css 参照）。
+ * ファイル先頭の "Theme Name: xxx" コメントを表示名として使う（省略時はファイル名）。
+ * ファイルを1つ追加するだけで一覧・設定画面に反映され、コード変更は不要。
+ *
+ * @return array スラッグ => ['name' => 表示名, 'file' => 相対パス]
+ */
+function get_ui_skin_list(){
+    static $cache = null;
+    if ($cache !== null) {
+        return $cache;
+    }
+
+    $list = [];
+    $paths = glob(__DIR__ . '/css/themes/skins/*.css');
+    if (is_array($paths)) {
+        sort($paths, SORT_STRING);
+        foreach ($paths as $path) {
+            $slug = basename($path, '.css');
+            if ($slug === '' || !preg_match('/^[A-Za-z0-9_-]+$/', $slug)) {
+                continue; // ファイル名がスラッグとして安全でないものは除外
+            }
+            $name = $slug;
+            $head = @file_get_contents($path, false, null, 0, 2048);
+            if ($head !== false && preg_match('/Theme\s*Name\s*:\s*([^\r\n*]+)/u', $head, $m)) {
+                $name = trim($m[1]);
+            }
+            $list[$slug] = ['name' => $name, 'file' => 'css/themes/skins/' . $slug . '.css'];
+        }
+    }
+    return $cache = $list;
+}
+
+/**
+ * 現在の外観プリセット(スキン)のスラッグを返す。
+ * 'default'（標準・上書きなし）は css/themes/skins/ に対応ファイルを置かない特別値。
+ * 未設定・空欄・存在しないスラッグは自動的に 'default' へフォールバックする。
+ */
+function get_ui_skin_preset($value = null){
+    if ($value === null) {
+        global $config_ini;
+        $value = $config_ini['ui_skin_preset'] ?? 'default';
+    }
+
+    if (is_array($value)) {
+        return 'default';
+    }
+
+    $preset = trim(urldecode((string)$value));
+    if ($preset === '' || $preset === 'default') {
+        return 'default';
+    }
+    if (!array_key_exists($preset, get_ui_skin_list())) {
+        return 'default';
+    }
+
+    return $preset;
+}
+
+function get_ui_skin_card_opacity($value = null){
+    if ($value === null) {
+        global $config_ini;
+        $value = $config_ini['ui_skin_card_opacity'] ?? 100;
+    }
+
+    if (is_array($value) || $value === '') {
+        return 100;
+    }
+
+    $opacity = (int)$value;
+    if ($opacity < 0) $opacity = 0;
+    if ($opacity > 100) $opacity = 100;
+    return $opacity;
+}
+
+/**
  * BS5ページ共通の <head> 核を出力する。
  * テーマ初期化スクリプト（FOUC防止）+ Bootstrap5 + テーマ変数 + テーマ切替 を
  * 一括出力し、ページ固有のCSSばらつきを排除する。
@@ -1411,9 +1487,20 @@ function print_bs5_head_core($page_css = [], $opts = []){
     print '<script>(function(){if(window.__ykThemeInit)return;window.__ykThemeInit=true;try{var t=localStorage.getItem("ykari-theme")||"light",f=localStorage.getItem("ykari-fontsize")||"normal";document.documentElement.setAttribute("data-theme",t);document.documentElement.setAttribute("data-fontsize",f);}catch(e){}})();</script>';
     print '<link rel="stylesheet" href="css/bootstrap5/bootstrap.min.css">';
     print '<link rel="stylesheet" href="css/themes/_variables.css">';
+    print '<style>:root{--ykr-skin-card-opacity:' . (get_ui_skin_card_opacity() / 100) . ';}</style>';
     foreach ((array)$page_css as $href){
         if($href === '') continue;
         print '<link rel="stylesheet" href="' . htmlspecialchars($href, ENT_QUOTES, 'UTF-8') . '">';
+    }
+    // 外観プリセット: 'default'（標準）はファイルを読み込まず、既存の見た目のまま。
+    // 非標準プリセットのときだけ、テーマ本体（変数定義）+ 共通コンポーネント適用ルールを読み込む。
+    $skin = get_ui_skin_preset();
+    if ($skin !== 'default') {
+        $skin_list = get_ui_skin_list();
+        if (isset($skin_list[$skin]['file'])) {
+            print '<link rel="stylesheet" href="' . htmlspecialchars($skin_list[$skin]['file'], ENT_QUOTES, 'UTF-8') . '">';
+            print '<link rel="stylesheet" href="css/themes/skin-components.css">';
+        }
     }
     print '<link rel="stylesheet" href="css/themes/theme-toggle.css">';
     if(!empty($opts['jquery'])){

--- a/css/themes/skin-components.css
+++ b/css/themes/skin-components.css
@@ -1,0 +1,88 @@
+﻿/* ==========================================================
+   BS5 外観プリセット: 共通コンポーネント適用ルール
+   css/themes/skins/*.css が定義する CSS変数を実際のコンポーネントへ
+   反映させるための共通ルール。標準（プリセット未選択）のときは
+   このファイル自体を読み込まないため、ここに書くセレクタは
+   常に「非標準プリセットが選択されている」前提で良い。
+
+   新しいプリセットを追加するときはこのファイルを変更する必要はない。
+   css/themes/skins/ に変数定義ファイルを1つ追加するだけでよい。
+   逆に、新しいコンポーネント（新画面の部品など）にプリセットを
+   反映させたいときは、このファイルに一度だけルールを追加すれば、
+   既存・将来のプリセットすべてに自動的に適用される。
+   ========================================================== */
+
+.navbar.bg-dark {
+  background: var(--ykr-navbar-bg) !important;
+  border-bottom: 1px solid var(--ykr-navbar-border);
+  box-shadow: var(--shadow-navbar);
+}
+
+.search-hero,
+.search-section,
+.player-nowplaying,
+.player-controls-card,
+.cfg-card,
+.card,
+.accordion-item,
+.dropdown-menu,
+.modal-content,
+.swap-banner,
+#stats-bar,
+.list-toolbar {
+  border: 1px solid var(--ykr-card-border);
+  background-image: var(--ykr-card-gradient);
+  background-color: rgba(var(--bg-card-rgb, 255, 255, 255), calc(var(--bg-card-alpha, 1) * var(--ykr-skin-card-opacity, 1)));
+  box-shadow: var(--shadow-card);
+}
+
+.list-toolbar {
+  border-radius: var(--radius-card);
+  padding: 10px 12px;
+}
+
+.search-section-header,
+.card-header,
+.accordion-button,
+#stats-bar {
+  background-image: var(--ykr-card-header-gradient);
+  background-color: rgba(var(--bg-card-alt-rgb, 248, 244, 240), calc(var(--bg-card-alpha, 1) * var(--ykr-skin-card-opacity, 1)));
+}
+
+.accordion-button:not(.collapsed) {
+  background-image: var(--ykr-card-header-gradient);
+  color: var(--color-accent-secondary);
+}
+
+.form-control,
+.form-select,
+.input-group-text {
+  border-color: var(--ykr-card-border-strong);
+  background-color: rgba(var(--bg-card-rgb, 255, 255, 255), calc(var(--bg-card-alpha, 1) * var(--ykr-skin-card-opacity, 1)));
+  box-shadow: var(--ykr-input-shadow);
+}
+
+.search-history-wrap,
+.search-history-word,
+.search-history-del,
+.search-history-footer,
+#search-history-clear,
+.card-comment-area {
+  background-color: rgba(var(--bg-card-alt-rgb, 248, 244, 240), calc(var(--bg-card-alpha, 1) * var(--ykr-skin-card-opacity, 1)));
+}
+
+.btn,
+.reservation-tab-btn,
+.index-btn,
+.card-comment-area,
+.player-key-display {
+  border-radius: var(--radius-button);
+}
+
+.btn-primary,
+.search-hero .btn-search-submit,
+.btn-request,
+.reservation-tab-btn.active,
+.index-btn.has-data {
+  box-shadow: var(--ykr-accent-glow);
+}

--- a/css/themes/skins/glass.css
+++ b/css/themes/skins/glass.css
@@ -1,0 +1,81 @@
+﻿/*
+Theme Name: ガラス
+Author: つぼはち
+*/
+:root {
+  --bg-card-rgb: 255, 251, 255;
+  --bg-card-alt-rgb: 244, 236, 247;
+  --bg-input: #fffafc;
+  --color-text: #2f2238;
+  --color-text-muted: #6c5a72;
+  --color-text-on-accent: #ffffff;
+  --color-accent: #ff4fa1;
+  --color-accent-hover: #ff2f92;
+  --color-accent-secondary: #8a6cff;
+  --color-accent-secondary-hover: #7656f5;
+  --color-border: rgba(154, 44, 156, 0.28);
+  --color-border-active: #ff79bc;
+  --bg-index-btn: #f7eff8;
+  --bg-index-btn-hover: #efe2f2;
+  --bg-index-btn-has-data: #ff66ba;
+  --bg-index-btn-has-data-hover: #ff4fa1;
+  --color-index-btn: #5a465d;
+  --radius-card: 22px;
+  --radius-button: 12px;
+  --radius-input: 16px;
+  --shadow-card: 0 12px 28px rgba(94, 52, 110, 0.14);
+  --shadow-card-hover: 0 18px 38px rgba(94, 52, 110, 0.18);
+  --shadow-navbar: 0 8px 24px rgba(58, 28, 72, 0.22);
+  --ykr-request-card-radius: 22px;
+  --ykr-request-chip-radius: 12px;
+  --ykr-request-card-shadow: 0 12px 28px rgba(94, 52, 110, 0.14);
+  --ykr-card-border: rgba(205, 162, 208, 0.56);
+  --ykr-card-border-strong: rgba(205, 162, 208, 0.78);
+  --ykr-card-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.84), rgba(255, 255, 255, 0.60));
+  --ykr-card-header-gradient: linear-gradient(90deg, rgba(255, 79, 161, 0.08), rgba(138, 108, 255, 0.08));
+  --ykr-navbar-bg: rgba(92, 62, 108, 0.90);
+  --ykr-navbar-border: rgba(255, 255, 255, 0.18);
+  --ykr-input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  --ykr-accent-glow: 0 0 22px rgba(255, 79, 161, 0.32);
+}
+
+[data-theme="dark"] {
+  --bg-card-rgb: 34, 26, 58;
+  --bg-card-alt-rgb: 48, 38, 78;
+  --bg-input: rgba(30, 24, 54, 0.92);
+  --color-text: #f7efff;
+  --color-text-muted: #d9c7f4;
+  --color-border: rgba(255, 255, 255, 0.20);
+  --bg-index-btn: rgba(255, 255, 255, 0.08);
+  --bg-index-btn-hover: rgba(255, 255, 255, 0.16);
+  --color-index-btn: #f7efff;
+  --shadow-card: 0 16px 40px rgba(20, 12, 38, 0.30);
+  --shadow-card-hover: 0 24px 52px rgba(20, 12, 38, 0.40);
+  --shadow-navbar: 0 8px 30px rgba(8, 8, 20, 0.35);
+  --ykr-request-card-shadow: 0 16px 40px rgba(20, 12, 38, 0.30);
+  --ykr-card-border: rgba(255, 255, 255, 0.20);
+  --ykr-card-border-strong: rgba(255, 255, 255, 0.24);
+  --ykr-card-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.05));
+  --ykr-card-header-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.04));
+  --ykr-navbar-bg: rgba(14, 12, 24, 0.86);
+  --ykr-navbar-border: rgba(255, 255, 255, 0.14);
+  --ykr-input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.10);
+}
+
+/* ガラス質感特有のレイヤリング調整（検索履歴ドロップダウン等の重なり順） */
+.search-hero {
+  position: relative;
+}
+.search-hero:focus-within {
+  z-index: 1202;
+}
+.search-section {
+  position: relative;
+  z-index: 1;
+}
+.search-history-wrap {
+  isolation: isolate;
+}
+#search-history-dropdown {
+  z-index: 1203;
+}

--- a/css/themes/skins/live.css
+++ b/css/themes/skins/live.css
@@ -1,0 +1,65 @@
+﻿/*
+Theme Name: ライブ
+Author: つぼはち
+*/
+:root {
+  --bg-card-rgb: 253, 250, 247;
+  --bg-card-alt-rgb: 246, 239, 243;
+  --bg-input: #fffdfd;
+  --color-text: #2c1f2c;
+  --color-text-muted: #6a5d6b;
+  --color-text-on-accent: #ffffff;
+  --color-accent: #ff4f9a;
+  --color-accent-hover: #ea327f;
+  --color-accent-secondary: #2dc9ff;
+  --color-accent-secondary-hover: #18b1e7;
+  --color-border: rgba(145, 110, 144, 0.28);
+  --color-border-active: #ff4f9a;
+  --bg-index-btn: #f8f0f5;
+  --bg-index-btn-hover: #f0e3ec;
+  --bg-index-btn-has-data: #22b7ef;
+  --bg-index-btn-has-data-hover: #10a4db;
+  --color-index-btn: #594d5b;
+  --radius-card: 18px;
+  --radius-button: 14px;
+  --radius-input: 14px;
+  --shadow-card: 0 10px 26px rgba(83, 48, 88, 0.14);
+  --shadow-card-hover: 0 16px 36px rgba(83, 48, 88, 0.18);
+  --shadow-navbar: 0 8px 26px rgba(44, 26, 52, 0.24);
+  --ykr-request-card-radius: 18px;
+  --ykr-request-chip-radius: 14px;
+  --ykr-request-card-shadow: 0 10px 26px rgba(83, 48, 88, 0.14);
+  --ykr-card-border: rgba(201, 155, 184, 0.44);
+  --ykr-card-border-strong: rgba(201, 155, 184, 0.64);
+  --ykr-card-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(255, 255, 255, 0.66));
+  --ykr-card-header-gradient: linear-gradient(90deg, rgba(255, 79, 154, 0.08), rgba(45, 201, 255, 0.08));
+  --ykr-navbar-bg: rgba(84, 50, 80, 0.92);
+  --ykr-navbar-border: rgba(255, 255, 255, 0.16);
+  --ykr-input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.42);
+  --ykr-accent-glow: 0 0 16px rgba(255, 79, 154, 0.22);
+}
+
+[data-theme="dark"] {
+  --bg-card-rgb: 18, 20, 32;
+  --bg-card-alt-rgb: 27, 30, 48;
+  --bg-input: #171b2a;
+  --color-text: #f8fbff;
+  --color-text-muted: #aeb6ca;
+  --color-border: rgba(80, 110, 164, 0.45);
+  --bg-index-btn: #151a29;
+  --bg-index-btn-hover: #1d2337;
+  --bg-index-btn-has-data: #204f7d;
+  --bg-index-btn-has-data-hover: #276494;
+  --color-index-btn: #dce7ff;
+  --shadow-card: 0 10px 26px rgba(0, 0, 0, 0.32);
+  --shadow-card-hover: 0 16px 36px rgba(0, 0, 0, 0.42);
+  --shadow-navbar: 0 8px 26px rgba(0, 0, 0, 0.40);
+  --ykr-request-card-shadow: 0 10px 26px rgba(0, 0, 0, 0.32);
+  --ykr-card-border: rgba(61, 92, 141, 0.58);
+  --ykr-card-border-strong: rgba(69, 116, 177, 0.72);
+  --ykr-card-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  --ykr-card-header-gradient: linear-gradient(90deg, rgba(255, 79, 154, 0.15), rgba(45, 201, 255, 0.12));
+  --ykr-navbar-bg: rgba(9, 12, 20, 0.92);
+  --ykr-navbar-border: rgba(255, 79, 154, 0.18);
+  --ykr-input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}

--- a/css/themes/skins/minimal.css
+++ b/css/themes/skins/minimal.css
@@ -1,0 +1,51 @@
+﻿/*
+Theme Name: ミニマル
+Author: つぼはち
+*/
+:root {
+  --bg-card-rgb: 255, 255, 255;
+  --bg-card-alt-rgb: 246, 248, 250;
+  --bg-input: #ffffff;
+  --color-text: #1f2937;
+  --color-text-muted: #667085;
+  --color-text-on-accent: #ffffff;
+  --color-accent: #3559a8;
+  --color-accent-hover: #29488a;
+  --color-accent-secondary: #4b5563;
+  --color-accent-secondary-hover: #374151;
+  --color-border: rgba(100, 116, 139, 0.24);
+  --color-border-active: #3559a8;
+  --bg-index-btn: #f6f8fb;
+  --bg-index-btn-hover: #edf1f6;
+  --bg-index-btn-has-data: #3559a8;
+  --bg-index-btn-has-data-hover: #29488a;
+  --color-index-btn: #475467;
+  --radius-card: 12px;
+  --radius-button: 10px;
+  --radius-input: 10px;
+  --shadow-card: 0 4px 14px rgba(15, 23, 42, 0.08);
+  --shadow-card-hover: 0 8px 18px rgba(15, 23, 42, 0.10);
+  --shadow-navbar: 0 4px 16px rgba(15, 23, 42, 0.14);
+  --ykr-request-card-radius: 12px;
+  --ykr-request-chip-radius: 10px;
+  --ykr-request-card-shadow: 0 4px 14px rgba(15, 23, 42, 0.08);
+  --ykr-card-border: rgba(100, 116, 139, 0.18);
+  --ykr-card-border-strong: rgba(100, 116, 139, 0.28);
+  --ykr-card-gradient: none;
+  --ykr-card-header-gradient: none;
+  --ykr-navbar-bg: rgba(28, 33, 42, 0.96);
+  --ykr-navbar-border: rgba(255, 255, 255, 0.08);
+  --ykr-input-shadow: none;
+  --ykr-accent-glow: none;
+}
+
+[data-theme="dark"] {
+  --bg-card-rgb: 28, 31, 40;
+  --bg-card-alt-rgb: 36, 41, 53;
+  --bg-input: #1d2230;
+  --color-text: #eff3f8;
+  --color-text-muted: #b0b8c5;
+  --color-index-btn: #d7deea;
+  --ykr-card-border: rgba(148, 163, 184, 0.24);
+  --ykr-card-border-strong: rgba(148, 163, 184, 0.34);
+}

--- a/css/themes/skins/oshi.css
+++ b/css/themes/skins/oshi.css
@@ -1,0 +1,99 @@
+﻿/*
+Theme Name: 推し活
+Author: つぼはち
+*/
+:root {
+  --bg-card-rgb: 255, 248, 252;
+  --bg-card-alt-rgb: 250, 240, 248;
+  --bg-input: #fffafd;
+  --color-text: #35122f;
+  --color-text-muted: #6f4168;
+  --color-text-on-accent: #ffffff;
+  --color-accent: #ff4aa7;
+  --color-accent-hover: #f72b95;
+  --color-accent-secondary: #6f5df8;
+  --color-accent-secondary-hover: #5b49e6;
+  --color-border: rgba(187, 87, 146, 0.34);
+  --color-border-active: #ff62b0;
+  --bg-index-btn: #f8f0ff;
+  --bg-index-btn-hover: #f1e3fb;
+  --bg-index-btn-has-data: #54c5ff;
+  --bg-index-btn-has-data-hover: #32b7fb;
+  --color-index-btn: #60335b;
+  --color-index-btn-has-data: #10263c;
+  --radius-card: 20px;
+  --radius-button: 12px;
+  --radius-input: 16px;
+  --shadow-card: 0 14px 34px rgba(161, 88, 162, 0.22);
+  --shadow-card-hover: 0 20px 42px rgba(161, 88, 162, 0.28);
+  --shadow-navbar: 0 8px 26px rgba(72, 34, 96, 0.28);
+  --ykr-request-card-radius: 20px;
+  --ykr-request-chip-radius: 12px;
+  --ykr-request-card-shadow: 0 14px 34px rgba(161, 88, 162, 0.22);
+  --ykr-card-border: rgba(224, 122, 186, 0.54);
+  --ykr-card-border-strong: rgba(224, 122, 186, 0.74);
+  --ykr-card-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.78), rgba(255, 255, 255, 0.44));
+  --ykr-card-header-gradient: linear-gradient(90deg, rgba(255, 74, 167, 0.18), rgba(84, 197, 255, 0.18));
+  --ykr-navbar-bg: rgba(74, 38, 87, 0.92);
+  --ykr-navbar-border: rgba(255, 197, 228, 0.34);
+  --ykr-input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.68);
+  --ykr-accent-glow: 0 0 18px rgba(255, 98, 176, 0.24);
+}
+
+[data-theme="dark"] {
+  --bg-card-rgb: 58, 34, 62;
+  --bg-card-alt-rgb: 76, 48, 84;
+  --bg-input: #432849;
+  --color-text: #fff0fb;
+  --color-text-muted: #f2c8e8;
+  --bg-index-btn: #6d4d73;
+  --bg-index-btn-hover: #7b5980;
+  --ykr-card-gradient: linear-gradient(180deg, rgba(72, 40, 82, 0.82), rgba(52, 28, 60, 0.58));
+  --ykr-card-header-gradient: linear-gradient(90deg, rgba(255, 74, 167, 0.20), rgba(84, 197, 255, 0.14));
+  --color-index-btn: #fff0fb;
+  --color-index-btn-has-data: #13283a;
+  --ykr-card-border: rgba(255, 168, 223, 0.34);
+  --ykr-card-border-strong: rgba(255, 168, 223, 0.48);
+}
+
+/* 推し活テーマは彩度が高いため、本文系テキストは基準色へ寄せて可読性を確保する */
+.search-section,
+.search-hero,
+.player-nowplaying,
+.player-controls-card,
+.card,
+.cfg-card,
+#stats-bar,
+.list-toolbar,
+.request-card {
+  color: var(--color-text);
+}
+
+.search-section-header,
+.card-header,
+.accordion-button,
+.search-hero label,
+.search-result-count,
+.search-tips,
+.index-section-label,
+.card-label,
+.card-meta {
+  color: var(--color-text) !important;
+}
+
+.reservation-tab-btn,
+.page-btn,
+.search-history-word,
+.search-history-del,
+#search-history-clear,
+.index-btn {
+  color: var(--color-text);
+}
+
+.btn,
+.btn-outline-secondary,
+.btn-secondary,
+.notice-embedded-html :where(.btn, .btn-secondary, .btn-outline-secondary, .bg-light, .bg-white, .card, .alert, .well),
+.notice-embedded-html :where(h1, h2, h3, h4, h5, h6, p, li, span, small, strong, em, div, label, th, td, code, pre) {
+  color: var(--color-text);
+}

--- a/css/themes/skins/wa.css
+++ b/css/themes/skins/wa.css
@@ -1,0 +1,51 @@
+﻿/*
+Theme Name: 和風
+Author: つぼはち
+*/
+:root {
+  --bg-card-rgb: 251, 245, 235;
+  --bg-card-alt-rgb: 244, 232, 213;
+  --bg-input: #fffaf3;
+  --color-text: #2f1b16;
+  --color-text-muted: #71584a;
+  --color-text-on-accent: #fff8ef;
+  --color-accent: #a53a2b;
+  --color-accent-hover: #8d2f22;
+  --color-accent-secondary: #b48a3a;
+  --color-accent-secondary-hover: #9d762f;
+  --color-border: rgba(120, 45, 35, 0.24);
+  --color-border-active: #a53a2b;
+  --bg-index-btn: #f5e8d7;
+  --bg-index-btn-hover: #edd9bf;
+  --bg-index-btn-has-data: #8e3124;
+  --bg-index-btn-has-data-hover: #79281d;
+  --color-index-btn: #4a3123;
+  --radius-card: 16px;
+  --radius-button: 10px;
+  --radius-input: 10px;
+  --shadow-card: 0 10px 24px rgba(58, 29, 20, 0.14);
+  --shadow-card-hover: 0 16px 30px rgba(58, 29, 20, 0.18);
+  --shadow-navbar: 0 6px 20px rgba(35, 18, 12, 0.28);
+  --ykr-request-card-radius: 16px;
+  --ykr-request-chip-radius: 10px;
+  --ykr-request-card-shadow: 0 10px 24px rgba(58, 29, 20, 0.14);
+  --ykr-card-border: rgba(149, 89, 57, 0.28);
+  --ykr-card-border-strong: rgba(149, 89, 57, 0.42);
+  --ykr-card-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.52), rgba(255, 255, 255, 0.12));
+  --ykr-card-header-gradient: linear-gradient(90deg, rgba(165, 58, 43, 0.08), rgba(180, 138, 58, 0.12));
+  --ykr-navbar-bg: rgba(36, 24, 18, 0.90);
+  --ykr-navbar-border: rgba(210, 174, 97, 0.22);
+  --ykr-input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.52);
+  --ykr-accent-glow: 0 0 0 rgba(0, 0, 0, 0);
+}
+
+[data-theme="dark"] {
+  --bg-card-rgb: 40, 26, 24;
+  --bg-card-alt-rgb: 58, 38, 34;
+  --bg-input: #2d1d1b;
+  --color-text: #f5e8d8;
+  --color-text-muted: #d0b49d;
+  --color-index-btn: #f5e8d8;
+  --ykr-card-border: rgba(212, 170, 116, 0.26);
+  --ykr-card-border-strong: rgba(212, 170, 116, 0.38);
+}

--- a/css/themes/theme-toggle.css
+++ b/css/themes/theme-toggle.css
@@ -607,6 +607,56 @@ body::before {
 }
 
 /* ============================================================
+   btn-primary / btn-secondary / btn-outline-secondary:
+   サイトのアクセントカラー・形状トークンに常時追従させる。
+   外観プリセット（css/themes/skins/*.css）未選択時も
+   --color-accent・--radius-button の既定値でBootstrap標準色を上書きする。
+   ============================================================ */
+.btn-primary {
+  --bs-btn-bg: var(--color-accent);
+  --bs-btn-border-color: var(--color-accent);
+  --bs-btn-hover-bg: var(--color-accent-hover);
+  --bs-btn-hover-border-color: var(--color-accent-hover);
+  --bs-btn-active-bg: var(--color-accent-hover);
+  --bs-btn-active-border-color: var(--color-accent-hover);
+}
+.btn-secondary,
+.btn-outline-secondary {
+  --bs-btn-border-radius: var(--radius-button);
+}
+
+/* ============================================================
+   notice-embedded-html: 管理者埋め込みHTMLボックス（常時適用）
+   外観プリセットのCSS変数を消費するが、フォールバック値のみで
+   標準の見た目（--color-border・--radius-card 等の既定値）になる。
+   ============================================================ */
+.notice-embedded-html,
+.ykr-notice-embedded {
+  color: var(--color-text);
+  border: 1px solid var(--ykr-card-border, var(--color-border));
+  border-radius: var(--radius-card);
+  background-image: var(--ykr-card-gradient, none);
+  background-color: rgba(var(--bg-card-rgb, 255, 255, 255), calc(var(--bg-card-alpha, 1) * var(--ykr-skin-card-opacity, 1)));
+  box-shadow: var(--shadow-card);
+}
+.notice-embedded-html :where(h1, h2, h3, h4, h5, h6, p, ul, ol, li, dl, dt, dd, span, small, strong, em, div, label, th, td, blockquote, code, pre) {
+  color: inherit;
+}
+.notice-embedded-html a {
+  color: var(--color-accent-secondary);
+}
+.notice-embedded-html :where(.card, .alert, .well, .accordion-item, .accordion-button, .accordion-body, .list-group-item, .dropdown-menu, .bg-light, .bg-white, .bg-info:not(.badge)) {
+  border-color: var(--ykr-card-border-strong, var(--color-border));
+  background-image: var(--ykr-card-gradient, none);
+  background-color: rgba(var(--bg-card-alt-rgb, 248, 244, 240), calc(var(--bg-card-alpha, 1) * var(--ykr-skin-card-opacity, 1)));
+  color: var(--color-text);
+}
+.notice-embedded-html :where(.btn, .btn-primary, .btn-secondary, .btn-outline-secondary) {
+  --bs-btn-border-radius: var(--radius-button);
+  border-radius: var(--radius-button);
+}
+
+/* ============================================================
    notice-embedded-html: 管理者埋め込みHTMLボックスのダークモード対応
    ============================================================ */
 [data-theme="dark"] .notice-embedded-html {

--- a/init.php
+++ b/init.php
@@ -25,6 +25,12 @@ $easyauth = new EasyAuth();
 $easyauth -> do_eashauthcheck();
 
 $newconfig = $_REQUEST;
+if (array_key_exists('ui_skin_preset', $newconfig)) {
+  $newconfig['ui_skin_preset'] = get_ui_skin_preset($newconfig['ui_skin_preset']);
+}
+if (array_key_exists('ui_skin_card_opacity', $newconfig)) {
+  $newconfig['ui_skin_card_opacity'] = (string)get_ui_skin_card_opacity($newconfig['ui_skin_card_opacity']);
+}
 
 // 背景画像のアップロード/削除処理
 // クロップ済み画像はクライアントから data URL (base64) で送信される。
@@ -315,6 +321,9 @@ print '</pre>';
     </li>
     <li class="menu">
      <a href="#bgcolor_t" class="menulink" > ページ背景色 </a>
+    </li>
+    <li class="menu">
+     <a href="#ui_skin_preset_t" class="menulink" > 外観プリセット </a>
     </li>
     <li class="menu">
      <a href="#bgimage_t" class="menulink" > 背景画像 </a>
@@ -806,6 +815,82 @@ print ' value="10" ';
       bgEl.addEventListener('change', applyBgColor);
   })();
   </script>
+</div></div>
+
+<?php
+    $current_ui_skin_preset = get_ui_skin_preset();
+    $current_ui_skin_card_opacity = get_ui_skin_card_opacity();
+    $ui_skin_list = get_ui_skin_list();
+?>
+<div class="card cfg-card mb-4"><div class="card-body">
+  <div class="mb-3">
+    <h3 id="ui_skin_preset_t" class="radio form-label menulink"> 外観プリセット </h3>
+    <label for="ui_skin_preset" class="form-label"><small>BS5画面のカード形状、影、枠線、アクセント色をまとめて切り替えます。既存の背景画像・背景色・透過度設定はそのまま併用されます。プリセットは <code>css/themes/skins/</code> に置かれたCSSファイルから自動的に読み込まれるため、ファイルを追加するだけで一覧に反映されます。</small></label>
+    <select name="ui_skin_preset" id="ui_skin_preset" class="form-select" style="max-width:320px;">
+      <option value="default" <?php echo selectedcheck($current_ui_skin_preset, 'default'); ?>>標準</option>
+      <?php foreach ($ui_skin_list as $slug => $skin): ?>
+      <option value="<?php echo htmlspecialchars($slug, ENT_QUOTES, 'UTF-8'); ?>" <?php echo selectedcheck($current_ui_skin_preset, $slug); ?>><?php echo htmlspecialchars($skin['name'], ENT_QUOTES, 'UTF-8'); ?></option>
+      <?php endforeach; ?>
+    </select>
+    <small>未設定・空欄・不正値は自動で標準になります。</small>
+  </div>
+  <div class="mb-3">
+    <label for="ui_skin_card_opacity"><small>プリセット面の透過度: <span id="ui_skin_card_opacity_val"><?php echo $current_ui_skin_card_opacity; ?></span>%</small></label>
+    <input type="range" name="ui_skin_card_opacity" id="ui_skin_card_opacity" min="0" max="100" step="1" value="<?php echo $current_ui_skin_card_opacity; ?>" style="max-width:320px;" />
+    <small>プリセットが加えるカード面・ヘッダー面の見え方だけを調整します。既存のカード透過度設定とも併用されます。</small>
+  </div>
+  <script>
+  (function(){
+      var skinEl = document.getElementById('ui_skin_preset');
+      var opacityEl = document.getElementById('ui_skin_card_opacity');
+      var opacityLabel = document.getElementById('ui_skin_card_opacity_val');
+      if (!skinEl || !opacityEl || !opacityLabel) return;
+      // スラッグ => CSSファイルパス（プレビュー用に <link> を差し替える）
+      var skinFiles = <?php
+          $skin_files_js = [];
+          foreach ($ui_skin_list as $slug => $skin) {
+              $skin_files_js[$slug] = $skin['file'];
+          }
+          echo json_encode($skin_files_js, JSON_UNESCAPED_SLASHES);
+      ?>;
+      var LINK_ID_SKIN = 'ykr-skin-preview-file';
+      var LINK_ID_COMPONENTS = 'ykr-skin-preview-components';
+
+      function setPreviewLink(id, href){
+          var el = document.getElementById(id);
+          if (!href) {
+              if (el) el.remove();
+              return;
+          }
+          if (!el) {
+              el = document.createElement('link');
+              el.id = id;
+              el.rel = 'stylesheet';
+              document.head.appendChild(el);
+          }
+          el.href = href;
+      }
+
+      function applySkinPreview(){
+          var value = skinEl.value || 'default';
+          var opacity = Math.max(0, Math.min(100, parseInt(opacityEl.value, 10) || 0));
+          if (value !== 'default' && skinFiles[value]) {
+              setPreviewLink(LINK_ID_SKIN, skinFiles[value]);
+              setPreviewLink(LINK_ID_COMPONENTS, 'css/themes/skin-components.css');
+          } else {
+              setPreviewLink(LINK_ID_SKIN, null);
+              setPreviewLink(LINK_ID_COMPONENTS, null);
+          }
+          document.documentElement.style.setProperty('--ykr-skin-card-opacity', String(opacity / 100));
+          opacityLabel.textContent = String(opacity);
+      }
+      skinEl.addEventListener('input', applySkinPreview);
+      skinEl.addEventListener('change', applySkinPreview);
+      opacityEl.addEventListener('input', applySkinPreview);
+      opacityEl.addEventListener('change', applySkinPreview);
+  })();
+  </script>
+</div></div>
 
 <!---- 背景画像 + 透過度設定 ----->
   <?php
@@ -826,7 +911,6 @@ print ' value="10" ';
           $bg_overlay_opacity = (int)$config_ini["bg_overlay_opacity"];
       }
   ?>
-</div></div>
 
 <div class="card cfg-card mb-4"><div class="card-body">
   <div class="mb-3">

--- a/kara_config.php
+++ b/kara_config.php
@@ -147,6 +147,12 @@ function readconfig_array()
     if(!array_key_exists("usenewrequestlist", $config_ini)){
         $config_ini = array_merge($config_ini,array("usenewrequestlist" => 1));
     }
+    if(!array_key_exists("ui_skin_preset", $config_ini)){
+        $config_ini["ui_skin_preset"] = urlencode("default");
+    }
+    if(!array_key_exists("ui_skin_card_opacity", $config_ini)){
+        $config_ini["ui_skin_card_opacity"] = 100;
+    }
     if(!array_key_exists("secret_display_text", $config_ini)){
         $config_ini["secret_display_text"] = urlencode("ヒ・ミ・ツ♪(シークレットリクエスト)");
     }


### PR DESCRIPTION
- プリセットを css/themes/skins/*.css （CSS変数の上書きのみ）として ファイル追加するだけで一覧・設定画面に反映される方式に変更
- get_ui_skin_list() でディレクトリを走査して動的に一覧を生成 （PHP側にプリセット名をハードコードしない）
- print_bs5_head_core() 内で <link> を1本だけ条件付きで読み込む方式にし、 各BS5ページの body 属性付与漏れ（旧方式で30ページ中15ページに機能が 反映されていなかった問題）を解消
- 標準（プリセット未選択）は一切ファイルを読み込まず、既存の見た目を 完全に維持
- 共通コンポーネント適用ルールを css/themes/skin-components.css に分離し、 非標準プリセット選択時のみ読み込む
- .btn-primary の配色・.btn-secondary系の角丸・.notice-embedded-html （管理者埋め込みHTML）は元々全プリセット共通で適用されていたため、 theme-toggle.css に常時適用ルールとして移設
- init.php の設定画面をプリセット一覧の動的生成に対応させ、旧shape 設定（形状の独立選択）は撤廃してプリセット毎の角丸値に統合
- プレビューJSは body 属性の切替ではなく <link> 要素の動的差し替えに変更