### PR TITLE
りすたーDB作品名インデックス検索: カテゴリー非表示設定と警告抑制

### DIFF
--- a/listerdb_config.ini
+++ b/listerdb_config.ini
@@ -1,6 +1,13 @@
+; 作品名インデックス検索のカテゴリー表示設定
+; [category_order] … 書いた順にカテゴリーを表示。未記載のカテゴリーは後ろに追加される
+; [category_hidden] … 書いたカテゴリーを非表示にする(「その他」「全部」も指定可能)
 [category_order]
 category_name[]=アニメ
 category_name[]=ゲーム
 category_name[]=特撮
 category_name[]=ボカロ
 
+;[category_hidden]
+;category_name[]=例レーベル
+;category_name[]=その他
+;category_name[]=全部

--- a/search_listerdb_program_index.php
+++ b/search_listerdb_program_index.php
@@ -61,22 +61,51 @@ function checkandbuild_headerlink( $oneheader, $headerlist ,$lister_dbpath) {
 }
 
 
+// listerdb_config.ini の [category_hidden] に設定された非表示カテゴリー名の一覧
+function get_listerdb_hidden_categories(){
+    static $hiddenlist = null;
+    if( $hiddenlist !== null ) return $hiddenlist;
+    $hiddenlist = array();
+    $lister_config = @parse_ini_file("listerdb_config.ini", true);
+    if( $lister_config !== FALSE
+        && array_key_exists("category_hidden",$lister_config)
+        && array_key_exists("category_name",$lister_config["category_hidden"])
+        && is_array($lister_config["category_hidden"]["category_name"]) ){
+        $hiddenlist = $lister_config["category_hidden"]["category_name"];
+    }
+    return $hiddenlist;
+}
+
+// カテゴリー未設定(NULL)は「その他」として判定する
+function is_hidden_category($category){
+    if( $category === NULL ) $category = 'その他';
+    return in_array($category, get_listerdb_hidden_categories(), true);
+}
+
 //カテゴリーリストの並べ替え
 function sortcategorylist($categorylist){
-    $lister_config = parse_ini_file("listerdb_config.ini", true);
+    if(! is_array($categorylist) ) return array();
+
+    foreach($categorylist as $key => $value ){
+        if( is_hidden_category($value["program_category"]) ) unset($categorylist[$key]);
+    }
+    $categorylist = array_values($categorylist);
+
+    $lister_config = @parse_ini_file("listerdb_config.ini", true);
     if( $lister_config === FALSE ){
         // ファイルがない場合、DBの順番
         return $categorylist;
     }
     $nullcategory_exists = 0;
     $allcategory_exists = 0;
-    
+
     $newcategorylist = array();
     if(! array_key_exists("category_order",$lister_config) )  return $categorylist;
     if(! array_key_exists("category_name",$lister_config["category_order"]) )  return $categorylist;
-    
+
     foreach($lister_config["category_order"]["category_name"] as $ordercat ){
     // print $ordercat;
+        if( is_hidden_category($ordercat) ) continue;
         if($ordercat === "全部" ){
             $newcategorylist[] = array("program_category" => $ordercat);
             $allcategory_exists++;
@@ -107,7 +136,7 @@ function sortcategorylist($categorylist){
         $result = array_merge($newcategorylist,$categorylist);
         $newcategorylist = $result;
     }
-    if($nullcategory_exists == 0 ) {
+    if($nullcategory_exists == 0 && !is_hidden_category('その他') ) {
         $foundkey = false;
         foreach($newcategorylist as $key => $value ){
            if($value["program_category"] == NULL ){
@@ -115,11 +144,13 @@ function sortcategorylist($categorylist){
                break;
            }
         }
-        $split = array_splice($newcategorylist,$foundkey,1);
+        if( $foundkey !== FALSE ){
+            $split = array_splice($newcategorylist,$foundkey,1);
+        }
         $newcategorylist[] = array("program_category" => NULL);
     }
-    
-    if($allcategory_exists == 0 ) {
+
+    if($allcategory_exists == 0 && !is_hidden_category('全部') ) {
         $newcategorylist[] = array("program_category" => '全部');
     }
     return $newcategorylist;
@@ -332,7 +363,7 @@ print '</div>';
 }
 
 // その他のカテゴリーは最後
-if($nullcategory_exists == 0 ){
+if($nullcategory_exists == 0 && !is_hidden_category('その他') ){
   $cur_category = 'その他';
   $url = 'http://localhost/search_listerdb_head_json.php?program_category=ISNULL';
 
@@ -399,7 +430,7 @@ print '</div>';
 }
 }
 
-if($allcategory_exists == 0 ){
+if($allcategory_exists == 0 && !is_hidden_category('全部') ){
 // カテゴリ分けしない全部表示
   $cur_category = '全部';
   $url = 'http://localhost/search_listerdb_head_json.php?'.$linkoption;

--- a/search_listerdb_program_index_bs5.php
+++ b/search_listerdb_program_index_bs5.php
@@ -47,10 +47,39 @@ function checkandbuild_headerlink($oneheader, $headlist, $lister_dbpath)
     return '<span class="index-btn no-data">' . htmlspecialchars($oneheader, ENT_QUOTES, 'UTF-8') . '</span>';
 }
 
+// listerdb_config.ini の [category_hidden] に設定された非表示カテゴリー名の一覧
+function get_listerdb_hidden_categories()
+{
+    static $hiddenlist = null;
+    if ($hiddenlist !== null) return $hiddenlist;
+    $hiddenlist = [];
+    $lister_config = @parse_ini_file("listerdb_config.ini", true);
+    if ($lister_config !== false
+        && array_key_exists("category_hidden", $lister_config)
+        && array_key_exists("category_name", $lister_config["category_hidden"])
+        && is_array($lister_config["category_hidden"]["category_name"])) {
+        $hiddenlist = $lister_config["category_hidden"]["category_name"];
+    }
+    return $hiddenlist;
+}
+
+// カテゴリー未設定(NULL)は「その他」として判定する
+function is_hidden_category($category)
+{
+    if ($category === null) $category = 'その他';
+    return in_array($category, get_listerdb_hidden_categories(), true);
+}
+
 function sortcategorylist($categorylist)
 {
     if (!is_array($categorylist)) return [];
-    $lister_config = parse_ini_file("listerdb_config.ini", true);
+
+    foreach ($categorylist as $key => $value) {
+        if (is_hidden_category($value["program_category"])) unset($categorylist[$key]);
+    }
+    $categorylist = array_values($categorylist);
+
+    $lister_config = @parse_ini_file("listerdb_config.ini", true);
     if ($lister_config === false) return $categorylist;
     if (!array_key_exists("category_order", $lister_config)) return $categorylist;
     if (!array_key_exists("category_name", $lister_config["category_order"])) return $categorylist;
@@ -59,6 +88,7 @@ function sortcategorylist($categorylist)
     $nullcategory_exists = 0;
     $allcategory_exists  = 0;
     foreach ($lister_config["category_order"]["category_name"] as $ordercat) {
+        if (is_hidden_category($ordercat)) continue;
         if ($ordercat === '全部') {
             $newcategorylist[] = ['program_category' => $ordercat];
             $allcategory_exists++;
@@ -80,7 +110,7 @@ function sortcategorylist($categorylist)
     if (count($categorylist) > 0) {
         $newcategorylist = array_merge($newcategorylist, $categorylist);
     }
-    if ($nullcategory_exists == 0) {
+    if ($nullcategory_exists == 0 && !is_hidden_category('その他')) {
         $foundkey = false;
         foreach ($newcategorylist as $key => $value) {
             if ($value["program_category"] == null) { $foundkey = $key; break; }
@@ -88,7 +118,7 @@ function sortcategorylist($categorylist)
         if ($foundkey !== false) array_splice($newcategorylist, $foundkey, 1);
         $newcategorylist[] = ['program_category' => null];
     }
-    if ($allcategory_exists == 0) {
+    if ($allcategory_exists == 0 && !is_hidden_category('全部')) {
         $newcategorylist[] = ['program_category' => '全部'];
     }
     return $newcategorylist;
@@ -255,7 +285,7 @@ showuppermenu('program_name', $linkoption);
   </div>
   <?php endforeach; ?>
 
-  <?php if ($nullcategory_exists == 0): ?>
+  <?php if ($nullcategory_exists == 0 && !is_hidden_category('その他')): ?>
     <?php
     $headlist_json = @file_get_contents('http://localhost/search_listerdb_head_json.php?program_category=ISNULL');
     if ($headlist_json):
@@ -271,7 +301,7 @@ showuppermenu('program_name', $linkoption);
     <?php endif; endif; ?>
   <?php endif; ?>
 
-  <?php if ($allcategory_exists == 0): ?>
+  <?php if ($allcategory_exists == 0 && !is_hidden_category('全部')): ?>
     <?php
     $headlist_json = @file_get_contents('http://localhost/search_listerdb_head_json.php?' . $linkoption);
     if ($headlist_json):


### PR DESCRIPTION
## 概要
りすたーDBの作品名インデックス検索のカテゴリー表示制御(`listerdb_config.ini`)を拡張・修正しました。

## 変更内容
### 新機能: `[category_hidden]` によるカテゴリー非表示
```ini
[category_hidden]
category_name[]=特撮
category_name[]=その他
category_name[]=全部
```
- 指定したカテゴリーをインデックス検索から非表示にできます
- 自動追加される「その他」(カテゴリー未設定)・「全部」も指定可能
- `[category_order]` と重複指定した場合は非表示が優先
- セクション未記載なら従来通りの動作(後方互換)

### 修正
- `listerdb_config.ini` が存在しない環境で `parse_ini_file` の Warning が画面に表示されていたのを `@` 抑制で修正(ファイル無し時はDB順で表示という従来のフォールバックは維持)
- 旧UI版 `search_listerdb_program_index.php` で、nullカテゴリーが見つからない場合に `array_splice` が先頭要素を誤削除するバグを修正(bs5版と同じガードを追加)
- `listerdb_config.ini` に設定方法のコメントと `[category_hidden]` の記入例(コメントアウト)を追記

## 検証
- 両ファイル `php -l` 通過
- 実ファイルから関数を抽出した動作テストで以下5ケースを確認
  1. ini無し → 警告なしでDB順表示
  2. `[category_order]` のみ → 指定順+残り+その他+全部
  3. 通常カテゴリーの非表示
  4. 「その他」「全部」の非表示
  5. order と hidden の重複時は非表示優先

🤖 Generated with [Claude Code](https://claude.com/claude-code)