### PR TITLE
chore: listerdb_config.ini をインストーラーの同梱ファイルに追加

### DIFF
--- a/InnoSetupScript.iss
+++ b/InnoSetupScript.iss
@@ -38,6 +38,7 @@ Source: "ykr.ico"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
 Source: "favicon.ico"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
 Source: ".htaccess"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main
 Source: "ini.ini"; DestDir: "{app}"; Flags: onlyifdoesntexist; Components: main
+Source: "listerdb_config.ini"; DestDir: "{app}"; Flags: onlyifdoesntexist; Components: main
 Source: "search_sort_priority.json"; DestDir: "{app}"; Flags: onlyifdoesntexist; Components: main
 Source: "search_sort_priority_auth.json"; DestDir: "{app}"; Flags: onlyifdoesntexist; Components: main
 Source: "limitlist_sample.json"; DestDir: "{app}"; Flags: IgnoreVersion; Components: main

--- a/InnoSetupScript.iss
+++ b/InnoSetupScript.iss
@@ -46,7 +46,7 @@ Source: "limitlist_sample.json"; DestDir: "{app}"; Flags: IgnoreVersion; Compone
 ; --- サブディレクトリ ---
 Source: "css\*"; DestDir: "{app}\css"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
 Source: "js\*"; DestDir: "{app}\js"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
-Source: "images\*"; DestDir: "{app}\images"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
+Source: "images\*"; DestDir: "{app}\images"; Excludes: "\マスコット\*"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
 Source: "fonts\*"; DestDir: "{app}\fonts"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
 Source: "modules\*"; DestDir: "{app}\modules"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
 Source: "cms\*"; DestDir: "{app}\cms"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main


### PR DESCRIPTION
## 概要

インストーラー刷新（PR #181 以降）の `[Files]` セクションに関する2件の修正です。

## 変更内容

### 1. listerdb_config.ini を同梱ファイルに追加

新規インストール時に ListerDB のカテゴリ順設定ファイルが配置されなかった問題の修正です。

```iss
Source: "listerdb_config.ini"; DestDir: "{app}"; Flags: onlyifdoesntexist; Components: main
```

ユーザーが編集する設定ファイルのため `onlyifdoesntexist` でアップデート時には上書きしません（`ini.ini` / `search_sort_priority.json` と同じパターン）。

### 2. images\マスコット をインストール対象から除外

マスコット画像はリポジトリ上の素材置き場のため、インストール先には配置しないよう `Excludes` を追加しました。

```iss
Source: "images\*"; DestDir: "{app}\images"; Excludes: "\マスコット\*"; Flags: IgnoreVersion recursesubdirs createallsubdirs; Components: main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)