### PR TITLE
fix:UI-v2有効時のrequestlist_only.php直アクセスを抑止

### DIFF
--- a/requestlist_only.php
+++ b/requestlist_only.php
@@ -3,6 +3,11 @@ require_once 'commonfunc.php';
 require_once 'easyauth_class.php';
 $easyauth = new EasyAuth();
 $easyauth -> do_eashauthcheck();
+if (!empty($config_ini['usenewrequestlist']) && $config_ini['usenewrequestlist'] == 1) {
+    $qs = !empty($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '';
+    header('Location: search_bs5.php' . $qs);
+    exit;
+}
 if(array_key_exists("showid", $_REQUEST)) {
     $showid = $_REQUEST["showid"];
 }
@@ -277,5 +282,4 @@ if($user === "admin"){
 </div>
 </body>
 </html>
-
 


### PR DESCRIPTION
## 概要

UI v2 有効時に旧UIの `requestlist_only.php` へ直接アクセスできる状態を抑止します。

## 変更内容

- `requestlist_only.php` の認証後、HTML出力前に `usenewrequestlist == 1` を確認
- UI v2 有効時は `search_bs5.php` へ `Location` ヘッダーで遷移
- 既存のクエリ文字列は `search.php` と同じ形で引き継ぎ

## 確認

- `C:\xampp\php\php.exe -l requestlist_only.php`
- ローカルPHPサーバーで以下を確認
  - `/requestlist_only.php` -> `302 Location: search_bs5.php`
  - `/requestlist_only.php?showid=12` -> `302 Location: search_bs5.php?showid=12`

## 関連

- Fork issue: https://github.com/hachi515tennis3-glitch/KaraokeRequestorWeb/issues/9
