### PR TITLE
fix:オンライン更新で検索優先設定を保持するよう修正

### DIFF
--- a/commonfunc.php
+++ b/commonfunc.php
@@ -2877,6 +2877,8 @@ function update_fromarchive($version_str, &$errmsg) {
         $exclude_list[] = 'request.db';
     }
     $exclude_list[] = 'images/bg';
+    $exclude_list[] = 'search_sort_priority.json';
+    $exclude_list[] = 'search_sort_priority_auth.json';
 
     _kara_update_copy_recursive($source_dir, $app_root, $exclude_list);
 


### PR DESCRIPTION
## 概要

ZIP方式のオンラインアップデート時に、検索優先表示設定が上書きされないようにします。

## 変更内容

- `update_fromarchive()` の上書き除外リストへ以下を追加
  - `search_sort_priority.json`
  - `search_sort_priority_auth.json`

## 確認

- `C:\xampp\php\php.exe -l commonfunc.php`

## 関連

- Fork issue: https://github.com/hachi515tennis3-glitch/KaraokeRequestorWeb/issues/11
