### PR TITLE
feat:作品名インデックスの初期開閉設定を追加

### DIFF
--- a/init.php
+++ b/init.php
@@ -1473,6 +1473,7 @@ foreach ($searchitem_defs as $idx => $def) {
 }
 asort($si_order_map);
 $si_sorted_indices = array_keys($si_order_map);
+$listerdb_index_default_collapsed = configbool("listerdb_index_default_collapsed", false);
 
 ?>
 
@@ -1489,6 +1490,17 @@ $si_sorted_indices = array_keys($si_order_map);
       <span class="searchitem-drag-handle" style="cursor:grab; color:var(--color-text-muted); font-size:20px; padding:0 10px 0 0; line-height:1; user-select:none; touch-action:none;">&#8942;</span>
       <input type="checkbox" name="searchitem[]" value="<?php echo $def['id']; ?>" <?php echo $checked; ?> style="margin-right:8px;">
       <span><?php echo $def['label']; ?></span>
+      <?php if ($def['id'] === 'listerDB'): ?>
+      <span style="margin-left:auto; display:inline-flex; align-items:center; gap:8px; font-size:0.9rem;">
+        <span class="text-muted">初期状態で閉じる</span>
+        <label class="radio-inline" style="margin-right:0;">
+          <input type="radio" name="listerdb_index_default_collapsed" value="1" <?php echo $listerdb_index_default_collapsed ? 'checked' : ''; ?>> オン
+        </label>
+        <label class="radio-inline" style="margin-right:0;">
+          <input type="radio" name="listerdb_index_default_collapsed" value="2" <?php echo !$listerdb_index_default_collapsed ? 'checked' : ''; ?>> オフ
+        </label>
+      </span>
+      <?php endif; ?>
       <input type="hidden" name="searchitem_o[<?php echo $idx; ?>]" value="<?php echo $si_sorted_pos + 1; ?>" class="searchitem-order-input">
     </div>
 <?php } ?>

--- a/kara_config.php
+++ b/kara_config.php
@@ -149,6 +149,9 @@ function readconfig_array()
     if(!array_key_exists("usenewrequestlist", $config_ini)){
         $config_ini = array_merge($config_ini,array("usenewrequestlist" => 1));
     }
+    if(!array_key_exists("listerdb_index_default_collapsed", $config_ini)){
+        $config_ini["listerdb_index_default_collapsed"] = 2;
+    }
     if(!array_key_exists("ui_skin_preset", $config_ini)){
         $config_ini["ui_skin_preset"] = urlencode("default");
     }

--- a/search_bs5.php
+++ b/search_bs5.php
@@ -532,8 +532,8 @@ else:
                     break;
                 case 1:
                     if (checkbox_check($config_ini['searchitem'], "listerDB")) {
-                        // 作品名インデックス検索は常時開いた状態にする
-                        _section_open('sec-listerdb', '作品名インデックス検索', true);
+                        $listerdb_default_open = !configbool("listerdb_index_default_collapsed", false);
+                        _section_open('sec-listerdb', '作品名インデックス検索', $listerdb_default_open ? $first : false);
                         print_listerdb_search();
                         _section_close();
                         $first = false;


### PR DESCRIPTION
## 概要

BS5検索画面の「作品名インデックス検索」を初期状態で閉じるかどうか、環境設定から切り替えられるようにします。

## 変更内容

- `listerdb_index_default_collapsed` 設定を追加
- `init.php` の「検索画面に表示する項目」で、作品名インデックス検索行の右側に「初期状態で閉じる」オン/オフを追加
- `search_bs5.php` の作品名インデックス検索セクションの初期開閉を設定値で制御

## 互換性

未設定時はオフ扱いにしているため、既存環境では従来どおり表示順上の最初のセクションとして開きます。

## 確認

- `C:\xampp\php\php.exe -l init.php`
- `C:\xampp\php\php.exe -l search_bs5.php`
- `C:\xampp\php\php.exe -l kara_config.php`

## 関連

- Fork issue: https://github.com/hachi515tennis3-glitch/KaraokeRequestorWeb/issues/12
