### PR TITLE
feat: マイページ一覧取得API /api/mypage_list.php を追加

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -303,9 +303,30 @@ GET /mpcctrl_bs5.php?cmd=comp_get | comp_inc | comp_dec | comp_reset | comp_appl
 
 ---
 
-## マイページ（既存 API）
+## マイページ
 
 `usemypage=1` 時のみ。ユーザー識別は Cookie `YkariUserID` (UUID)。
+モバイルアプリは端末で生成した UUID を Cookie ヘッダーで送る (Web 版と同じ UUID ならデータ共有できる)。
+
+### GET /api/mypage_list.php — 一覧取得（エンベロープ版）
+
+| パラメータ | 必須 | 説明 |
+|---|---|---|
+| `kind` | ○ | `history` (履歴) / `later` (あとで歌う) / `favorite_song` (お気に入り曲) |
+| `sort` | - | `date` (既定) / `count` (history のみ) / `filedate` |
+| `order` | - | `desc` (既定) / `asc` |
+| `limit` | - | history の取得上限 (既定 200) |
+
+```json
+{ "ok":true, "data": { "kind":"later", "userid":"UUID", "displayname":"...",
+  "items": [ { "fullpath":"...", "songfile":"...", "kind":"動画", "added_at":N } ] } }
+// history の items は { fullpath, songfile, kind, times, last_requested_at, first_id }
+```
+
+- Cookie が無い場合は新規 UUID が発行され (Set-Cookie)、一覧は空で返る
+- `usemypage=0` のサーバーでは 404
+
+### GET /mypage_api.php — 追加・削除（既存）
 
 ```
 GET /mypage_api.php?action=<action>&...

--- a/api/mypage_list.php
+++ b/api/mypage_list.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * /api/mypage_list.php
+ *
+ * マイページの一覧取得 (履歴 / あとで歌う / お気に入り曲)。
+ * 追加・削除は既存の mypage_api.php を使う (本 API は取得系のみ)。
+ *
+ * ユーザー識別は Cookie `YkariUserID` (UUID)。Web 版と同じ UUID を送れば
+ * データを共有できる。Cookie が無い場合は新規ユーザーとして UUID が発行され
+ * Set-Cookie で返る (一覧は空)。
+ *
+ * パラメータ:
+ *   kind  (必須) history | later | favorite_song
+ *   sort  (任意) date (既定) | count (history のみ) | filedate
+ *   order (任意) desc (既定) | asc
+ *   limit (任意) history の取得上限 (既定 200)
+ *
+ * 応答:
+ * {
+ *   "ok": true,
+ *   "data": {
+ *     "kind": "history",
+ *     "userid": "UUID",
+ *     "displayname": "...",
+ *     "items": [
+ *       // history: { fullpath, songfile, kind, times, last_requested_at, first_id }
+ *       // later / favorite_song: { fullpath, songfile, kind, added_at }
+ *     ]
+ *   }
+ * }
+ *
+ * usemypage=0 のサーバーでは 404 を返す。
+ */
+require_once __DIR__ . '/_common.php';
+require_once __DIR__ . '/../mypage_class.php';
+
+if (!configbool('usemypage', false)) {
+    api_error('mypage is disabled on this server', 404);
+}
+
+$kind = (string)api_param('kind', '');
+if (!in_array($kind, ['history', 'later', 'favorite_song'], true)) {
+    api_error('invalid kind (history|later|favorite_song)');
+}
+
+$sort = (string)api_param('sort', 'date');
+if (!in_array($sort, ['date', 'count', 'filedate'], true)) {
+    $sort = 'date';
+}
+$order = (string)api_param('order', 'desc');
+if (!in_array($order, ['asc', 'desc'], true)) {
+    $order = 'desc';
+}
+$limit = api_param('limit');
+$limit = ($limit !== null && ctype_digit((string)$limit) && (int)$limit > 0) ? (int)$limit : 200;
+
+try {
+    $mypage = new MypageUser($db);
+
+    switch ($kind) {
+        case 'history':
+            $items = $mypage->getHistory($sort, $order, $limit);
+            break;
+        case 'later':
+            $items = $mypage->getLaterList($sort, $order);
+            break;
+        default:
+            $items = $mypage->getFavoriteSongs($sort, $order);
+            break;
+    }
+
+    api_ok([
+        'kind'        => $kind,
+        'userid'      => $mypage->getUserId(),
+        'displayname' => $mypage->getDisplayName(),
+        'items'       => $items,
+    ]);
+} catch (Exception $e) {
+    api_error('DB error', 500);
+}


### PR DESCRIPTION
## 概要

ゆかナビ M3 (マイページ機能) 用の一覧取得 API です。追加・削除は既存の mypage_api.php をそのまま使い、本 PR は取得系のみ追加します (設計書 §5.2 の「マイページ一覧取得 API」)。

## 変更内容

- `GET /api/mypage_list.php?kind=history|later|favorite_song` — エンベロープ形式の一覧取得
  - sort (date/count/filedate)・order・limit 対応
  - ユーザー識別は既存と同じ Cookie `YkariUserID` (アプリは端末生成 UUID を送信、Web と同 UUID ならデータ共有可)
  - usemypage=0 では 404
- 実装は MypageUser クラスの既存メソッドを共用 (重複実装なし)
- api/README.md に仕様を追記

## 動作確認 (PHP ビルトインサーバー + curl)

- ✅ Cookie なし → UUID 発行 + 空一覧
- ✅ add_later (mypage_api.php) → kind=later で1件取得
- ✅ exec.php 予約 → kind=history に times/last_requested_at 込みで反映
- ✅ kind 不正 → 400、php -l 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)