### PR TITLE
fix: SSE の接続滞留と localhost ポート枯渇 (TIME_WAIT 蓄積) を修正

### DIFF
--- a/commonfunc.php
+++ b/commonfunc.php
@@ -132,6 +132,9 @@ function file_get_html_with_retry($url, $retrytimes = 5, $timeoutsec = 1, $ipvar
         curl_setopt($ch, CURLOPT_TIMEOUT_MS, $timeoutsec_ms);
         }
         curl_setopt($ch, CURLOPT_FAILONERROR, true);
+        /* サーバー側から先に切断させる。先に切断した側に TIME_WAIT (約2分) が残るため、
+           これがないと localhost への定期呼び出しで httpd のエフェメラルポートが枯渇する */
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Connection: close'));
         //リダイレクト先追従
         //Locationをたどる
         curl_setopt($ch,CURLOPT_FOLLOWLOCATION,true);
@@ -1073,8 +1076,10 @@ function commentpost_v3($nm,$col,$size,$msg,$commenturl)
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 2);
     curl_setopt($curl, CURLOPT_TIMEOUT, 2);
+    curl_setopt($curl, CURLOPT_HTTPHEADER, array('Connection: close'));
     curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($POST_DATA));
     $output= curl_exec($curl);
+    curl_close($curl);
 
     if($output === false){
         return false;
@@ -1100,8 +1105,10 @@ function commentpost_v4($cmd,$msg,$commenturl)
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 2);
     curl_setopt($curl, CURLOPT_TIMEOUT, 2);
+    curl_setopt($curl, CURLOPT_HTTPHEADER, array('Connection: close'));
     curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($POST_DATA));
     $output= curl_exec($curl);
+    curl_close($curl);
 
     if($output === false){
         return false;

--- a/func_keychange.php
+++ b/func_keychange.php
@@ -3,18 +3,19 @@ class EasyKeychanger {
     public $KeychangerURL = 'http://localhost:13580/';
     public $Keychangertimeout = 1;
     
-    public function getstatus() {
+    public function getstatus($retrytimes = 10) {
         require_once 'commonfunc.php';
-        
+
         $url = $this->KeychangerURL.'command.html?help=ver';
-        
-        for ($i=0; $i<10; $i++) {
+
+        $res = false;
+        for ($i=0; $i<$retrytimes; $i++) {
             $res = @file_get_html_with_retry($url,2,$this->Keychangertimeout,4);
             if($res !== false) break;
         }
-        if($i == 10 ) return false;
+        if($res === false ) return false;
         return $this->build_result($res);
-        
+
     }
     
     public function keyup($token = "") {

--- a/func_playerprogress.php
+++ b/func_playerprogress.php
@@ -15,8 +15,28 @@ class PlayerProgress {
     public $playingfile = "";
     public $playingsinger = "";
     public $playercommandname = "";
-    
-    
+
+    public $http_ch = null;
+    public $running_cache = null;
+    public $running_cache_time = 0;
+
+    /* SSE ループから0.5秒間隔で呼ばれるため、curl ハンドルを使い回して接続を
+       keep-alive させる。毎回新規に TCP 接続を張るとエフェメラルポートを
+       食い潰す (TIME_WAIT が約2分残る) */
+    public function http_get($url) {
+        if ($this->http_ch === null) {
+            $this->http_ch = curl_init();
+            curl_setopt($this->http_ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($this->http_ch, CURLOPT_HEADER, false);
+            curl_setopt($this->http_ch, CURLOPT_CONNECTTIMEOUT, 1);
+            curl_setopt($this->http_ch, CURLOPT_TIMEOUT, 2);
+            curl_setopt($this->http_ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+        }
+        curl_setopt($this->http_ch, CURLOPT_URL, $url);
+        return curl_exec($this->http_ch);
+    }
+
+
     public function show_progress_text(){
 /*
         print '<script language="javascript" type="text/javascript">';
@@ -47,7 +67,7 @@ class PlayerProgress {
         }
         $result = array();
     
-        $status = file_get_html_with_retry($this->MPCVARIABLESURL);
+        $status = $this->http_get($this->MPCVARIABLESURL);
         if($status === FALSE) return $status;
         $status_array = preg_match_all("/\<p .*?>(.*?)<\/p>/", $status, $result);
         //var_dump($result);
@@ -142,20 +162,26 @@ class PlayerProgress {
     
     public function runningcheck_player() {
         global $config_ini;
+        /* tasklist はプロセス起動コストが高いため、SSE ループ内での連続呼び出しに備えて10秒キャッシュする */
+        if ($this->running_cache !== null && (microtime(true) - $this->running_cache_time) < 10) {
+            return $this->running_cache;
+        }
         $this->playercommandname = basename(urldecode($config_ini["playerpath"]));
         $pscheck_cmd='tasklist /fi "imagename eq '.$this->playercommandname.'"';
         //print $pscheck_cmd;
         exec($pscheck_cmd, $psresult );
         // sleep(1);
-        
+
         $process_found = false;
-        
+
         foreach( $psresult as $psline ){
           $pos = strpos($psline,$this->playercommandname);
           if ( $pos !== FALSE) {
              $process_found = true;
           }
         }
+        $this->running_cache = $process_found;
+        $this->running_cache_time = microtime(true);
         return $process_found;
     }
 }

--- a/func_playerprogress.php
+++ b/func_playerprogress.php
@@ -17,12 +17,16 @@ class PlayerProgress {
     public $playercommandname = "";
 
     public $http_ch = null;
+    public $http_keepalive = false;
     public $running_cache = null;
     public $running_cache_time = 0;
 
-    /* SSE ループから0.5秒間隔で呼ばれるため、curl ハンドルを使い回して接続を
-       keep-alive させる。毎回新規に TCP 接続を張るとエフェメラルポートを
-       食い潰す (TIME_WAIT が約2分残る) */
+    /* curl ハンドルを使い回して接続数を抑える。
+       既定 ($http_keepalive = false) では Connection: close を付けてサーバー側から
+       先に切断させる (先に切断した側に TIME_WAIT が約2分残り、httpd 側だと
+       エフェメラルポートを食い潰すため)。
+       SSE のように同一リクエスト内で連続呼び出しする場合のみ $http_keepalive = true
+       にして keep-alive で接続を維持する */
     public function http_get($url) {
         if ($this->http_ch === null) {
             $this->http_ch = curl_init();
@@ -31,6 +35,9 @@ class PlayerProgress {
             curl_setopt($this->http_ch, CURLOPT_CONNECTTIMEOUT, 1);
             curl_setopt($this->http_ch, CURLOPT_TIMEOUT, 2);
             curl_setopt($this->http_ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+            if (!$this->http_keepalive) {
+                curl_setopt($this->http_ch, CURLOPT_HTTPHEADER, array('Connection: close'));
+            }
         }
         curl_setopt($this->http_ch, CURLOPT_URL, $url);
         return curl_exec($this->http_ch);

--- a/getcurrentkey.php
+++ b/getcurrentkey.php
@@ -7,7 +7,8 @@
 
    if($cfg["usekeychange"] == 1) {
        $kc = new EasyKeychanger();
-       $status = $kc->getstatus();
+       /* キーチェンジャー不達時に接続試行が積み上がらないようリトライは2回まで */
+       $status = $kc->getstatus(2);
        if($status){
            print $status["currentkey"];
        }else {

--- a/getcurrentkey_event.php
+++ b/getcurrentkey_event.php
@@ -3,10 +3,6 @@
    header('Content-Type: text/event-stream');
    header('Cache-Control: no-cache');
    
-   /* キーチェンジャーが無効だと判定するアクセスチェック回数 */
-   $keychanger_checktimes_max = 4;
-   $keychanger_checktimes = 0;
-   
    require_once 'func_keychange.php';
    require_once 'func_readconfig.php';
    
@@ -20,29 +16,30 @@
        set_time_limit(300);
        $kc = new EasyKeychanger();
        while (1) {
-       
-           $newstatus = $kc->getstatus();
-           if( $newstatus == 'failed' ){
-             if($firstflg){
+
+           /* ループ自体が0.5秒周期で再試行するため、1回の確認での内部リトライは1回に抑える */
+           $newstatus = $kc->getstatus(1);
+           if( $newstatus === false ){
+             /* キーチェンジャー不達 */
+             if($firstflg || $status !== false){
                print "data:"."None"."\n\n";
-             }else if( $keychanger_checktimes++ > $keychanger_checktimes_max ){
-                $status = $newstatus;
-                print "data:"."None"."\n\n";
+               $status = false;
+               $firstflg = false;
              }
            }else if( $newstatus != $status) {
                $status = $newstatus;
                print "data:".$status["currentkey"]."\n\n";
                $firstflg = false;
-               $keychanger_checktimes = 0;
            }else if($firstflg){
                print "data:".$status["currentkey"]."\n\n";
                $firstflg = false;
-               $keychanger_checktimes = 0;
            }
-           //print "1";
+           print ": ping\n\n"; /* SSEコメント行。切断済みクライアントへの書き込み失敗で即終了させる */
            ob_flush();
            flush();
-           usleep(500000); /* サーバー側では0.5秒おきにチェック */
+           if (connection_aborted()) break;
+           /* 不達時は確認間隔を5秒に広げて接続試行を抑える */
+           usleep($status === false ? 5000000 : 500000); /* サーバー側では0.5秒おきにチェック */
        }
        set_time_limit(300);
    }

--- a/mpcctrl_func.php
+++ b/mpcctrl_func.php
@@ -255,7 +255,10 @@ function keychange($keycmd){
     $res = TRUE;
     $requesturl=$EASYKEYCHANGERURL.'?key='.$keycmd.'&token='.$clienttoken;
     $res = file_get_html_with_retry($requesturl,5,1);
-    update_requestdb_key();
+    /* キー送信に失敗した場合は現在キーの取得も失敗するだけなのでスキップ */
+    if($res !== false){
+        update_requestdb_key();
+    }
     return $res;
 }
 

--- a/player_event.php
+++ b/player_event.php
@@ -62,12 +62,14 @@
            $response_array_json = json_encode($response_array);
            if($response_array_json)
                print "data:".$response_array_json."\n\n";
-           ob_flush();
-           flush();
        }
-       
+       print ": ping\n\n"; /* SSEコメント行。切断済みクライアントへの書き込み失敗で即終了させる */
+       ob_flush();
+       flush();
+       if(connection_aborted()) break;
+
        usleep(500000); /* サーバー側では0.5秒おきにチェック */
-       
+
    }
    
 

--- a/player_event.php
+++ b/player_event.php
@@ -11,6 +11,7 @@
    $readconfig = new ReadConfig();
    $cfg = $readconfig->read_config();
    $playstat = new PlayerProgress;
+   $playstat->http_keepalive = true; /* SSE ループ内で連続呼び出しするため接続を維持する */
    $playerstatus_old = false;
    
    $status_progress=false;

--- a/requestlist_event.php
+++ b/requestlist_event.php
@@ -50,8 +50,10 @@
                print "data:"."None"."\n\n";
              }
            }
+           print ": ping\n\n"; /* SSEコメント行。切断済みクライアントへの書き込み失敗で即終了させる */
            ob_flush();
            flush();
+           if (connection_aborted()) break;
            usleep(500000); /* サーバー側では0.5秒おきにチェック */
        }
    set_time_limit(30);


### PR DESCRIPTION
## 概要

運用中に httpd.exe が 127.0.0.1 のエフェメラルポートを大量消費して動作不能になる問題の修正。

## 原因

1. **SSE の切断検知漏れ**: `requestlist_event.php` / `player_event.php` / `getcurrentkey_event.php` は状態変化時しか出力しないため、切断済みクライアントのループが `set_time_limit` (300〜600秒) まで走り続け、Apache スレッドとソケットを占有していた。
2. **TIME_WAIT の蓄積**: TCP は先に切断 (FIN) した側に TIME_WAIT が約2分残る。curl は HTTP/1.1 keep-alive で接続するため、応答後も接続を維持する相手 (キーチェンジャー・MPC-BE) に対して curl_close した httpd 側が先に切断し、httpd 側にポートを占有する TIME_WAIT が積み上がっていた。特にキーチェンジャーポーリング (0.5秒間隔) は画面1つで2分間に約240個を蓄積。
3. **不達時のリトライ増幅**: キーチェンジャー不達時、SSE で毎秒最大40接続試行。キーチェンジ操作1回で最大40超の接続試行 + 自己 HTTP 経由の `getcurrentkey.php` 呼び出し連鎖が発生していた。

## 修正内容

- SSE 3ファイルの各ループに ping コメント行出力と `connection_aborted()` チェックを追加し、切断済みクライアントを最大0.5秒で終了
- `file_get_html_with_retry` / `commentpost_v3` / `commentpost_v4` に `Connection: close` を付与し、サーバー側から先に切断させて httpd のポートを即解放 (`commentpost` は欠けていた `curl_close` も追加)
- `PlayerProgress` に curl ハンドル再利用の `http_get()` を追加。既定は `Connection: close`、SSE (`player_event.php`) のみ keep-alive で接続維持
- `runningcheck_player()` の `tasklist` 実行を10秒キャッシュ化 (SSE 1接続あたり毎秒2回のプロセス起動を削減)
- `EasyKeychanger::getstatus()` にリトライ回数引数を追加。SSE は1回・`getcurrentkey.php` は2回に削減し、不達時は SSE の確認間隔を5秒に拡大
- `keychange()` でキー送信失敗時は `update_requestdb_key()` をスキップし、自己 HTTP 呼び出し連鎖を防止

## 動作確認

- 試験環境にて、修正前は無操作でも数百個の TIME_WAIT が蓄積していたが、修正後は蓄積しないことを確認済み
- `php -l` による構文チェック全ファイル通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)