### PR TITLE
feat: マイページのアプリ連携 API (/api/mypage.php)

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -346,6 +346,56 @@ GET /mypage_api.php?action=<action>&...
 
 ---
 
+## マイページ（アプリ連携 API）
+
+```
+GET/POST /api/mypage.php?action=<action>&userid=<UUID>&...
+→ {"ok":true, "data":{...}} / {"ok":false, "error":"..."}
+```
+
+`usemypage=1` 時のみ (無効時は 503)。Web 版が Cookie `YkariUserID` で識別するのに対し、
+アプリはクエリ/POST の `userid` で識別する。**userid (UUID) を知っていること自体が認可**
+(Web の cookie と同じモデル)。
+
+### デバイスリンク
+
+| action | パラメータ | 応答 data |
+|---|---|---|
+| `pair_apply` | `code` (Web のデバイスリンクで発行した6文字) | `{userid}`。コードは消費される。無効/期限切れは 404 |
+| `pair_generate` | `userid` | `{code}` (5分有効) |
+
+### データ読み書き
+
+| action | パラメータ | 応答 data |
+|---|---|---|
+| `summary` | `userid` | 表示名・各リスト件数・`google_linked` |
+| `history` | `userid`, `sort`, `order` | `{items:[{fullpath,songfile,kind,times,last_requested_at}]}` |
+| `history_add` / `history_remove` | `fullpath` (+`songfile`,`kind`) | — |
+| `later` / `favorite` | `userid` | `{items:[{fullpath,songfile,kind,added_at}]}` |
+| `later_add` / `later_remove` / `favorite_add` / `favorite_remove` | `fullpath` (+`songfile`,`kind`) | — |
+| `keyword` | `userid` | `{items:[{id,keyword,search_type,search_params,added_at}]}` |
+| `keyword_add` | `keyword`, `search_type`, `search_params` | — |
+| `keyword_remove` | `id` **または** `keyword`+`search_type`+`search_params` (条件一致) | — |
+| `import` | `data` (POST。Web 版エクスポート形式 version 1 の JSON) | `{counts}`。マージ取り込みで冪等 (履歴は fullpath+日時、他は完全一致の重複をスキップ) |
+
+書き込み系アクションの成功時は、Google 連携済み + 自動同期オンなら Drive へも自動保存する
+(Web 版 `mypage_api.php` と同じ挙動。同期失敗しても書き込みの応答は成功のまま)。
+
+### Google 同期
+
+| action | パラメータ | 応答 data / エラー |
+|---|---|---|
+| `google_status` | `userid` | `{linked, email, auto_sync, last_synced_at}` |
+| `google_sync` | `userid`, `direction=to_drive\|from_drive` | `{synced, direction}`。未設定 503 / 未連携 404 / Drive 失敗 502 |
+| `google_token_get` | `userid` | トークン一式 + 発行元 `client_id` (アプリの「同期の持ち歩き」用)。未連携 404 |
+| `google_register` | POST: `google_sub`, `google_email`, `access_token`, `refresh_token`, `token_expires_at`, `client_id` | この部屋にその Google アカウントのユーザーを用意し (既存は `google_sub` で再利用)、Drive から復元して `{userid, access_token, token_expires_at, refreshed}` を返す |
+
+`google_register` のエラー: Google 同期未設定の部屋は **503** (アプリは静かにスキップ)、
+`client_id` がこの部屋の設定と不一致は **409** (別の Google 連携設定 = 持ち歩き対象外)、
+トークン無効 (読めず・更新できず・期限切れ) は **401** (アプリは持ち歩きを破棄して再連携を促す)。
+
+---
+
 ## 既知の注意点
 
 - `exec.php` の XHR 応答は先頭に改行を含む → パース前に trim すること

--- a/api/mypage.php
+++ b/api/mypage.php
@@ -22,6 +22,12 @@
  *                   マージ取り込み。重複はスキップされるため何度実行しても安全
  *   google_status   userid=      → 連携有無・メール・自動同期・最終同期時刻
  *   google_sync     userid= direction=to_drive|from_drive → Google Drive と同期
+ *   google_token_get userid=     → Google トークン一式 (アプリの「同期の持ち歩き」用。
+ *                   userid を知っている = 本人という Web cookie と同じ認可モデル)
+ *   google_register (POST: google_sub= google_email= access_token= refresh_token=
+ *                   token_expires_at=) → この部屋にその Google アカウントのユーザーを
+ *                   用意し (既存があれば再利用)、Drive から復元して userid を返す。
+ *                   Google 同期未設定の部屋では 503
  *
  * 書き込み系アクションの成功時は、Google 連携済み+自動同期オンなら Drive へも
  * 自動保存する (Web 版 mypage_api.php と同じ挙動)。
@@ -46,6 +52,56 @@ if ($action === 'pair_apply') {
         api_error('コードが無効または有効期限切れです (有効期限は5分です)', 404);
     }
     api_ok(['userid' => $userid]);
+}
+
+// ---- Google トークンによる自動引き継ぎ (userid 不要。アプリの部屋またぎ同期用) ----
+if ($action === 'google_register') {
+    $relay_url    = $config_ini['google_relay_url'] ?? 'https://ykr.moe/mypage_google_callback.php';
+    $relay_secret = $config_ini['google_relay_secret'] ?? '';
+    $client_id    = $config_ini['google_client_id'] ?? '';
+    if (empty($client_id) || empty($relay_secret)) {
+        api_error('Google同期が設定されていません', 503);
+    }
+    $google_sub    = (string)api_param('google_sub', '');
+    $google_email  = (string)api_param('google_email', '');
+    $access_token  = (string)api_param('access_token', '');
+    $refresh_token = (string)api_param('refresh_token', '');
+    $expires_at    = (int)api_param('token_expires_at', 0);
+    if ($google_sub === '' || $access_token === '') {
+        api_error('google_sub and access_token are required');
+    }
+
+    // この Google アカウントのユーザーが既にいればそれを、いなければ新規作成して紐付ける
+    $existing = MypageUser::findUserByGoogleSub($db, $google_sub);
+    $mypage = new MypageUser($db, $existing !== null ? $existing : '');
+    if ($mypage->getUserId() === '') {
+        $mypage->createNewUser();
+    }
+    $mypage->linkGoogle($google_sub, $google_email, $access_token, $refresh_token, $expires_at);
+
+    // Drive から復元 (マージ)。mypage_google_callback.php の初回同期と同じ流れ
+    require_once __DIR__ . '/../mypage_google_drive.php';
+    $drive = new GoogleDriveHelper($access_token, $refresh_token, $expires_at,
+        $relay_url, $relay_secret);
+    $drive_data = $drive->readData();
+    if ($drive_data) {
+        $mypage->importData($drive_data, false);
+    }
+    list($new_at, $new_exp, $refreshed) = $drive->getNewTokens();
+    if ($refreshed) {
+        $mypage->updateGoogleTokens($new_at, $new_exp);
+    }
+    // 読めず・更新もできず・期限切れ = トークン無効 (アプリは持ち歩きを破棄して再連携を促す)
+    if (!$drive_data && !$refreshed && $expires_at < time()) {
+        api_error('Google のトークンが無効です (連携をやり直してください)', 401);
+    }
+    $mypage->updateGoogleSyncTime();
+    api_ok([
+        'userid'           => $mypage->getUserId(),
+        'access_token'     => $refreshed ? $new_at : $access_token,
+        'token_expires_at' => $refreshed ? (int)$new_exp : $expires_at,
+        'refreshed'        => (bool)$refreshed,
+    ]);
 }
 
 // ---- 以降は userid 必須 ----
@@ -188,6 +244,20 @@ switch ($action) {
         }
         mypage_auto_sync($mypage); // 統合結果も Drive へ反映
         api_ok(['counts' => $result['counts']]);
+        break;
+
+    case 'google_token_get':
+        $link = $mypage->getGoogleLink();
+        if ($link === null) {
+            api_error('Google アカウントと連携されていません', 404);
+        }
+        api_ok([
+            'google_sub'       => $link['google_sub'],
+            'google_email'     => $link['google_email'],
+            'access_token'     => $link['access_token'],
+            'refresh_token'    => $link['refresh_token'],
+            'token_expires_at' => (int)$link['token_expires_at'],
+        ]);
         break;
 
     case 'google_status':

--- a/api/mypage.php
+++ b/api/mypage.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * /api/mypage.php
+ *
+ * マイページのアプリ連携 API (mypage_class.php の JSON ファサード)。
+ * Web 版は cookie (YkariUserID) でユーザーを識別するが、アプリはデバイスリンクの
+ * ペアコード (mypage_link_device.php で発行) から取得した userid をクエリで渡す。
+ * userid (UUID) を知っていること自体が認可となる (Web 版 cookie と同じモデル)。
+ *
+ * アクション (action):
+ *   pair_apply      code=XXXXXX  → { userid } コードを消費して userid を返す
+ *   pair_generate   userid=      → { code } このユーザーのペアコードを発行 (5分有効)
+ *   summary         userid=      → 表示名・各リスト件数・Google 連携有無
+ *   history         userid= [sort=date|name|filedate] [order=asc|desc]
+ *   history_add     userid= fullpath= songfile= [kind=]
+ *   later           userid= / later_add (同上) / later_remove userid= fullpath=
+ *   favorite        userid= / favorite_add (同上) / favorite_remove userid= fullpath=
+ *   keyword         userid=
+ *   keyword_add     userid= keyword= [search_type=] [search_params=]
+ *   keyword_remove  userid= id=
+ *   google_status   userid=      → 連携有無・メール・自動同期・最終同期時刻
+ *   google_sync     userid= direction=to_drive|from_drive → Google Drive と同期
+ *
+ * 応答: { "ok":true, "data":{...} } / { "ok":false, "error":"..." }
+ */
+require_once __DIR__ . '/_common.php';
+
+if (!configbool('usemypage', true)) {
+    api_error('マイページ機能が無効です', 503);
+}
+require_once __DIR__ . '/../mypage_class.php';
+
+$action = (string)api_param('action', '');
+
+// ---- ペアコード適用 (userid 不要。'' を渡して cookie を使わないモードにする) ----
+if ($action === 'pair_apply') {
+    $code = (string)api_param('code', '');
+    $mypage = new MypageUser($db, '');
+    $userid = $mypage->lookupPairingCode($code);
+    if ($userid === null) {
+        api_error('コードが無効または有効期限切れです (有効期限は5分です)', 404);
+    }
+    api_ok(['userid' => $userid]);
+}
+
+// ---- 以降は userid 必須 ----
+$userid = (string)api_param('userid', '');
+$mypage = new MypageUser($db, $userid);
+if ($mypage->getUserId() === '') {
+    api_error('invalid userid');
+}
+
+/** 追加系アクションの共通パラメータを取り出す (fullpath / songfile 必須)。 */
+function mypage_song_params()
+{
+    $fullpath = (string)api_param('fullpath', '');
+    $songfile = (string)api_param('songfile', '');
+    if ($fullpath === '' || $songfile === '') {
+        api_error('fullpath and songfile are required');
+    }
+    return [$fullpath, $songfile, (string)api_param('kind', '')];
+}
+
+switch ($action) {
+    case 'pair_generate':
+        api_ok(['code' => $mypage->generatePairingCode()]);
+        break;
+
+    case 'summary':
+        $link = $mypage->getGoogleLink();
+        api_ok([
+            'displayname'   => $mypage->getDisplayName(),
+            'history'       => count($mypage->getHistory()),
+            'later'         => count($mypage->getLaterList()),
+            'favorite'      => count($mypage->getFavoriteSongs()),
+            'keyword'       => count($mypage->getFavoriteKeywords()),
+            'google_linked' => $link !== null,
+        ]);
+        break;
+
+    case 'history':
+        api_ok(['items' => $mypage->getHistory(
+            (string)api_param('sort', 'date'), (string)api_param('order', 'desc'))]);
+        break;
+
+    case 'history_add':
+        list($fullpath, $songfile, $kind) = mypage_song_params();
+        $mypage->addHistory($fullpath, $songfile, $kind);
+        api_ok(['added' => true]);
+        break;
+
+    case 'later':
+        api_ok(['items' => $mypage->getLaterList()]);
+        break;
+
+    case 'later_add':
+        list($fullpath, $songfile, $kind) = mypage_song_params();
+        $mypage->addLater($fullpath, $songfile, $kind);
+        api_ok(['added' => true]);
+        break;
+
+    case 'later_remove':
+        $mypage->removeLater((string)api_param('fullpath', ''));
+        api_ok(['removed' => true]);
+        break;
+
+    case 'favorite':
+        api_ok(['items' => $mypage->getFavoriteSongs()]);
+        break;
+
+    case 'favorite_add':
+        list($fullpath, $songfile, $kind) = mypage_song_params();
+        $mypage->addFavoriteSong($fullpath, $songfile, $kind);
+        api_ok(['added' => true]);
+        break;
+
+    case 'favorite_remove':
+        $mypage->removeFavoriteSong((string)api_param('fullpath', ''));
+        api_ok(['removed' => true]);
+        break;
+
+    case 'keyword':
+        api_ok(['items' => $mypage->getFavoriteKeywords()]);
+        break;
+
+    case 'keyword_add':
+        $ok = $mypage->addFavoriteKeyword(
+            (string)api_param('keyword', ''),
+            (string)api_param('search_type', ''),
+            (string)api_param('search_params', ''));
+        if (!$ok) {
+            api_error('keyword is required');
+        }
+        api_ok(['added' => true]);
+        break;
+
+    case 'keyword_remove':
+        $mypage->removeFavoriteKeyword((int)api_param('id', 0));
+        api_ok(['removed' => true]);
+        break;
+
+    case 'google_status':
+        $link = $mypage->getGoogleLink();
+        if ($link === null) {
+            api_ok(['linked' => false]);
+        }
+        api_ok([
+            'linked'         => true,
+            'email'          => $link['google_email'],
+            'auto_sync'      => (int)$link['auto_sync'] === 1,
+            'last_synced_at' => (int)$link['last_synced_at'],
+        ]);
+        break;
+
+    case 'google_sync':
+        global $config_ini;
+        $relay_url    = $config_ini['google_relay_url'] ?? 'https://ykr.moe/mypage_google_callback.php';
+        $relay_secret = $config_ini['google_relay_secret'] ?? '';
+        $client_id    = $config_ini['google_client_id'] ?? '';
+        if (empty($client_id) || empty($relay_secret)) {
+            api_error('Google同期が設定されていません (管理者設定が必要です)', 503);
+        }
+        $link = $mypage->getGoogleLink();
+        if ($link === null) {
+            api_error('Google アカウントと連携されていません', 404);
+        }
+        require_once __DIR__ . '/../mypage_google_drive.php';
+        $drive = new GoogleDriveHelper(
+            $link['access_token'],
+            $link['refresh_token'],
+            $link['token_expires_at'],
+            $relay_url,
+            $relay_secret
+        );
+        $direction = (string)api_param('direction', 'to_drive');
+        if ($direction === 'from_drive') {
+            // Drive → サーバー (マージ)
+            $drive_data = $drive->readData();
+            if (!$drive_data) {
+                api_error('Drive からデータを取得できませんでした', 502);
+            }
+            $mypage->importData($drive_data, false);
+        } else {
+            // サーバー → Drive
+            if (!$drive->writeData($mypage->exportData())) {
+                api_error('Drive への書き込みに失敗しました', 502);
+            }
+        }
+        list($new_at, $new_exp, $refreshed) = $drive->getNewTokens();
+        if ($refreshed) {
+            $mypage->updateGoogleTokens($new_at, $new_exp);
+        }
+        $mypage->updateGoogleSyncTime();
+        api_ok(['synced' => true, 'direction' => $direction]);
+        break;
+
+    default:
+        api_error('unknown action: ' . $action);
+}

--- a/api/mypage.php
+++ b/api/mypage.php
@@ -18,8 +18,13 @@
  *   keyword         userid=
  *   keyword_add     userid= keyword= [search_type=] [search_params=]
  *   keyword_remove  userid= id=
+ *   import          userid= data= (POST) → Web 版エクスポート形式 (version 1) の JSON を
+ *                   マージ取り込み。重複はスキップされるため何度実行しても安全
  *   google_status   userid=      → 連携有無・メール・自動同期・最終同期時刻
  *   google_sync     userid= direction=to_drive|from_drive → Google Drive と同期
+ *
+ * 書き込み系アクションの成功時は、Google 連携済み+自動同期オンなら Drive へも
+ * 自動保存する (Web 版 mypage_api.php と同じ挙動)。
  *
  * 応答: { "ok":true, "data":{...} } / { "ok":false, "error":"..." }
  */
@@ -61,6 +66,16 @@ function mypage_song_params()
     return [$fullpath, $songfile, (string)api_param('kind', '')];
 }
 
+/** 書き込み成功後の自動 Drive 同期。同期失敗で書き込み自体の応答は壊さない。 */
+function mypage_auto_sync($mypage)
+{
+    try {
+        $mypage->autoSyncToDrive();
+    } catch (Exception $e) {
+        // 自動同期は best effort (次回の書き込みまたは手動同期で追い付く)
+    }
+}
+
 switch ($action) {
     case 'pair_generate':
         api_ok(['code' => $mypage->generatePairingCode()]);
@@ -86,11 +101,13 @@ switch ($action) {
     case 'history_add':
         list($fullpath, $songfile, $kind) = mypage_song_params();
         $mypage->addHistory($fullpath, $songfile, $kind);
+        mypage_auto_sync($mypage);
         api_ok(['added' => true]);
         break;
 
     case 'history_remove':
         $mypage->removeHistory((string)api_param('fullpath', ''));
+        mypage_auto_sync($mypage);
         api_ok(['removed' => true]);
         break;
 
@@ -101,11 +118,13 @@ switch ($action) {
     case 'later_add':
         list($fullpath, $songfile, $kind) = mypage_song_params();
         $mypage->addLater($fullpath, $songfile, $kind);
+        mypage_auto_sync($mypage);
         api_ok(['added' => true]);
         break;
 
     case 'later_remove':
         $mypage->removeLater((string)api_param('fullpath', ''));
+        mypage_auto_sync($mypage);
         api_ok(['removed' => true]);
         break;
 
@@ -116,11 +135,13 @@ switch ($action) {
     case 'favorite_add':
         list($fullpath, $songfile, $kind) = mypage_song_params();
         $mypage->addFavoriteSong($fullpath, $songfile, $kind);
+        mypage_auto_sync($mypage);
         api_ok(['added' => true]);
         break;
 
     case 'favorite_remove':
         $mypage->removeFavoriteSong((string)api_param('fullpath', ''));
+        mypage_auto_sync($mypage);
         api_ok(['removed' => true]);
         break;
 
@@ -136,6 +157,7 @@ switch ($action) {
         if (!$ok) {
             api_error('keyword is required');
         }
+        mypage_auto_sync($mypage);
         api_ok(['added' => true]);
         break;
 
@@ -150,7 +172,22 @@ switch ($action) {
                 (string)api_param('search_type', ''),
                 (string)api_param('search_params', ''));
         }
+        mypage_auto_sync($mypage);
         api_ok(['removed' => true]);
+        break;
+
+    case 'import':
+        // 端末内データの一括統合 (アプリのデバイスリンク時・再接続時に使う)
+        $data = json_decode((string)api_param('data', ''), true);
+        if (!is_array($data)) {
+            api_error('data (JSON) is required');
+        }
+        $result = $mypage->importData($data, false);
+        if (empty($result['ok'])) {
+            api_error(isset($result['error']) ? $result['error'] : 'import failed');
+        }
+        mypage_auto_sync($mypage); // 統合結果も Drive へ反映
+        api_ok(['counts' => $result['counts']]);
         break;
 
     case 'google_status':

--- a/api/mypage.php
+++ b/api/mypage.php
@@ -89,6 +89,11 @@ switch ($action) {
         api_ok(['added' => true]);
         break;
 
+    case 'history_remove':
+        $mypage->removeHistory((string)api_param('fullpath', ''));
+        api_ok(['removed' => true]);
+        break;
+
     case 'later':
         api_ok(['items' => $mypage->getLaterList()]);
         break;
@@ -135,7 +140,16 @@ switch ($action) {
         break;
 
     case 'keyword_remove':
-        $mypage->removeFavoriteKeyword((int)api_param('id', 0));
+        // id 指定 (Web と同じ) または条件指定 (id を持たないアプリからの解除)
+        $id = (int)api_param('id', 0);
+        if ($id > 0) {
+            $mypage->removeFavoriteKeyword($id);
+        } else {
+            $mypage->removeFavoriteKeywordByCondition(
+                (string)api_param('keyword', ''),
+                (string)api_param('search_type', ''),
+                (string)api_param('search_params', ''));
+        }
         api_ok(['removed' => true]);
         break;
 

--- a/api/mypage.php
+++ b/api/mypage.php
@@ -70,6 +70,12 @@ if ($action === 'google_register') {
     if ($google_sub === '' || $access_token === '') {
         api_error('google_sub and access_token are required');
     }
+    // トークンの発行元クライアント ID がこの部屋の設定と違うなら持ち歩き対象外
+    // (トークン更新ができず後で必ず失敗するため、先に分かるエラーで返す)
+    $token_client_id = (string)api_param('client_id', '');
+    if ($token_client_id !== '' && $token_client_id !== $client_id) {
+        api_error('この部屋は別の Google 連携設定のため持ち歩きできません', 409);
+    }
 
     // この Google アカウントのユーザーが既にいればそれを、いなければ新規作成して紐付ける
     $existing = MypageUser::findUserByGoogleSub($db, $google_sub);
@@ -257,6 +263,8 @@ switch ($action) {
             'access_token'     => $link['access_token'],
             'refresh_token'    => $link['refresh_token'],
             'token_expires_at' => (int)$link['token_expires_at'],
+            // 発行元のクライアント ID (別設定の部屋を google_register 側で見分けるため)
+            'client_id'        => $config_ini['google_client_id'] ?? '',
         ]);
         break;
 

--- a/mypage_class.php
+++ b/mypage_class.php
@@ -176,6 +176,17 @@ class MypageUser {
         return $this->userid;
     }
 
+    /**
+     * 新しいユーザー ID を発行して登録し、このインスタンスのユーザーにする
+     * (cookie は変更しない)。アプリの Google 自動引き継ぎ用。
+     */
+    public function createNewUser() {
+        $uid = $this->generateUuid();
+        $this->upsertUser($uid);
+        $this->userid = $uid;
+        return $uid;
+    }
+
     public function getDisplayName() {
         $stmt = $this->db->prepare(
             "SELECT displayname FROM mypage_user WHERE userid = ?"

--- a/mypage_class.php
+++ b/mypage_class.php
@@ -11,10 +11,19 @@ class MypageUser {
     const COOKIE_DAYS    = 365;
     const PAIR_CODE_TTL  = 300; // ペアリングコード有効秒数
 
-    public function __construct($db) {
+    public function __construct($db, $userid = null) {
         $this->db = $db;
         $this->initTables();
-        $this->userid = $this->resolveUserId();
+        if ($userid !== null) {
+            // API (アプリ連携) 用: cookie を使わず userid を直接指定する。
+            // 有効な UUID のときだけユーザー登録する ('' を渡すとペアコード照会のみできる)
+            $this->userid = $this->isValidUuid($userid) ? $userid : '';
+            if ($this->userid !== '') {
+                $this->upsertUser($this->userid);
+            }
+        } else {
+            $this->userid = $this->resolveUserId();
+        }
     }
 
     // ---- テーブル初期化 ----
@@ -583,6 +592,26 @@ class MypageUser {
      * コードを検証して自分のCookieを相手のuseridに切り替える
      * @return string|false 成功時は元のuserid、失敗時はfalse
      */
+    /**
+     * ペアコードを検証して対応する userid を返す (コードは使用済みにする)。
+     * cookie は変更しない。アプリ (API) 連携用。
+     * @return string|null 無効・期限切れなら null
+     */
+    public function lookupPairingCode($code) {
+        $code = strtoupper(trim($code));
+        if ($code === '') return null;
+        $stmt = $this->db->prepare(
+            "SELECT userid FROM mypage_pair_code
+             WHERE code = ? AND expires_at >= ?"
+        );
+        $stmt->execute([$code, time()]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$row) return null;
+        $this->db->prepare("DELETE FROM mypage_pair_code WHERE code = ?")
+                 ->execute([$code]);
+        return $row['userid'];
+    }
+
     public function applyPairingCode($code) {
         $code = strtoupper(trim($code));
         $stmt = $this->db->prepare(

--- a/mypage_class.php
+++ b/mypage_class.php
@@ -258,6 +258,14 @@ class MypageUser {
         $stmt->execute([$this->userid, $fullpath, $songfile, $kind, time()]);
     }
 
+    /** 指定ファイルの履歴 (全回数分) を削除する。アプリの履歴行削除用。 */
+    public function removeHistory($fullpath) {
+        $stmt = $this->db->prepare(
+            "DELETE FROM mypage_history WHERE userid = ? AND fullpath = ?"
+        );
+        $stmt->execute([$this->userid, $fullpath]);
+    }
+
     /**
      * @param string $sort  'date'|'count'|'filedate'
      * @param string $order 'desc'|'asc'
@@ -417,6 +425,15 @@ class MypageUser {
             "DELETE FROM mypage_favorite_keyword WHERE id = ? AND userid = ?"
         );
         $stmt->execute([(int)$id, $this->userid]);
+    }
+
+    /** 条件一致でお気に入り検索を削除する (id を持たないアプリからの解除用)。 */
+    public function removeFavoriteKeywordByCondition($keyword, $search_type, $search_params) {
+        $stmt = $this->db->prepare(
+            "DELETE FROM mypage_favorite_keyword
+             WHERE userid = ? AND keyword = ? AND search_type = ? AND search_params = ?"
+        );
+        $stmt->execute([$this->userid, $keyword, $search_type, $search_params]);
     }
 
     public function getFavoriteKeywords() {


### PR DESCRIPTION
ゆかナビのマイページ・サーバー連携 (YukaNavi 側 PR とペア) に必要なサーバー側 API です。
詳細仕様は api/README.md の「マイページ（アプリ連携 API）」を参照。

## 変更内容

- **/api/mypage.php 新設**: Web 版マイページ (mypage_class.php) の JSON ファサード
  - デバイスリンク (pair_apply / pair_generate)。アプリは cookie の代わりに userid をクエリで渡す
  - 履歴・あとで歌う・お気に入り曲・お気に入り検索の読み書き (履歴削除・条件指定のキーワード削除を含む)
  - import: Web 版エクスポート形式 (version 1) の一括マージ取り込み (冪等)
  - Google 同期: 状態取得・Drive へ保存/取込、書き込み時の自動 Drive 同期 (Web 版 mypage_api.php と同じ挙動)
  - Google 同期の持ち歩き: google_token_get / google_register (トークンで別の部屋に自動引き継ぎ。クライアント ID 不一致は 409、未設定は 503、トークン無効は 401)
- **mypage_class.php**: userid 直接指定モード (cookie を使わない API 用)、lookupPairingCode、removeHistory、removeFavoriteKeywordByCondition、createNewUser を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)