### PR TITLE
feat: relay にゆかナビ用の直接 Google 認証フローを追加 (持ち歩き API は削除)

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -381,18 +381,11 @@ GET/POST /api/mypage.php?action=<action>&userid=<UUID>&...
 書き込み系アクションの成功時は、Google 連携済み + 自動同期オンなら Drive へも自動保存する
 (Web 版 `mypage_api.php` と同じ挙動。同期失敗しても書き込みの応答は成功のまま)。
 
-### Google 同期
-
-| action | パラメータ | 応答 data / エラー |
-|---|---|---|
-| `google_status` | `userid` | `{linked, email, auto_sync, last_synced_at}` |
-| `google_sync` | `userid`, `direction=to_drive\|from_drive` | `{synced, direction}`。未設定 503 / 未連携 404 / Drive 失敗 502 |
-| `google_token_get` | `userid` | トークン一式 + 発行元 `client_id` (アプリの「同期の持ち歩き」用)。未連携 404 |
-| `google_register` | POST: `google_sub`, `google_email`, `access_token`, `refresh_token`, `token_expires_at`, `client_id` | この部屋にその Google アカウントのユーザーを用意し (既存は `google_sub` で再利用)、Drive から復元して `{userid, access_token, token_expires_at, refreshed}` を返す |
-
-`google_register` のエラー: Google 同期未設定の部屋は **503** (アプリは静かにスキップ)、
-`client_id` がこの部屋の設定と不一致は **409** (別の Google 連携設定 = 持ち歩き対象外)、
-トークン無効 (読めず・更新できず・期限切れ) は **401** (アプリは持ち歩きを破棄して再連携を促す)。
+※ アプリ (ゆかナビ) の Google 同期は、アプリ自身が relay
+(`mypage_google_relay_server.php` の `app_auth` / `app_poll` / `app_refresh`) 経由で
+認証して Google Drive を直接読み書きする方式のため、この API に Google 系アクションは
+無い (トークンを返す API を持たない)。Web 版の部屋単位の Google 連携
+(`mypage_google_sync.php`) とは Drive 上の同一ファイル (`mypage_data.json`) を共有する。
 
 ---
 

--- a/api/mypage.php
+++ b/api/mypage.php
@@ -20,17 +20,11 @@
  *   keyword_remove  userid= id=
  *   import          userid= data= (POST) → Web 版エクスポート形式 (version 1) の JSON を
  *                   マージ取り込み。重複はスキップされるため何度実行しても安全
- *   google_status   userid=      → 連携有無・メール・自動同期・最終同期時刻
- *   google_sync     userid= direction=to_drive|from_drive → Google Drive と同期
- *   google_token_get userid=     → Google トークン一式 (アプリの「同期の持ち歩き」用。
- *                   userid を知っている = 本人という Web cookie と同じ認可モデル)
- *   google_register (POST: google_sub= google_email= access_token= refresh_token=
- *                   token_expires_at=) → この部屋にその Google アカウントのユーザーを
- *                   用意し (既存があれば再利用)、Drive から復元して userid を返す。
- *                   Google 同期未設定の部屋では 503
  *
  * 書き込み系アクションの成功時は、Google 連携済み+自動同期オンなら Drive へも
  * 自動保存する (Web 版 mypage_api.php と同じ挙動)。
+ * ※ アプリの Google 同期はアプリ自身が relay 経由で認証して Drive を直接読み書きする
+ *    方式のため、この API に Google 系アクションは無い (トークンを返す API を持たない)。
  *
  * 応答: { "ok":true, "data":{...} } / { "ok":false, "error":"..." }
  */
@@ -52,62 +46,6 @@ if ($action === 'pair_apply') {
         api_error('コードが無効または有効期限切れです (有効期限は5分です)', 404);
     }
     api_ok(['userid' => $userid]);
-}
-
-// ---- Google トークンによる自動引き継ぎ (userid 不要。アプリの部屋またぎ同期用) ----
-if ($action === 'google_register') {
-    $relay_url    = $config_ini['google_relay_url'] ?? 'https://ykr.moe/mypage_google_callback.php';
-    $relay_secret = $config_ini['google_relay_secret'] ?? '';
-    $client_id    = $config_ini['google_client_id'] ?? '';
-    if (empty($client_id) || empty($relay_secret)) {
-        api_error('Google同期が設定されていません', 503);
-    }
-    $google_sub    = (string)api_param('google_sub', '');
-    $google_email  = (string)api_param('google_email', '');
-    $access_token  = (string)api_param('access_token', '');
-    $refresh_token = (string)api_param('refresh_token', '');
-    $expires_at    = (int)api_param('token_expires_at', 0);
-    if ($google_sub === '' || $access_token === '') {
-        api_error('google_sub and access_token are required');
-    }
-    // トークンの発行元クライアント ID がこの部屋の設定と違うなら持ち歩き対象外
-    // (トークン更新ができず後で必ず失敗するため、先に分かるエラーで返す)
-    $token_client_id = (string)api_param('client_id', '');
-    if ($token_client_id !== '' && $token_client_id !== $client_id) {
-        api_error('この部屋は別の Google 連携設定のため持ち歩きできません', 409);
-    }
-
-    // この Google アカウントのユーザーが既にいればそれを、いなければ新規作成して紐付ける
-    $existing = MypageUser::findUserByGoogleSub($db, $google_sub);
-    $mypage = new MypageUser($db, $existing !== null ? $existing : '');
-    if ($mypage->getUserId() === '') {
-        $mypage->createNewUser();
-    }
-    $mypage->linkGoogle($google_sub, $google_email, $access_token, $refresh_token, $expires_at);
-
-    // Drive から復元 (マージ)。mypage_google_callback.php の初回同期と同じ流れ
-    require_once __DIR__ . '/../mypage_google_drive.php';
-    $drive = new GoogleDriveHelper($access_token, $refresh_token, $expires_at,
-        $relay_url, $relay_secret);
-    $drive_data = $drive->readData();
-    if ($drive_data) {
-        $mypage->importData($drive_data, false);
-    }
-    list($new_at, $new_exp, $refreshed) = $drive->getNewTokens();
-    if ($refreshed) {
-        $mypage->updateGoogleTokens($new_at, $new_exp);
-    }
-    // 読めず・更新もできず・期限切れ = トークン無効 (アプリは持ち歩きを破棄して再連携を促す)
-    if (!$drive_data && !$refreshed && $expires_at < time()) {
-        api_error('Google のトークンが無効です (連携をやり直してください)', 401);
-    }
-    $mypage->updateGoogleSyncTime();
-    api_ok([
-        'userid'           => $mypage->getUserId(),
-        'access_token'     => $refreshed ? $new_at : $access_token,
-        'token_expires_at' => $refreshed ? (int)$new_exp : $expires_at,
-        'refreshed'        => (bool)$refreshed,
-    ]);
 }
 
 // ---- 以降は userid 必須 ----
@@ -250,77 +188,6 @@ switch ($action) {
         }
         mypage_auto_sync($mypage); // 統合結果も Drive へ反映
         api_ok(['counts' => $result['counts']]);
-        break;
-
-    case 'google_token_get':
-        $link = $mypage->getGoogleLink();
-        if ($link === null) {
-            api_error('Google アカウントと連携されていません', 404);
-        }
-        api_ok([
-            'google_sub'       => $link['google_sub'],
-            'google_email'     => $link['google_email'],
-            'access_token'     => $link['access_token'],
-            'refresh_token'    => $link['refresh_token'],
-            'token_expires_at' => (int)$link['token_expires_at'],
-            // 発行元のクライアント ID (別設定の部屋を google_register 側で見分けるため)
-            'client_id'        => $config_ini['google_client_id'] ?? '',
-        ]);
-        break;
-
-    case 'google_status':
-        $link = $mypage->getGoogleLink();
-        if ($link === null) {
-            api_ok(['linked' => false]);
-        }
-        api_ok([
-            'linked'         => true,
-            'email'          => $link['google_email'],
-            'auto_sync'      => (int)$link['auto_sync'] === 1,
-            'last_synced_at' => (int)$link['last_synced_at'],
-        ]);
-        break;
-
-    case 'google_sync':
-        global $config_ini;
-        $relay_url    = $config_ini['google_relay_url'] ?? 'https://ykr.moe/mypage_google_callback.php';
-        $relay_secret = $config_ini['google_relay_secret'] ?? '';
-        $client_id    = $config_ini['google_client_id'] ?? '';
-        if (empty($client_id) || empty($relay_secret)) {
-            api_error('Google同期が設定されていません (管理者設定が必要です)', 503);
-        }
-        $link = $mypage->getGoogleLink();
-        if ($link === null) {
-            api_error('Google アカウントと連携されていません', 404);
-        }
-        require_once __DIR__ . '/../mypage_google_drive.php';
-        $drive = new GoogleDriveHelper(
-            $link['access_token'],
-            $link['refresh_token'],
-            $link['token_expires_at'],
-            $relay_url,
-            $relay_secret
-        );
-        $direction = (string)api_param('direction', 'to_drive');
-        if ($direction === 'from_drive') {
-            // Drive → サーバー (マージ)
-            $drive_data = $drive->readData();
-            if (!$drive_data) {
-                api_error('Drive からデータを取得できませんでした', 502);
-            }
-            $mypage->importData($drive_data, false);
-        } else {
-            // サーバー → Drive
-            if (!$drive->writeData($mypage->exportData())) {
-                api_error('Drive への書き込みに失敗しました', 502);
-            }
-        }
-        list($new_at, $new_exp, $refreshed) = $drive->getNewTokens();
-        if ($refreshed) {
-            $mypage->updateGoogleTokens($new_at, $new_exp);
-        }
-        $mypage->updateGoogleSyncTime();
-        api_ok(['synced' => true, 'direction' => $direction]);
         break;
 
     default:

--- a/mypage_google_relay_server.php
+++ b/mypage_google_relay_server.php
@@ -8,6 +8,12 @@
  *   GET  ?code=XXX&state=YYY                   → コード交換 → ローカルサーバーへリダイレクト
  *   POST ?action=refresh  (JSON body)           → トークンリフレッシュ API
  *
+ * アプリ (ゆかナビ) 用の直接認証フロー:
+ *   GET  ?action=app_auth&session=<64hex>       → Google OAuth へ (アプリがブラウザで開く)
+ *   GET  ?code=XXX&state=<app用state>           → トークンを一時保存し「認証完了」を表示
+ *   GET  ?action=app_poll&session=<64hex>       → 保存済みトークンを返して削除 (ワンタイム)
+ *   POST ?action=app_refresh (JSON body)        → アプリ用トークンリフレッシュ (HMAC 不要)
+ *
  * 設定: mypage_google_relay_config.php を同ディレクトリに置く
  */
 
@@ -73,6 +79,101 @@ if ($method === 'POST' && $action === 'refresh') {
 }
 
 // ============================================================
+// POST ?action=app_refresh — アプリ用トークンリフレッシュ
+// (refresh_token 自体が資格情報のため HMAC は要求しない)
+// ============================================================
+if ($method === 'POST' && $action === 'app_refresh') {
+    header('Content-Type: application/json');
+
+    $body = file_get_contents('php://input');
+    $data = json_decode($body, true);
+    if (empty($data['refresh_token'])) {
+        http_response_code(400);
+        echo json_encode(['error' => 'missing_params']);
+        exit;
+    }
+
+    $resp = relay_http_post(GOOGLE_TOKEN_URL, http_build_query([
+        'client_id'     => $RELAY_CLIENT_ID,
+        'client_secret' => $RELAY_CLIENT_SECRET,
+        'refresh_token' => $data['refresh_token'],
+        'grant_type'    => 'refresh_token',
+    ]), ['Content-Type: application/x-www-form-urlencoded']);
+
+    $token = json_decode($resp, true);
+    if (empty($token['access_token'])) {
+        http_response_code(502);
+        echo json_encode(['error' => 'refresh_failed']);
+        exit;
+    }
+
+    echo json_encode([
+        'access_token' => $token['access_token'],
+        'expires_in'   => (int)($token['expires_in'] ?? 3600),
+    ]);
+    exit;
+}
+
+// ============================================================
+// GET ?action=app_auth — アプリからの OAuth 開始
+// (session はアプリが生成した乱数。state は relay 自身が署名するため
+//  アプリ側に共有シークレットを持たせる必要がない)
+// ============================================================
+if ($method === 'GET' && $action === 'app_auth') {
+    $session = $_GET['session'] ?? '';
+    if (!app_session_valid($session)) {
+        http_response_code(400);
+        exit('session が不正です。');
+    }
+
+    $state = make_signed(json_encode([
+        'app_session' => $session,
+        'iat'         => time(),
+    ]), $RELAY_SECRET);
+
+    $params = http_build_query([
+        'client_id'     => $RELAY_CLIENT_ID,
+        'redirect_uri'  => RELAY_REDIRECT_URI,
+        'response_type' => 'code',
+        'scope'         => 'openid email profile https://www.googleapis.com/auth/drive.appdata',
+        'access_type'   => 'offline',
+        'prompt'        => 'consent',
+        'state'         => $state,
+    ]);
+    header('Location: ' . GOOGLE_AUTH_URL . '?' . $params);
+    exit;
+}
+
+// ============================================================
+// GET ?action=app_poll — アプリが認証完了を取りに来る (ワンタイム)
+// ============================================================
+if ($method === 'GET' && $action === 'app_poll') {
+    header('Content-Type: application/json');
+
+    $session = $_GET['session'] ?? '';
+    if (!app_session_valid($session)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'invalid_session']);
+        exit;
+    }
+
+    $file = app_session_file($session);
+    if (!file_exists($file)) {
+        echo json_encode(['status' => 'pending']);
+        exit;
+    }
+    if (time() - filemtime($file) > 600) {
+        @unlink($file);
+        echo json_encode(['status' => 'expired']);
+        exit;
+    }
+    $payload = file_get_contents($file);
+    @unlink($file);
+    echo json_encode(['status' => 'ok', 'token' => json_decode($payload, true)]);
+    exit;
+}
+
+// ============================================================
 // GET ?action=auth  — OAuth 開始（ローカルサーバーから呼ばれる）
 // ============================================================
 if ($method === 'GET' && $action === 'auth') {
@@ -116,6 +217,34 @@ if ($method === 'GET' && !empty($_GET['code']) && !empty($_GET['state'])) {
         exit_no_redirect('state の署名検証に失敗しました。');
     }
     $state_data = json_decode($state_json, true);
+
+    // ---- アプリ (ゆかナビ) の直接認証: トークンを一時保存してブラウザに完了表示 ----
+    if (!empty($state_data['app_session'])) {
+        if (!app_session_valid($state_data['app_session'])
+            || abs(time() - (int)($state_data['iat'] ?? 0)) > 600) {
+            exit_no_redirect('セッションが無効か期限切れです。アプリからやり直してください。');
+        }
+        $token_json = app_exchange_code($code, $RELAY_CLIENT_ID, $RELAY_CLIENT_SECRET);
+        if ($token_json === null) {
+            exit_no_redirect('Google からトークンを取得できませんでした。アプリからやり直してください。');
+        }
+        file_put_contents(app_session_file($state_data['app_session']), $token_json);
+        header('Content-Type: text/html; charset=utf-8');
+        echo '<!doctype html><html lang="ja"><head><meta charset="utf-8">'
+           . '<meta name="viewport" content="width=device-width, initial-scale=1">'
+           . '<title>ゆかナビ - 認証完了</title></head>'
+           . '<body style="font-family:sans-serif; text-align:center; padding-top:4em;">'
+           . '<h2>✅ Google 認証が完了しました</h2>'
+           . '<p>このページを閉じて、ゆかナビに戻ってください。</p>'
+           . '<p style="color:#888; font-size:0.85em; max-width:32em; margin:2em auto 0;">'
+           . 'ゆかナビの「Google にログイン」操作中でない場合は、誰かに送られた URL から'
+           . 'この画面を開いた可能性があります。その場合はこの認証を使用せず、'
+           . 'Google アカウントの「サードパーティ製のアプリとサービス」から'
+           . 'アクセス権を削除してください。</p>'
+           . '</body></html>';
+        exit;
+    }
+
     if (empty($state_data['return_url']) || empty($state_data['nonce'])) {
         exit_no_redirect('state の内容が不正です。');
     }
@@ -227,6 +356,58 @@ function redirect_error($return_url, $error) {
 function exit_no_redirect($msg) {
     http_response_code(400);
     exit(htmlspecialchars($msg, ENT_QUOTES, 'UTF-8'));
+}
+
+/**
+ * アプリセッション ID の形式チェック (32〜64桁の16進のみ。ファイル名に使うため)
+ */
+function app_session_valid($session) {
+    return (bool)preg_match('/^[0-9a-f]{32,64}$/', $session);
+}
+
+/**
+ * アプリセッションのトークン一時保存先
+ */
+function app_session_file($session) {
+    return sys_get_temp_dir() . '/yukanavi_gauth_' . $session . '.json';
+}
+
+/**
+ * 認可コードをトークンに交換し、アプリへ渡す JSON を作る。失敗時 null
+ */
+function app_exchange_code($code, $client_id, $client_secret) {
+    $resp = relay_http_post(GOOGLE_TOKEN_URL, http_build_query([
+        'code'          => $code,
+        'client_id'     => $client_id,
+        'client_secret' => $client_secret,
+        'redirect_uri'  => RELAY_REDIRECT_URI,
+        'grant_type'    => 'authorization_code',
+    ]), ['Content-Type: application/x-www-form-urlencoded']);
+
+    $token = json_decode($resp, true);
+    if (empty($token['access_token'])) {
+        return null;
+    }
+    // id_token から sub / email を取り出す (アプリの表示・識別用)
+    $google_sub   = '';
+    $google_email = '';
+    $id_parts = explode('.', $token['id_token'] ?? '');
+    if (count($id_parts) >= 2) {
+        $id_payload = json_decode(
+            base64_decode(strtr($id_parts[1], '-_', '+/')
+                . str_repeat('=', (4 - strlen($id_parts[1]) % 4) % 4)),
+            true
+        );
+        $google_sub   = $id_payload['sub']   ?? '';
+        $google_email = $id_payload['email'] ?? '';
+    }
+    return json_encode([
+        'google_sub'    => $google_sub,
+        'google_email'  => $google_email,
+        'access_token'  => $token['access_token'],
+        'refresh_token' => $token['refresh_token'] ?? '',
+        'expires_at'    => time() + (int)($token['expires_in'] ?? 3600),
+    ]);
 }
 
 /**


### PR DESCRIPTION
## 概要

ゆかナビの Google 同期リアーキテクチャのサーバー側。アプリが relay 経由で直接
Google 認証して Drive を読み書きする方式に変更し、部屋のサーバーからは
トークンを扱う API を撤去する。

## 変更内容

### mypage_google_relay_server.php (ykr.moe 配置用の原本)
アプリ用の 3 エンドポイントを追加 (既存の Web 版フローは後方互換のまま):

- `GET ?action=app_auth&session=<32〜64桁hex>` — アプリ生成の乱数セッションで OAuth 開始。state は relay 自身が署名するため、アプリは共有シークレット不要
- `GET ?action=app_poll&session=` — 認証完了トークンのワンタイム取得 (一時ファイル保存・10分で期限切れ)
- `POST ?action=app_refresh` — refresh_token のみでリフレッシュ (refresh_token 自体が資格情報のため HMAC 不要。Web 版の `refresh` は HMAC 必須のまま)
- コールバックにアプリ用 state (app_session) の分岐を追加: トークン交換 → 一時保存 → 「認証完了」画面 (URL 踏ませ攻撃への注意文言付き)

### api/mypage.php
持ち歩き用の `google_status` / `google_sync` / `google_token_get` / `google_register` を削除
(アプリが使わなくなったため。トークンを返す API を残さない)。
Web 版の部屋単位の Google 連携 (mypage_google_sync.php) はそのまま。

### api/README.md
上記に合わせて更新。

## 配置

relay は ykr.moe の `mypage_google_callback.php` として上書き配置 (**配置済み・動作確認済み**)。

## 依存

アプリ側 PR: YukaNavi feat/m8-google-direct (このブランチの relay が前提)

🤖 Generated with [Claude Code](https://claude.com/claude-code)