### PR TITLE
feat: Web UI から曲の情報を修正できるページを追加 + シークレット予約の曲情報漏えい修正

### DIFF
--- a/function_requestlist_json.php
+++ b/function_requestlist_json.php
@@ -19,6 +19,8 @@
  */
 function build_requestlist_data($db, $config_ini, $limit = 0, $offset = 0)
 {
+    global $user;
+
     $total = (int)$db->query("SELECT COUNT(*) FROM requesttable")->fetchColumn();
 
     $remaining_count = (int)$db->query(
@@ -29,7 +31,8 @@ function build_requestlist_data($db, $config_ini, $limit = 0, $offset = 0)
         "SELECT COALESCE(SUM(duration), 0) FROM requesttable WHERE nowplaying IN ('未再生', '1') AND duration > 0"
     )->fetchColumn();
 
-    $sql = "SELECT id, songfile, fullpath, singer, comment, kind, reqorder, nowplaying, secret, loop, pause, track, keychange, audiodelay, duration, volume, song_name, lister_artist, lister_work, lister_op_ed, lister_comment FROM requesttable ORDER BY reqorder DESC";
+    // clientip / clientua は所有者判定 (シークレットのマスク除外) にのみ使い、出力には含めない
+    $sql = "SELECT id, songfile, fullpath, singer, comment, kind, reqorder, nowplaying, secret, loop, pause, track, keychange, audiodelay, duration, volume, song_name, lister_artist, lister_work, lister_op_ed, lister_comment, clientip, clientua FROM requesttable ORDER BY reqorder DESC";
     if ($limit > 0) {
         $stmt = $db->prepare($sql . " LIMIT :limit OFFSET :offset");
         $stmt->bindValue(':limit',  $limit,  PDO::PARAM_INT);
@@ -41,31 +44,48 @@ function build_requestlist_data($db, $config_ini, $limit = 0, $offset = 0)
     $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
     $stmt->closeCursor();
 
+    // シークレット予約のマスク除外判定用 (本人と管理者には曲情報を渡してよい)
+    $is_admin  = (isset($user) && $user === 'admin');
+    $myname    = function_exists('returnusername_self') ? returnusername_self() : '';
+    $remote_ip = $_SERVER['REMOTE_ADDR'] ?? '';
+    $remote_ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
+
     $items = [];
     foreach ($rows as $idx => $row) {
         $songfile     = $row['songfile'];
         $display_name = $songfile;
         $nowplaying_val = !empty($row['nowplaying']) ? $row['nowplaying'] : '1';
-        if (!empty($row['secret']) && $row['secret'] == 1
-            && ($nowplaying_val === '未再生' || $nowplaying_val === '1')) {
+        $is_hidden_secret = (!empty($row['secret']) && $row['secret'] == 1
+            && ($nowplaying_val === '未再生' || $nowplaying_val === '1'));
+        if ($is_hidden_secret) {
             $display_name = urldecode($config_ini['secret_display_text'] ?? urlencode('ヒ・ミ・ツ♪(シークレットリクエスト)'));
         }
+        // 未再生シークレットは display_name だけでなく曲情報そのものを非所有者へ渡さない
+        // (song_name があるとカードにタイトルが出てしまう漏えいの修正)。
+        // 所有者判定は既存の流儀に合わせて「リクエスト端末 (clientip+clientua) が同じ」
+        // または「登録者名が自分 (returnusername_self) と同じ」
+        $is_owner = (($row['clientip'] ?? '') !== '' && ($row['clientip'] ?? '') === $remote_ip
+                     && ($row['clientua'] ?? '') === $remote_ua)
+                 || (($row['singer'] ?? '') !== '' && ($row['singer'] ?? '') === $myname);
+        $mask = ($is_hidden_secret && !$is_owner && !$is_admin);
         $items[] = [
             'id'           => (int)$row['id'],
             'reqorder'     => (int)$row['reqorder'],
-            'songfile'     => $songfile,
+            'songfile'     => $mask ? $display_name : $songfile,
             'display_name' => $display_name,
-            'song_name'     => $row['song_name']     ?? '',
-            'lister_artist' => $row['lister_artist'] ?? '',
-            'lister_work'   => $row['lister_work']   ?? '',
-            'lister_op_ed'  => $row['lister_op_ed']  ?? '',
-            'lister_comment'=> $row['lister_comment']?? '',
+            'song_name'     => $mask ? '' : ($row['song_name']     ?? ''),
+            'lister_artist' => $mask ? '' : ($row['lister_artist'] ?? ''),
+            'lister_work'   => $mask ? '' : ($row['lister_work']   ?? ''),
+            'lister_op_ed'  => $mask ? '' : ($row['lister_op_ed']  ?? ''),
+            'lister_comment'=> $mask ? '' : ($row['lister_comment']?? ''),
             'singer'        => $row['singer'] ?? '',
             'comment'      => $row['comment'] ?? '',
             'kind'         => $row['kind'] ?? '',
             'nowplaying'   => !empty($row['nowplaying']) ? $row['nowplaying'] : '1',
+            // この行の曲情報をマスクして返したか (クライアントは曲情報系 UI の出し分けに使う)
+            'masked'       => $mask ? 1 : 0,
             // 予約の変更 (アプリの編集画面) 用: 現在のオプション値一式
-            'fullpath'     => $row['fullpath'] ?? '',
+            'fullpath'     => $mask ? '' : ($row['fullpath'] ?? ''),
             'secret'       => (int)($row['secret'] ?? 0),
             'loop'         => (int)($row['loop']   ?? 0),
             'pause'        => (int)($row['pause']  ?? 0),

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -749,11 +749,10 @@ function createCardHTML(item, idx, displayMode) {
     var extraMetaHtml = extraChips.length > 0
         ? '<div class="meta-chips">' + extraChips.join('') + '</div>'
         : '';
-    // 曲情報修正リンク (小休止には不要。未再生シークレットは本人と管理者のみ)
+    // 曲情報修正リンク (小休止には不要。マスク行 = 非所有者の未再生シークレットには出さない。
+    // 出し分けはサーバー側の masked フラグに従う)
     var metaEditHtml = '';
-    if (item.kind !== '小休止'
-        && (!(item.secret == 1 && isUnplayed(item.nowplaying))
-            || IS_ADMIN || item.singer === getUsernameFromCookie())) {
+    if (item.kind !== '小休止' && !item.masked) {
         metaEditHtml = '<a href="song_metadata_edit_bs5.php?id=' + item.id + '" class="card-metaedit-link">&#9998; 曲情報を修正</a>';
     }
     var hasDetails = extraChips.length > 0 || tweetHtml !== '' || metaEditHtml !== '';

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -243,6 +243,17 @@ $requestlist_num = isset($config_ini['requestlist_num']) ? (int)$config_ini['req
 }
 .card-tweet-link:hover { text-decoration: underline; color: #0c85d0; }
 
+/* 曲情報修正リンク */
+.card-metaedit-link {
+  font-size: 11px;
+  color: var(--bs-primary, #0d6efd);
+  text-decoration: none;
+  display: inline-block;
+  margin-top: 3px;
+  margin-right: 10px;
+}
+.card-metaedit-link:hover { text-decoration: underline; }
+
 /* 展開ボタン（技術設定・Tweetを表示） */
 .card-expand-btn {
   background: none;
@@ -738,9 +749,16 @@ function createCardHTML(item, idx, displayMode) {
     var extraMetaHtml = extraChips.length > 0
         ? '<div class="meta-chips">' + extraChips.join('') + '</div>'
         : '';
-    var hasDetails = extraChips.length > 0 || tweetHtml !== '';
+    // 曲情報修正リンク (小休止には不要。未再生シークレットは本人と管理者のみ)
+    var metaEditHtml = '';
+    if (item.kind !== '小休止'
+        && (!(item.secret == 1 && isUnplayed(item.nowplaying))
+            || IS_ADMIN || item.singer === getUsernameFromCookie())) {
+        metaEditHtml = '<a href="song_metadata_edit_bs5.php?id=' + item.id + '" class="card-metaedit-link">&#9998; 曲情報を修正</a>';
+    }
+    var hasDetails = extraChips.length > 0 || tweetHtml !== '' || metaEditHtml !== '';
     var cardDetailsHtml = hasDetails
-        ? '<div class="card-details">' + extraMetaHtml + tweetHtml + '</div>'
+        ? '<div class="card-details">' + extraMetaHtml + metaEditHtml + tweetHtml + '</div>'
         : '';
     var expandBtnHtml = hasDetails
         ? '<button class="card-expand-btn" aria-label="詳細を展開">&#9662;</button>'

--- a/requestlist_table_json.php
+++ b/requestlist_table_json.php
@@ -43,6 +43,7 @@ $json = json_encode($allrequest,JSON_PRETTY_PRINT);
 
 $requsetlisttable = array();
 $reqcount = count(getallrequest_array()) - $displayfrom;
+$myname = returnusername_self();
 
 foreach($allrequest as $value ){
     $playingid = 'id="id_'.$value['id'].'" ';
@@ -191,6 +192,14 @@ if($value['kind'] == 'カラオケ配信' && $config_ini['usebgv'] == 1 ) {
 } else {
   $sasikaemenu = '<li> <a class="requestmove" name="changesong" id="changesong" href="searchreserve.php?id='.$value['id'].'" value="changesong"  > 曲差し替え</a> </li>';
 }
+// 曲情報の修正 (小休止には不要。未再生シークレットは本人と管理者のみ)
+if($value['kind'] != '小休止'){
+    $metaedit_hidden = ($value['secret'] == 1 && $value['nowplaying'] === '未再生'
+        && $value['singer'] !== $myname && $user !== 'admin');
+    if(!$metaedit_hidden){
+        $sasikaemenu = $sasikaemenu.'<li> <a href="song_metadata_edit_bs5.php?id='.$value['id'].'" > 曲情報の修正</a> </li>';
+    }
+}
 if($user === "admin"){
     if($usebingo){
         $list_bingoinput='<li> <a class="requestmove" name="bingoinput" id="bingoinput" href="bingo_openinput.php?id='.$value['id'].'" value="bingoinput"  > ビンゴ入力</a> </li>';
@@ -267,7 +276,6 @@ EOD;
     // シークレット予約時の曲対応
     // 条件：表示している人が本人かどうか
     $public_songname=$value['songfile'];
-    $myname = returnusername_self();
     if($value['singer'] === $myname ){
        $dialogsongname='「'.$value['songfile'].'」';
     }else{

--- a/requestlist_table_json.php
+++ b/requestlist_table_json.php
@@ -44,6 +44,7 @@ $json = json_encode($allrequest,JSON_PRETTY_PRINT);
 $requsetlisttable = array();
 $reqcount = count(getallrequest_array()) - $displayfrom;
 $myname = returnusername_self();
+$secret_text = urldecode($config_ini['secret_display_text'] ?? urlencode('ヒ・ミ・ツ♪(シークレットリクエスト)'));
 
 foreach($allrequest as $value ){
     $playingid = 'id="id_'.$value['id'].'" ';
@@ -53,9 +54,21 @@ foreach($allrequest as $value ){
     $onerequset = array();
     $onerequset += array("no" => $reqcount);
     $reqcount -= 1;
+
+    // 未再生シークレットの所有者判定 (本人と管理者以外には曲名を一切出さない)
+    $is_hidden_secret = ($value['secret'] == 1
+        && (strcmp($value['nowplaying'],'未再生') == 0 || $value['nowplaying'] === '1' || empty($value['nowplaying'])));
+    $is_secret_owner = ((($value['clientip'] ?? '') !== ''
+            && ($value['clientip'] ?? '') === ($_SERVER['REMOTE_ADDR'] ?? '')
+            && ($value['clientua'] ?? '') === ($_SERVER['HTTP_USER_AGENT'] ?? ''))
+        || ($value['singer'] !== '' && $value['singer'] === $myname));
+    // hidden input や onclick 属性に埋め込む曲名 (HTML ソース経由の漏えい防止。
+    // delete.php / changeplaystatus.php は songfile パラメータを使わないため動作に影響しない)
+    $form_songfile = ($is_hidden_secret && !$is_secret_owner && $user !== 'admin')
+        ? $secret_text : $value['songfile'];
+
     $songfilename = '';
-    if( ($value['secret'] == 1 ) && strcmp($value['nowplaying'],'未再生') == 0){
-        $secret_text  = urldecode($config_ini['secret_display_text'] ?? urlencode('ヒ・ミ・ツ♪(シークレットリクエスト)'));
+    if($is_hidden_secret){
         $songfilename = nl2br(htmlspecialchars(' ' . $secret_text . ' '));
     }else{
         $songfilename = nl2br(htmlspecialchars($value['songfile']));
@@ -175,7 +188,7 @@ $playstatus_pf = <<<EOD
 </div>
 EOD;
 
-    $playstatus = sprintf($playstatus_pf, $value['nowplaying'], $value['id'], $value['songfile']);
+    $playstatus = sprintf($playstatus_pf, $value['nowplaying'], $value['id'], htmlspecialchars($form_songfile));
     if($config_ini['playmode'] == 1){
         $onerequset += array("playstatus" => $playstatus);
     }elseif($config_ini['playmode'] == 2){
@@ -194,9 +207,7 @@ if($value['kind'] == 'カラオケ配信' && $config_ini['usebgv'] == 1 ) {
 }
 // 曲情報の修正 (小休止には不要。未再生シークレットは本人と管理者のみ)
 if($value['kind'] != '小休止'){
-    $metaedit_hidden = ($value['secret'] == 1 && $value['nowplaying'] === '未再生'
-        && $value['singer'] !== $myname && $user !== 'admin');
-    if(!$metaedit_hidden){
+    if(!($is_hidden_secret && !$is_secret_owner && $user !== 'admin')){
         $sasikaemenu = $sasikaemenu.'<li> <a href="song_metadata_edit_bs5.php?id='.$value['id'].'" > 曲情報の修正</a> </li>';
     }
 }
@@ -290,8 +301,13 @@ EOD;
     $useposttwitter = configbool("useposttwitter", true);
       $tweet_link = ' ';
       if($useposttwitter) {
+        // 曲名は $form_songfile (未再生シークレットの非所有者にはマスク済み) を使う。
+        // nowplaying が '1'/空 の未再生別表記でも生の songfile が漏れないようにする。
         if($value['nowplaying'] === '再生中'){
                 $tweet_message = sprintf("「%s」は「%s」を歌っています",$value['singer'],$value['songfile']);
+        }
+        elseif($is_hidden_secret){
+                $tweet_message = sprintf("「%s」は「%s」を歌います",$value['singer'],$form_songfile);
         }
         elseif($value['nowplaying'] === '未再生'){
                 $tweet_message = sprintf("「%s」は「%s」を歌います",$value['singer'],$public_songname);
@@ -306,7 +322,7 @@ EOD;
     }
     $tweet_link = $songstop.$tweet_link;
     
-    $action = sprintf($action_pf,$value['id'],htmlspecialchars($value['songfile']),$value['id'],urlencode($value['songfile']),$value['id'],urlencode($value['songfile']),$value['id'],urlencode($value['songfile']),$sasikaemenu,$value['id'],$value['id'],$dialogsongname,$value['id'],htmlspecialchars($value['songfile']), $tweet_link);
+    $action = sprintf($action_pf,$value['id'],htmlspecialchars($form_songfile),$value['id'],urlencode($form_songfile),$value['id'],urlencode($form_songfile),$value['id'],urlencode($form_songfile),$sasikaemenu,$value['id'],$value['id'],$dialogsongname,$value['id'],htmlspecialchars($form_songfile), $tweet_link);
     $onerequset += array("action" => $action);
     
     if($user === "admin"){

--- a/song_metadata_edit_bs5.php
+++ b/song_metadata_edit_bs5.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * song_metadata_edit_bs5.php
+ *
+ * 予約された曲のメタデータ (曲名・歌手名・作品名・読み仮名・使われ方・補足説明) を
+ * Web UI から修正するページ (Bootstrap 5)。
+ * アプリ (ゆかナビ) の「曲の情報を修正する」機能の Web 版で、
+ * 保存は同じ /api/song_metadata.php (action=correct) を使う。
+ * 修正は予約一覧の表示に反映され、変更した項目だけが修正ログ
+ * (metadata_correction テーブル) に記録される。
+ *
+ * GET ?id=<予約ID>
+ */
+require_once 'commonfunc.php';
+require_once 'easyauth_class.php';
+require_once 'function_search_listerdb.php';
+
+$easyauth = new EasyAuth();
+$easyauth->do_eashauthcheck();
+
+$l_id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+if ($l_id === false || $l_id === null || $l_id <= 0) {
+    http_response_code(400);
+    die('wrong id');
+}
+
+$stmt = $db->prepare('SELECT id, songfile, fullpath, singer, kind, nowplaying, secret,'
+    . ' song_name, lister_artist, lister_work, lister_op_ed, lister_comment'
+    . ' FROM requesttable WHERE id = :id');
+$stmt->bindValue(':id', $l_id, PDO::PARAM_INT);
+$stmt->execute();
+$request = $stmt->fetch(PDO::FETCH_ASSOC);
+$stmt->closeCursor();
+if (!$request) {
+    http_response_code(404);
+    die('nodata');
+}
+
+// シークレット予約 (未再生) は本人と管理者以外には曲情報を見せない
+$nowplaying_val = !empty($request['nowplaying']) ? $request['nowplaying'] : '未再生';
+$is_hidden_secret = ((int)$request['secret'] === 1
+    && ($nowplaying_val === '未再生' || $nowplaying_val === '1'));
+$is_owner = ($request['singer'] !== '' && $request['singer'] === returnusername_self());
+$is_admin = (isset($user) && $user === 'admin');
+$secret_blocked = ($is_hidden_secret && !$is_owner && !$is_admin);
+
+// 読み仮名の現在値は ListerDB から (requesttable に列が無い。API の修正前値と同じ基準)
+$ruby = ['song_ruby' => '', 'lister_artist_ruby' => '', 'lister_work_ruby' => ''];
+if (!$secret_blocked && !empty($request['fullpath']) && array_key_exists('listerDBPATH', $config_ini)) {
+    $lister_dbpath = urldecode($config_ini['listerDBPATH']);
+    if (file_exists($lister_dbpath)) {
+        $info = listerdb_lookup_songinfo($request['fullpath'], $lister_dbpath, true);
+        if ($info) {
+            foreach (array_keys($ruby) as $k) {
+                $ruby[$k] = (string)($info[$k] ?? '');
+            }
+        }
+    }
+}
+
+function h($value)
+{
+    return htmlspecialchars((string)$value, ENT_QUOTES, 'UTF-8');
+}
+?>
+<!doctype html>
+<html lang="ja">
+<head>
+<?php print_meta_header(); ?>
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title><?php
+if (!empty($config_ini['roomurl'])) {
+    $roomnames = array_keys($config_ini['roomurl']);
+    echo h($roomnames[0]) . '：';
+}
+?>曲情報の修正</title>
+<?php print_bs5_search_head(); ?>
+<style>
+.metaedit-ref {
+  font-size: 0.9rem;
+  word-break: break-all;
+}
+.metaedit-ruby-note {
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #6c757d);
+}
+</style>
+</head>
+<body>
+
+<?php shownavigatioinbar_bs5(); ?>
+
+<div class="container py-3" style="max-width: 720px;">
+
+<h4 class="mb-3">&#9998; 曲情報の修正</h4>
+
+<?php if ($secret_blocked): ?>
+
+<div class="alert alert-warning" role="alert">
+シークレットリクエストのため、再生されるまで曲情報は修正できません。
+</div>
+<a href="requestlist_top.php" class="btn btn-secondary">予約一覧へ戻る</a>
+
+<?php else: ?>
+
+<div class="card mb-3">
+  <div class="card-body metaedit-ref">
+    <div><strong>予約 #<?php echo (int)$request['id']; ?></strong>　登録者：<?php echo h($request['singer']); ?></div>
+    <div>ファイル：<?php echo h($request['songfile']); ?></div>
+    <?php if (!empty($request['fullpath']) && $request['fullpath'] !== $request['songfile']): ?>
+    <div class="text-muted small"><?php echo h($request['fullpath']); ?></div>
+    <?php endif; ?>
+  </div>
+</div>
+
+<p class="small text-muted mb-3">
+修正した内容は予約一覧の曲情報表示に反映されます。変更した項目は修正ログに記録され、
+ゆかりすたー (ListerDB) の登録情報を直す材料として管理画面から CSV でダウンロードできます。
+</p>
+
+<div id="metaedit-result"></div>
+
+<form id="metaedit-form">
+  <div class="card mb-3">
+    <div class="card-body">
+
+      <div class="row g-3">
+        <div class="col-md-6">
+          <label class="form-label" for="song_name">曲名</label>
+          <input type="text" class="form-control" id="song_name" name="song_name"
+                 value="<?php echo h($request['song_name']); ?>">
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="song_ruby">曲名の読み</label>
+          <input type="text" class="form-control" id="song_ruby" name="song_ruby"
+                 value="<?php echo h($ruby['song_ruby']); ?>" placeholder="キョクメイノヨミ">
+        </div>
+
+        <div class="col-md-6">
+          <label class="form-label" for="lister_artist">歌手名</label>
+          <input type="text" class="form-control" id="lister_artist" name="lister_artist"
+                 value="<?php echo h($request['lister_artist']); ?>">
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="lister_artist_ruby">歌手名の読み</label>
+          <input type="text" class="form-control" id="lister_artist_ruby" name="lister_artist_ruby"
+                 value="<?php echo h($ruby['lister_artist_ruby']); ?>" placeholder="カシュメイノヨミ">
+        </div>
+
+        <div class="col-md-6">
+          <label class="form-label" for="lister_work">作品名</label>
+          <input type="text" class="form-control" id="lister_work" name="lister_work"
+                 value="<?php echo h($request['lister_work']); ?>">
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="lister_work_ruby">作品名の読み</label>
+          <input type="text" class="form-control" id="lister_work_ruby" name="lister_work_ruby"
+                 value="<?php echo h($ruby['lister_work_ruby']); ?>" placeholder="サクヒンメイノヨミ">
+        </div>
+
+        <div class="col-md-6">
+          <label class="form-label" for="lister_op_ed">使われ方</label>
+          <input type="text" class="form-control" id="lister_op_ed" name="lister_op_ed"
+                 value="<?php echo h($request['lister_op_ed']); ?>" placeholder="OP1 / ED2 / 挿入歌 など">
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="lister_comment">補足説明</label>
+          <input type="text" class="form-control" id="lister_comment" name="lister_comment"
+                 value="<?php echo h($request['lister_comment']); ?>">
+        </div>
+      </div>
+
+      <p class="metaedit-ruby-note mt-3 mb-0">
+      ※ 読みは ひらがな・カタカナ で入力してください。保存時にゆかりすたーの登録規則
+      (全角カタカナ・濁点/半濁点なし) へ自動変換されます。
+      </p>
+
+    </div>
+  </div>
+
+  <div class="d-flex gap-2">
+    <button type="submit" class="btn btn-primary" id="metaedit-submit">修正を保存</button>
+    <a href="requestlist_top.php" class="btn btn-secondary">予約一覧へ戻る</a>
+  </div>
+</form>
+
+<script>
+(function () {
+    var form      = document.getElementById('metaedit-form');
+    var submitBtn = document.getElementById('metaedit-submit');
+    var resultEl  = document.getElementById('metaedit-result');
+    var requestId = <?php echo (int)$request['id']; ?>;
+
+    // 変更した項目だけ API へ送る (送らない項目は「変更なし」扱い。
+    // 読み仮名の修正前値は ListerDB 基準のため、毎回全項目を送ると
+    // 同じ修正が保存のたびに重複記録されてしまう)
+    var initial = {};
+    Array.prototype.forEach.call(form.querySelectorAll('input[name]'), function (el) {
+        initial[el.name] = el.value;
+    });
+
+    function showResult(type, message) {
+        resultEl.innerHTML = '<div class="alert alert-' + type + '" role="alert"></div>';
+        resultEl.firstChild.textContent = message;
+        resultEl.firstChild.scrollIntoView({ block: 'nearest' });
+    }
+
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+
+        var params  = new URLSearchParams();
+        var changed = 0;
+        Array.prototype.forEach.call(form.querySelectorAll('input[name]'), function (el) {
+            if (el.value !== initial[el.name]) {
+                params.append(el.name, el.value);
+                changed++;
+            }
+        });
+        if (changed === 0) {
+            showResult('info', '変更された項目はありません。');
+            return;
+        }
+        params.append('action', 'correct');
+        params.append('id', requestId);
+
+        submitBtn.disabled = true;
+        fetch('api/song_metadata.php', { method: 'POST', body: params })
+            .then(function (res) { return res.json(); })
+            .then(function (json) {
+                if (json && json.ok) {
+                    // 保存済みの値を新しい基準にする (再保存時の重複記録防止)
+                    Array.prototype.forEach.call(form.querySelectorAll('input[name]'), function (el) {
+                        initial[el.name] = el.value;
+                    });
+                    showResult('success', '修正を保存しました。予約一覧の表示に反映されます。');
+                } else {
+                    showResult('danger', '保存に失敗しました：' + (json && json.error ? json.error : '不明なエラー'));
+                }
+            })
+            .catch(function () {
+                showResult('danger', '保存に失敗しました。通信状態を確認してください。');
+            })
+            .finally(function () {
+                submitBtn.disabled = false;
+            });
+    });
+})();
+</script>
+
+<?php endif; ?>
+
+</div>
+
+<?php print_bg_style_block(true); ?>
+</body>
+</html>

--- a/song_metadata_edit_bs5.php
+++ b/song_metadata_edit_bs5.php
@@ -25,7 +25,8 @@ if ($l_id === false || $l_id === null || $l_id <= 0) {
 }
 
 $stmt = $db->prepare('SELECT id, songfile, fullpath, singer, kind, nowplaying, secret,'
-    . ' song_name, lister_artist, lister_work, lister_op_ed, lister_comment'
+    . ' song_name, lister_artist, lister_work, lister_op_ed, lister_comment,'
+    . ' clientip, clientua'
     . ' FROM requesttable WHERE id = :id');
 $stmt->bindValue(':id', $l_id, PDO::PARAM_INT);
 $stmt->execute();
@@ -37,10 +38,15 @@ if (!$request) {
 }
 
 // シークレット予約 (未再生) は本人と管理者以外には曲情報を見せない
+// (所有者判定は function_requestlist_json.php のマスク判定と同じ基準:
+//  リクエスト端末 clientip+clientua の一致、または登録者名の一致)
 $nowplaying_val = !empty($request['nowplaying']) ? $request['nowplaying'] : '未再生';
 $is_hidden_secret = ((int)$request['secret'] === 1
     && ($nowplaying_val === '未再生' || $nowplaying_val === '1'));
-$is_owner = ($request['singer'] !== '' && $request['singer'] === returnusername_self());
+$is_owner = (($request['clientip'] ?? '') !== ''
+        && ($request['clientip'] ?? '') === ($_SERVER['REMOTE_ADDR'] ?? '')
+        && ($request['clientua'] ?? '') === ($_SERVER['HTTP_USER_AGENT'] ?? ''))
+    || ($request['singer'] !== '' && $request['singer'] === returnusername_self());
 $is_admin = (isset($user) && $user === 'admin');
 $secret_blocked = ($is_hidden_secret && !$is_owner && !$is_admin);
 


### PR DESCRIPTION
## 概要

アプリ (ゆかナビ) で可能になった「曲の情報を修正する」操作 (#213) を Web UI からもできるようにする。あわせて、その過程で見つかったシークレット未再生予約の曲情報漏えい (song_name が設定されているとスワイプ一覧のカードに曲名が表示される等) を修正する。

## 変更内容

### 曲情報修正ページ (Web 版)

- **song_metadata_edit_bs5.php (新規)** — 予約の曲名・歌手名・作品名・各読み仮名・使われ方・補足説明を修正する BS5 ページ。保存はアプリと同じ `/api/song_metadata.php` (action=correct) を使うため、予約一覧への反映・修正ログへの記録・読み仮名の正規化はサーバー側の既存ロジックに乗る
  - 変更した項目だけを送信する (読み仮名の修正前値は ListerDB 基準のため、全項目送信だと保存のたびに修正ログへ重複記録されるのを防ぐ)
  - 未再生シークレット予約は本人と管理者以外は修正不可 (曲情報も表示しない)
- **requestlist_swipe.php** — カード展開部に「✎ 曲情報を修正」リンクを追加
- **requestlist_table_json.php** — 「リスト操作」ドロップダウンに「曲情報の修正」を追加。ループ内で毎回呼んでいた `returnusername_self()` をループ前の 1 回に集約

### シークレット漏えい修正

未再生シークレット予約は `display_name` のみマスクされ、`song_name` / `songfile` / `fullpath` / `lister_*` は生値のまま JSON/HTML に含まれていた。

- **function_requestlist_json.php** — 行ごとに「未再生シークレット かつ 非所有者 かつ 非 admin」を判定し、該当時は `songfile` を `secret_display_text` に、`song_name` / `fullpath` / `lister_*` を空にして返す。`masked` フラグも付与。所有者判定は clientip+clientua 一致または登録者名一致 (既存の `returnusername_self` と同基準)。`/api/requests.php` (アプリ) も同関数のため同時に解消
- **requestlist_table_json.php** — hidden input・onclick 引数・playstatus フォーム・Tweet リンクに埋め込む曲名もマスク済みの値に統一。`nowplaying` が `'1'`/空 (未再生の別表記) でも漏れないよう判定を拡張

## 動作確認

ローカル PHP サーバー + ヘッドレス Chromium で確認済み:

- 編集ページの描画 (ライト/ダーク両テーマ)・保存・読み仮名正規化 (ひらがな→全角カタカナ濁点なし)・修正ログ記録・不正 ID の 400/404
- 4 パターン (通常曲 / 他人の未再生シークレット / 自分の未再生シークレット / 再生済みシークレット) × 3 視点 (非所有者 / 所有者 / admin) で、swipe JSON・API・BS3 JSON・swipe DOM のマスク/非マスクを検証
- 削除・並べ替え等の操作は `id` のみ使用のためマスクの影響なし (`delete.php` / `changeplaystatus.php` は songfile パラメータを参照しない)

## 補足

周辺監査で、別エンドポイント (requestlist_xml.php / requestlist_json.php / simplelistexport_* / simplelist.php / search_bs5.php 差し替えバナー / change.php / api/playstatus.php) にも同種の漏えいが確認済み。本 PR のスコープ外として未対応 (詳細はセッション記録参照)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179VipyfdZDT4PY7WUUS2dg

---
_Generated by [Claude Code](https://claude.ai/code/session_0179VipyfdZDT4PY7WUUS2dg)_