### PR TITLE
fix: 予約・確認画面が進まなくなる不具合の対策 (SSE 接続枠の占有が原因) ほか

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ list/
 # デバッグ用スクリプト（本番環境に含めない）
 mypage_google_debug.php
 .claude/settings.local.json
+
+# getID3 解析キャッシュとファイルガードのロック（実行時に生成）
+_getid3_cache/
+
+# デバッグログ（実行時に生成）
+ykrdebug.log

--- a/func_audiotracklist.php
+++ b/func_audiotracklist.php
@@ -1,6 +1,39 @@
 <?php
 require_once('modules/getid3/getid3.php');
 
+// ==================== NAS I/O 停滞の連鎖ガード ====================
+// NAS/SMB の I/O 停滞中に同じファイルへアクセスした後続リクエストが次々ブロックし、
+// PHP ワーカーを食い潰す事故 (確認画面が開かない・予約の応答が返らない) を防ぐ。
+// ファイル単位の非ブロッキングロックを取り、取れないとき (= 別プロセスが同じファイルの
+// I/O で停滞している可能性) は待たずに「情報なし」で即応答させる。
+// ロックはリクエスト終了時に自動解放される (明示解放しないことで、同一リクエスト内の
+// 存在チェック → getID3 解析の間もロックを保持し続ける)。
+
+$GLOBALS['_fileguard_handles'] = array();
+
+// ファイルへの I/O を始めてよければ true。false ならこのファイルには触らないこと。
+function _fileguard_enter($path) {
+    if (empty($path)) return true;
+    $key = md5($path);
+    // 同一リクエスト内の再入 (存在チェック → 解析) は許可
+    if (isset($GLOBALS['_fileguard_handles'][$key])) return true;
+
+    $lock_dir = dirname(__FILE__) . DIRECTORY_SEPARATOR . '_getid3_cache';
+    if (!is_dir($lock_dir) && !@mkdir($lock_dir, 0755, true)) {
+        return true; // ロックを用意できない環境ではガードなしで従来どおり動作
+    }
+    $fp = @fopen($lock_dir . DIRECTORY_SEPARATOR . $key . '.lock', 'c');
+    if ($fp === false) {
+        return true; // 同上
+    }
+    if (!flock($fp, LOCK_EX | LOCK_NB)) {
+        fclose($fp);
+        return false;
+    }
+    $GLOBALS['_fileguard_handles'][$key] = $fp; // リクエスト終了まで保持
+    return true;
+}
+
 function getphpversion_fa(){
   if (!defined('PHP_VERSION_ID')) {
     $version = explode('.', PHP_VERSION);
@@ -125,6 +158,8 @@ function _videodetails_from_info($info) {
 // $with_atom_data=true のときのみ QuickTime アトムデータを全量読み込む（重い）。
 // 成功時は getID3 の $info 配列を返す。失敗時は false を返す。
 function _getid3_analyze($filename, $with_atom_data = false) {
+    // 別プロセスが同じファイルの I/O で停滞中なら解析しない (情報なし扱い)
+    if (!_fileguard_enter($filename)) return false;
     $getID3 = new getID3();
     if ($with_atom_data) {
         $getID3->options_audiovideo_quicktime_ReturnAtomData = true;
@@ -146,6 +181,11 @@ function _getid3_analyze($filename, $with_atom_data = false) {
 // 結果はファイル更新日時ベースでディスクキャッシュされる（2回目以降は getID3 解析不要）。
 // 戻り値: ['audiotracklist' => array, 'videodetails' => array]
 function getfileinfo($filename, $need_tracklist = false) {
+    // 別プロセスが同じファイルの I/O で停滞中なら待たずに「情報なし」で返す
+    // (filemtime も NAS アクセスのためブロックし得る)
+    if (!_fileguard_enter($filename)) {
+        return array('audiotracklist' => array(), 'videodetails' => array());
+    }
     $cache_dir = dirname(__FILE__) . DIRECTORY_SEPARATOR . '_getid3_cache';
 
     // ファイル更新日時取得（Windows パスのエンコーディング対応）
@@ -234,6 +274,13 @@ function get_fullfilename($l_fullpath,$word,&$filepath_utf8,$lister_dbpath=''){
     $filepath_utf8 = "";
     // ファイル名のチェック
     if(empty($l_fullpath) && empty($word) ) return "";
+    // 別プロセスが同じファイルの I/O で停滞中なら触らない
+    // (存在チェックの fopen 自体が NAS 停滞でブロックするため)。
+    // 空を返すと呼び出し元は「情報なし」のまま予約フローを継続できる
+    if (!_fileguard_enter($l_fullpath)) {
+        logtocmd("fileguard: busy file skipped: $l_fullpath");
+        return "";
+    }
     // ファイル名のチェック
     // logtocmd ("Debug l_fullpath: $l_fullpath\r\n");
     $winfillpath = mb_convert_encoding($l_fullpath,"SJIS-win");

--- a/getcurrentkey_event.php
+++ b/getcurrentkey_event.php
@@ -13,7 +13,8 @@
    $firstflg = true;
 
    if($cfg["usekeychange"] == 1) {
-       set_time_limit(300);
+       set_time_limit(120); /* 下の自発的な接続終了 (90秒) が効かない異常時の保険 */
+       $sse_started = time();
        $kc = new EasyKeychanger();
        while (1) {
 
@@ -38,9 +39,13 @@
            ob_flush();
            flush();
            if (connection_aborted()) break;
+           /* 接続は90秒で自発的に閉じる (クライアントの EventSource は自動で再接続する)。
+              長時間の接続保持がブラウザの同一サーバー接続枠 (HTTP/1.1 は最大6本) を
+              占有し続け、他ページの表示や予約送信が止まる不具合の対策 */
+           if (time() - $sse_started >= 90) break;
            /* 不達時は確認間隔を5秒に広げて接続試行を抑える */
            usleep($status === false ? 5000000 : 500000); /* サーバー側では0.5秒おきにチェック */
        }
-       set_time_limit(300);
+       set_time_limit(30);
    }
 ?>

--- a/js/requsetlist_confirm.js
+++ b/js/requsetlist_confirm.js
@@ -5,18 +5,18 @@ $(document).ready(function()
         var newid = "none";
         // HTMLでの送信をキャンセル
         event.preventDefault();
-        
+
         // 操作対象のフォーム要素を取得
         var $form = $(this);
         var $script     = $('#nanasycheck');
-        
+
         // 送信ボタンを取得
         var $button = $form.find('input[type="submit"]');
         var newname = $('form input[name="freesinger"]').val();
         var existname = $('#singer').val();
         var existname_setting = JSON.parse($script.attr('data-nanasy'));
         var nanasyflg = JSON.parse($script.attr('data-nanasyflg'));
-        
+
         if (newname == "" && existname == existname_setting ) {
             if(nanasyflg != 1) {
                 return false;
@@ -25,7 +25,60 @@ $(document).ready(function()
         if (newname == "" ){
             newname = existname;
         }
-        
+
+        // タイムアウト時の受理確認中フラグ (complete でのボタン再有効化を抑止する)
+        var verifying = false;
+        // 受理確認の照合キー (exec.php で songfile は加工されるため fullpath で照合する)
+        var fullpath = $form.find('[name="fullpath"]').val() || '';
+
+        function goComplete(showid) {
+            var url = 'requestlist_top.php?username=' + newname;
+            if (showid) url += '&showid=' + showid;
+            window.location.href = url;
+        }
+
+        // タイムアウト時: サーバー側では処理が続いていて予約が登録されていることが
+        // 多い (そのまま再送させると二重予約になる)。予約一覧で「同じファイル・
+        // 同じ名前の未再生予約」を数回確認し、受理済みなら完了画面へ遷移する
+        function verifyAccepted(attemptsLeft) {
+            $.ajax({
+                url: 'api/requests.php',
+                type: 'GET',
+                data: { limit: 30 },
+                dataType: 'json',
+                timeout: 5000
+            }).always(function(res) {
+                var foundid = 0;
+                try {
+                    var items = (res && res.data && res.data.items) ? res.data.items : [];
+                    for (var i = 0; i < items.length; i++) {
+                        var it = items[i];
+                        if ((it.nowplaying == '未再生' || it.nowplaying == '1')
+                            && it.singer == newname
+                            && fullpath !== '' && it.fullpath == fullpath) {
+                            foundid = it.id;
+                            break;
+                        }
+                    }
+                } catch (e) { /* 応答が壊れていたら未確認扱い */ }
+                if (foundid) {
+                    goComplete(foundid);
+                    return;
+                }
+                if (attemptsLeft > 1) {
+                    setTimeout(function(){ verifyAccepted(attemptsLeft - 1); }, 3000);
+                    return;
+                }
+                // 受理を確認できなかった: 盲目的な再送をさせないため、一覧の確認を促す
+                verifying = false;
+                $button.attr('disabled', false);
+                if ($button.data('orig-label')) {
+                    $button.val($button.data('orig-label'));
+                }
+                alert('サーバーの応答がありませんでした。予約が入っている場合があるため、予約一覧で受け付け状況を確認してから、必要ならもう一度お試しください。');
+            });
+        }
+
                 /**
                  * Ajax通信メソッド
                  * @param type  : HTTP通信の種類
@@ -36,13 +89,16 @@ $(document).ready(function()
             url: $form.attr('action'),
             type: $form.attr('method'),
             data: $form.serialize(),
-            timeout: 10000,  // 単位はミリ秒
+            timeout: 30000,  // 単位はミリ秒 (混雑時のサーバー処理を待つ。旧: 10秒)
             //dataType: 'json',
-            
+
             // 送信前
             beforeSend: function(xhr, settings) {
                 // ボタンを無効化し、二重送信を防止
                 $button.attr('disabled', true);
+                if (!$button.data('orig-label')) {
+                    $button.data('orig-label', $button.val());
+                }
             },
             success : function( data ) {
                 try{
@@ -54,6 +110,10 @@ $(document).ready(function()
             },
             // 応答後
             complete: function(data, xhr, textStatus) {
+                if (verifying) {
+                    // タイムアウト後の受理確認中はボタンを無効のまま維持する
+                    return;
+                }
                 // ボタンを有効化し、再送信を許可
                 $button.attr('disabled', false);
                 try{
@@ -68,12 +128,17 @@ $(document).ready(function()
             */
             error: function(XMLHttpRequest, textStatus, errorThrown)
             {
+                if (textStatus === 'timeout') {
+                    verifying = true;
+                    $button.val('予約の受け付けを確認しています...');
+                    verifyAccepted(3);
+                    return;
+                }
                 alert('Error : ' + errorThrown);
             }
         });
-        
+
         //サブミット後、ページをリロードしないようにする
         return false;
     });
 });
-

--- a/mpcctrl.js
+++ b/mpcctrl.js
@@ -5,13 +5,21 @@ var playerurl2 = playerurlbase + "/mpcctrl.php";
 
 var EventSource = window.EventSource || window.MozEventSource;
 
+// ページが見えていない間は SSE を切断して接続枠を手放す。
+// バックグラウンドタブの持続接続がブラウザの同一サーバー接続枠
+// (HTTP/1.1 は最大6本) を占有し続けると、他ページの表示や予約送信が
+// ブラウザ内で送信待ちのまま止まる (特に Android は接続を保持し続ける)
+var source_key = null;
+var source_player = null;
+
     function event_initial(){
         if (!EventSource){
             // alert("EventSourceが利用できません。");
             return;
         }
-        var source = new EventSource('getcurrentkey_event.php');
-        source.onmessage = function(event){
+        if (source_key) return;
+        source_key = new EventSource('getcurrentkey_event.php');
+        source_key.onmessage = function(event){
             if (event.data == "Bye"){
                 event.target.close();
                 // alert('終了しました。');
@@ -37,7 +45,8 @@ var EventSource = window.EventSource || window.MozEventSource;
             // alert("EventSourceが利用できません。");
             return;
         }
-        var source_player = new EventSource('player_event.php');
+        if (source_player) return;
+        source_player = new EventSource('player_event.php');
         source_player.onmessage = function(event){
             if (event.data == "Bye"){
                 event.target.close();
@@ -55,6 +64,23 @@ var EventSource = window.EventSource || window.MozEventSource;
             }
         };
     }
+
+    function event_close_all(){
+        if (source_key){ source_key.close(); source_key = null; }
+        if (source_player){ source_player.close(); source_player = null; }
+    }
+
+document.addEventListener('visibilitychange', function(){
+    if (document.hidden){
+        event_close_all();
+    } else {
+        event_initial();
+        event_initial_player();
+        // 非表示中の変化を取り込む
+        if (typeof progresstime_init === 'function') progresstime_init();
+    }
+});
+window.addEventListener('pagehide', event_close_all);
 
 window.onload = function () {
 //    document.body.onclick  = setiframe();

--- a/player_event.php
+++ b/player_event.php
@@ -21,7 +21,8 @@
    $un = new UpdateNotice();
    $un->initdb();
       
-   set_time_limit(600);  // set timeout 600sec
+   set_time_limit(120); /* 下の自発的な接続終了 (90秒) が効かない異常時の保険 */
+   $sse_started = time();
    while (1) {
        $response_array = array();
        
@@ -68,6 +69,10 @@
        ob_flush();
        flush();
        if(connection_aborted()) break;
+       /* 接続は90秒で自発的に閉じる (クライアントの EventSource は自動で再接続する)。
+          長時間の接続保持がブラウザの同一サーバー接続枠 (HTTP/1.1 は最大6本) を
+          占有し続け、他ページの表示や予約送信が止まる不具合の対策 */
+       if (time() - $sse_started >= 90) break;
 
        usleep(500000); /* サーバー側では0.5秒おきにチェック */
 

--- a/requestlist_event.php
+++ b/requestlist_event.php
@@ -23,7 +23,8 @@
 
 
    if(array_key_exists("requestlistactivereload", $cfg) && $cfg["requestlistactivereload"] == 1) {   // config check
-   set_time_limit(300);
+   set_time_limit(120); /* 下の自発的な接続終了 (90秒) が効かない異常時の保険 */
+   $sse_started = time();
        while (1) {
            $statusarray =  $un->show_all();
            if(array_key_exists($checkkind, $statusarray[0])) {
@@ -54,6 +55,10 @@
            ob_flush();
            flush();
            if (connection_aborted()) break;
+           /* 接続は90秒で自発的に閉じる (クライアントの EventSource は自動で再接続する)。
+              長時間の接続保持がブラウザの同一サーバー接続枠 (HTTP/1.1 は最大6本) を
+              占有し続け、他ページの表示や予約送信が止まる不具合の対策 */
+           if (time() - $sse_started >= 90) break;
            usleep(500000); /* サーバー側では0.5秒おきにチェック */
        }
    set_time_limit(30);

--- a/requestlist_only.php
+++ b/requestlist_only.php
@@ -159,9 +159,16 @@ function event_initial(){
           // alert("EventSourceが利用できません。");
           return;
       }
-      var source = new EventSource('requestlist_event.php?kind=requestlist');
+      // ページが見えていない間は SSE を切断して接続枠を手放す。
+      // バックグラウンドタブの持続接続がブラウザの同一サーバー接続枠
+      // (HTTP/1.1 は最大6本) を占有し続けると、他ページの表示や予約送信が
+      // ブラウザ内で送信待ちのまま止まる (特に Android は接続を保持し続ける)
+      var source = null;
       var lastkey = 0;
-      source.onmessage = function(event){
+      function rl_openEventStream(){
+        if (source) return;
+        source = new EventSource('requestlist_event.php?kind=requestlist');
+        source.onmessage = function(event){
           if (event.data == "Bye"){
               event.target.close();
               // alert('終了しました。');
@@ -183,7 +190,24 @@ function event_initial(){
                 }
             }
           }
-      };
+        };
+      }
+      function rl_closeEventStream(){
+        if (source){ source.close(); source = null; }
+      }
+      document.addEventListener('visibilitychange', function(){
+        if (document.hidden){
+            rl_closeEventStream();
+        } else {
+            rl_openEventStream();
+            // 非表示中の変更を取り込む
+            if($("[name=autoreload]").prop("checked")){
+                reloadtable();
+            }
+        }
+      });
+      window.addEventListener('pagehide', rl_closeEventStream);
+      rl_openEventStream();
     }
     else {
       tm();

--- a/requestlist_swipe.php
+++ b/requestlist_swipe.php
@@ -1417,16 +1417,38 @@ function initAutoReload() {
             }
             return;
         }
-        var source  = new ES('requestlist_event.php?kind=requestlist');
+        // ページが見えていない間は SSE を切断して接続枠を手放す。
+        // バックグラウンドタブの持続接続がブラウザの同一サーバー接続枠
+        // (HTTP/1.1 は最大6本) を占有し続けると、他ページの表示や予約送信が
+        // ブラウザ内で送信待ちのまま止まる (特に Android は接続を保持し続ける)
+        var source  = null;
         var lastkey = 0;
-        source.onmessage = function (e) {
-            if (e.data === 'Bye') { source.close(); return; }
-            var nowkey = e.data;
-            if (nowkey && nowkey !== 'None' && lastkey !== nowkey) {
+        function openEventStream() {
+            if (source) return;
+            source = new ES('requestlist_event.php?kind=requestlist');
+            source.onmessage = function (e) {
+                if (e.data === 'Bye') { closeEventStream(); return; }
+                var nowkey = e.data;
+                if (nowkey && nowkey !== 'None' && lastkey !== nowkey) {
+                    if (!isDragging && shouldAutoReload()) reloadCurrent();
+                    lastkey = nowkey;
+                }
+            };
+        }
+        function closeEventStream() {
+            if (source) { source.close(); source = null; }
+        }
+        document.addEventListener('visibilitychange', function () {
+            if (document.hidden) {
+                closeEventStream();
+            } else {
+                openEventStream();
+                // 非表示中の変更を取り込む
                 if (!isDragging && shouldAutoReload()) reloadCurrent();
-                lastkey = nowkey;
             }
-        };
+        });
+        window.addEventListener('pagehide', closeEventStream);
+        openEventStream();
     } else {
         setInterval(function () {
             if (!isDragging && shouldAutoReload()) reloadCurrent();


### PR DESCRIPTION
## 概要

運用不具合調査報告 (2026-07-20) の不具合2 (予約タイムアウト・二重予約) と不具合3 (確認画面に進まない) への対策です。**実サーバー (ykr.moe:11002) での再現テストと当日の Apache ログ分析により、当初仮説 (NAS/SSD の I/O 停滞) は誤りで、真の原因を特定しました**。

## 特定した原因: ブラウザの同一サーバー接続枠 (6本) を SSE が占有

- 予約一覧・プレイヤー画面が張る SSE (`requestlist_event.php` 等) は接続を最大 300〜600 秒保持する
- ブラウザは HTTP/1.1 では同一サーバーへ**最大6本**しか接続できないため、複数タブ・バックグラウンドタブの SSE が枠を使い果たすと、**新しいリクエスト (確認画面への遷移・予約送信) がブラウザ内で送信待ちのまま止まる**
- サーバーには届かないため、サーバー側には痕跡が残らない (当日のログに該当リクエストが存在しないこと、Apache のスレッド枯渇警告 AH00326 が皆無なことを確認済み)
- **Android はバックグラウンドタブの接続を保持し続けるため発生しやすく、接続を積極的に切る iOS では回避できた** — 運用の「iOS ブラウザなら回避できる」と一致
- 「約10分で自然回復」= SSE が max_execution_time (300秒) で切れて枠が空くため

### 実証 (Playwright 実ブラウザ操作)

| 操作 | 修正前 (11002 実サーバー) | 修正後 (ローカル) |
|---|---|---|
| 予約一覧6タブ+軽い API へ fetch | **15秒以上ブロック** | **28ms** |
| 7枚目のタブで確認画面へ遷移 | **進まない (タイムアウト)** | **即表示** |
| タブを3枚に減らして fetch | 0.036秒 (回復) | — |

## 変更内容 (3コミット)

### 1. SSE の接続枠占有対策 (96396fc) — 本命
- **クライアント**: ページ非表示 (`visibilitychange`/`pagehide`) で SSE を切断して枠を手放し、表示復帰で再接続+表示最新化 (`requestlist_swipe.php` / `requestlist_only.php` / `mpcctrl.js`)
- **サーバー**: SSE 接続を90秒で自発的に閉じて回転させる (EventSource は自動再接続)。`set_time_limit` 到達の Fatal error も解消 (`requestlist_event.php` / `getcurrentkey_event.php` / `player_event.php`)

### 2. Web 予約送信の二重予約対策 (e93a750)
- タイムアウト 10秒→30秒。タイムアウト時は予約一覧で受理を確認してから完了/再試行を判断 (受理済みなら再送させない)。**接続枠詰まりで遅延到着した予約の二重登録もこれで防げる**
- 検証: exec.php に人工遅延を入れたローカル環境で、修正前「10秒タイムアウト→再送→同曲同名2件」を再現、修正後「受理確認→完了画面遷移で1件のみ」を確認

### 3. getID3 解析の多重実行ガード (275c527)
- ファイル単位の非ブロッキングロック (flock LOCK_NB)。同一ファイルの解析が滞った場合の連鎖を防ぐ**保険**として維持 (今回の主因ではなかったが、低スペック機での多重解析抑止に有効)
- 検証: ロック保持中の別リクエストが 0.001秒で「情報なし」応答、解放後は通常動作

## 適用

マージ後、ykr.moe:11002 (および各サーバー機) へ反映。反映後に同じ6タブテストで最終確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)