### PR TITLE
feat: 年齢制限曲の表示を利用者ごとのオプトイン制に変更

### DIFF
--- a/api/lister_index.php
+++ b/api/lister_index.php
@@ -9,7 +9,8 @@
  * 期の判別は t_found.song_release_date (修正ユリウス日)。この値はゆかりすたーが
  * タイアップのリリース日を優先して書き込むマージ値 (無ければ曲の発売日) のため、
  * ゆかりすたー本家の期別リストと同じ基準になる。
- * 現状は一般向けのみ対象 (tie_up_age_limit < 18。成人向けは対象外)。
+ * 既定は一般向けのみ対象 (tie_up_age_limit < 18)。include_agelimit=1 を付けると
+ * 年齢制限のあるタイアップ曲も対象になる (検索画面で有効化した利用者ごとのオプトイン)。
  *
  * mode:
  *   years                        → 年ごとの曲数 (降順)
@@ -55,8 +56,13 @@ try {
     api_error('ListerDB を開けません', 503);
 }
 
-// 共通の対象条件: 一般向けのみ (ゆかりすたー本家は 18 歳以上対象を成人向けとして分離する)
-$base_where = '(tie_up_age_limit IS NULL OR tie_up_age_limit < 18)';
+// 共通の対象条件: 既定は一般向けのみ (ゆかりすたー本家は 18 歳以上対象を成人向けとして分離する)。
+// include_agelimit=1 のとき (検索画面のチェックで有効化した利用者) は年齢制限曲も含める
+if (api_param('include_agelimit', '') == 1) {
+    $base_where = '1=1';
+} else {
+    $base_where = '(tie_up_age_limit IS NULL OR tie_up_age_limit < 18)';
+}
 // 期別系はタイアップ (作品) が付いている曲のみ (本家の期別リストと同じ)
 $program_where = "program_name IS NOT NULL AND program_name != ''";
 
@@ -373,15 +379,21 @@ if ($mode === 'songs') {
     // あいまい検索 (検索トップのキーワード検索用)
     $anyword = api_param('anyword', '');
     if ($anyword !== '' && $anyword !== null) {
-        $orConds = [
+        // 空白のみの anyword では各条件が空文字になる。そのまま連結すると
+        // "( OR  OR ...)" の不正な SQL になるため、空の条件を除いてから組み立てる
+        $orConds = array_filter([
             lister_like_cond($ldb, 'song_name', 'song_ruby', $anyword),
             lister_like_cond($ldb, 'song_artist', 'found_artist_ruby', $anyword),
             lister_like_cond($ldb, 'program_name', 'tie_up_ruby', $anyword),
             lister_like_cond($ldb, 'tie_up_group_name', 'tie_up_group_ruby', $anyword),
             lister_like_cond($ldb, 'maker_name', 'maker_ruby', $anyword),
             lister_like_cond($ldb, 'found_path', null, $anyword),
-        ];
-        $where[] = '(' . implode(' OR ', $orConds) . ')';
+        ], function ($cond) { return $cond !== ''; });
+        if (count($orConds) > 0) {
+            $where[] = '(' . implode(' OR ', $orConds) . ')';
+        } else {
+            $anyword = ''; // 空白のみは未指定として扱う (下の必須チェックへ)
+        }
     }
 
     if (count($params) === 0 && ($anyword === '' || $anyword === null)) {

--- a/commonfunc.php
+++ b/commonfunc.php
@@ -3373,4 +3373,94 @@ function mypageAction(el, type) {
 </script>
 JS;
 }
+
+// ==================== リスターDB検索の年齢制限オプトイン ====================
+
+/**
+ * 年齢制限タイアップ曲 (tie_up_age_limit >= 18) を検索結果に含めるかどうか。
+ * 利用者ごとのオプトイン方式: 既定は含めない。検索画面のチェックで有効化すると
+ * Cookie (YkariIncludeAgelimit=1) が保存され、その利用者の検索にだけ含まれる。
+ * リクエストパラメータ include_agelimit はサーバー内の JSON 呼び出しへの転送と
+ * アプリ (ゆかナビ) からの明示指定用 (Cookie より優先)。
+ */
+function listerdb_include_agelimit() {
+    if (array_key_exists('include_agelimit', $_REQUEST)) {
+        return $_REQUEST['include_agelimit'] == 1;
+    }
+    return isset($_COOKIE['YkariIncludeAgelimit']) && $_COOKIE['YkariIncludeAgelimit'] == 1;
+}
+
+/**
+ * 年齢制限タイアップ曲の絞り込み SQL 条件を返す。
+ * 含める設定の利用者には絞り込まない (空文字を返す)。
+ * 各リスターDB検索エンドポイントの WHERE 構築で共通に使う。
+ */
+function listerdb_agelimit_where() {
+    if (listerdb_include_agelimit()) {
+        return '';
+    }
+    return '(tie_up_age_limit IS NULL OR tie_up_age_limit < 18)';
+}
+
+/**
+ * 組み立て済みの WHERE 条件文字列 (WHERE キーワードなし) に年齢制限の絞り込みを
+ * AND で足す。既存条件は括弧で包む (anyword 検索の OR 連結が外側括弧なしのため、
+ * そのまま AND すると演算子の優先順位で誤結合する)。
+ */
+function listerdb_apply_agelimit($select_where) {
+    $agelimit = listerdb_agelimit_where();
+    if ($agelimit === '') {
+        return $select_where;
+    }
+    if (empty($select_where)) {
+        return $agelimit;
+    }
+    return '(' . $select_where . ') AND ' . $agelimit;
+}
+
+/**
+ * 年齢制限曲を含めるかのチェックボックス (BS5 検索ページ用)。
+ * 状態は js/agelimit_optin.js が Cookie で管理する (初回オン時に確認あり)。
+ * 同一ページで複数回呼んでもよい (スクリプトの読み込みは1回だけ出力)。
+ */
+function print_agelimit_optin_check() {
+    static $printed_script = false;
+    print '<div class="form-check mt-2">'
+        . '<label class="form-check-label small">'
+        . '<input class="form-check-input include-agelimit-check" type="checkbox"> '
+        . '年齢制限のある曲を検索結果に含める</label>'
+        . '</div>' . "\n";
+    if (!$printed_script) {
+        print '<script src="js/agelimit_optin.js"></script>' . "\n";
+        $printed_script = true;
+    }
+}
+
+/**
+ * サーバー内の JSON 呼び出し URL に、年齢制限曲を含める設定を転送する。
+ * ブラウザの Cookie はサーバー内 HTTP (localhost への file_get_contents) には
+ * 乗らないため、URL パラメータとして渡す。
+ */
+function listerdb_forward_agelimit($url) {
+    if (!listerdb_include_agelimit()) {
+        return $url;
+    }
+    return $url . (strpos($url, '?') === false ? '?' : '&') . 'include_agelimit=1';
+}
+
+/**
+ * ' WHERE ...' 形式 (または空) の句文字列に年齢制限の絞り込みを足す。
+ * 既に WHERE があれば AND、なければ WHERE として付ける。
+ * ORDER BY / LIMIT 等を連結する前に呼ぶこと。
+ */
+function listerdb_apply_agelimit_clause($where_clause) {
+    $agelimit = listerdb_agelimit_where();
+    if ($agelimit === '') {
+        return $where_clause;
+    }
+    if (trim($where_clause) === '') {
+        return ' WHERE ' . $agelimit;
+    }
+    return $where_clause . ' AND ' . $agelimit;
+}
 ?>

--- a/js/agelimit_optin.js
+++ b/js/agelimit_optin.js
@@ -1,0 +1,59 @@
+// 年齢制限のあるタイアップ曲を検索結果に含めるかのオプトイン制御。
+// 状態は Cookie (YkariIncludeAgelimit=1) に保存され、その利用者の
+// すべてのリスターDB検索 (BS5/BS3 共通) に効く。初回オン時のみ確認を出し、
+// 承諾済みかどうかは localStorage に記録する (以降は確認なしで切り替え可能)。
+(function () {
+    var COOKIE_NAME = 'YkariIncludeAgelimit';
+    var CONSENT_KEY = 'ykari-agelimit-consent';
+
+    function getCookie(name) {
+        var m = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+        return m ? decodeURIComponent(m[1]) : '';
+    }
+    function setCookie(name, value, days) {
+        var d = new Date();
+        d.setTime(d.getTime() + days * 24 * 60 * 60 * 1000);
+        document.cookie = name + '=' + encodeURIComponent(value)
+            + '; expires=' + d.toUTCString() + '; path=/';
+    }
+    function deleteCookie(name) {
+        document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+    }
+    function hasConsent() {
+        try { return localStorage.getItem(CONSENT_KEY) === '1'; } catch (e) { return false; }
+    }
+    function saveConsent() {
+        try { localStorage.setItem(CONSENT_KEY, '1'); } catch (e) {}
+    }
+
+    function init() {
+        var checks = document.querySelectorAll('.include-agelimit-check');
+        if (!checks.length) return;
+        var enabled = getCookie(COOKIE_NAME) === '1';
+        Array.prototype.forEach.call(checks, function (check) {
+            check.checked = enabled;
+            check.addEventListener('change', function () {
+                if (check.checked) {
+                    if (!hasConsent()) {
+                        var ok = window.confirm(
+                            '年齢制限のある作品のタイアップ曲を検索結果に表示します。\n'
+                            + '18歳以上の方のみ有効にしてください。よろしいですか？');
+                        if (!ok) { check.checked = false; return; }
+                        saveConsent();
+                    }
+                    setCookie(COOKIE_NAME, '1', 365);
+                } else {
+                    deleteCookie(COOKIE_NAME);
+                }
+                // 同一ページ内に複数のチェックがある場合は状態をそろえる
+                Array.prototype.forEach.call(checks, function (c) { c.checked = check.checked; });
+            });
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/search_bs5.php
+++ b/search_bs5.php
@@ -221,6 +221,7 @@ function print_listerdb_fileonly() {
     print '    </div>';
     print      $sid_field;
     print '  </form>';
+    print_agelimit_optin_check();
     print '</div>';
 }
 

--- a/search_listerdb_anysearch_index.php
+++ b/search_listerdb_anysearch_index.php
@@ -103,6 +103,9 @@ print <<<EOM
   </div>
   <button type="submit" class="btn btn-default">検索</button>
 </form>
+EOM;
+print_agelimit_optin_check();
+print <<<EOM
 
 </div>
 </div>

--- a/search_listerdb_anysearch_index_bs5.php
+++ b/search_listerdb_anysearch_index_bs5.php
@@ -61,6 +61,7 @@ function printfilenamesearch()
     print '    </div>';
     print    $sid_field;
     print '  </form>';
+    print_agelimit_optin_check();
     print '</div>';
     print '</div>';
 }

--- a/search_listerdb_artist.php
+++ b/search_listerdb_artist.php
@@ -88,7 +88,7 @@ print_meta_header();
 
 <?php
    $errmsg = "";
-   $geturl = 'http://localhost/search_listerdb_artistmany_json.php?list=1&start='.$displayfrom.'&length='.$displaynum;
+   $geturl = listerdb_forward_agelimit('http://localhost/search_listerdb_artistmany_json.php?list=1&start='.$displayfrom.'&length='.$displaynum);
    $artistmanylist_json = file_get_contents($geturl);
    if(!$artistmanylist_json) {
       $errmsg = '歌手名リストの取得に失敗';

--- a/search_listerdb_artistlist_json.php
+++ b/search_listerdb_artistlist_json.php
@@ -89,6 +89,8 @@ if ( $match === 'full' ) {
         $select_where = $select_where . ' WHERE song_artist LIKE ' . $listerdb->quote('%'.$artist.'%');
     }
 }
+// 年齢制限タイアップ曲の絞り込み (既定は除外、include_agelimit=1 の利用者のみ含める)
+$select_where = listerdb_apply_agelimit_clause($select_where);
 if (!empty($select_orderby) ){
     $select_where = $select_where .  ' ORDER BY '. $select_orderby . ' ' . $select_scending ;
 }

--- a/search_listerdb_artistmany_json.php
+++ b/search_listerdb_artistmany_json.php
@@ -44,8 +44,11 @@ if( !$listerdb ) {
   $select_where = "";
   $select_where_limit = $select_where . ' LIMIT '. $displaynum .' OFFSET '. $displayfrom;
 
+  // 年齢制限タイアップ曲の絞り込み (既定は除外、include_agelimit=1 の利用者のみ含める)
+  $agelimit_clause = listerdb_apply_agelimit_clause('');
+
 // 総件数のみ取得
-$sql = 'select COUNT(DISTINCT song_artist) from t_found;';
+$sql = 'select COUNT(DISTINCT song_artist) from t_found'. $agelimit_clause .';';
 $alldbdata =  $lister->select($sql);
 if(!$alldbdata){
      print $sql;
@@ -53,7 +56,7 @@ if(!$alldbdata){
 }
 $totalrequest = $alldbdata[0]["COUNT(DISTINCT song_artist)"];
 
-  $sql = 'select song_artist,COUNT(*) AS COUNT from t_found GROUP BY song_artist ORDER BY COUNT DESC '. $select_where_limit.';';
+  $sql = 'select song_artist,COUNT(*) AS COUNT from t_found'. $agelimit_clause .' GROUP BY song_artist ORDER BY COUNT DESC '. $select_where_limit.';';
   $alldbdata =  $lister->select($sql);
   if(!$alldbdata){
      print $sql;

--- a/search_listerdb_artistname_artistlist.php
+++ b/search_listerdb_artistname_artistlist.php
@@ -45,7 +45,7 @@ if(array_key_exists("draw", $_REQUEST)) {
 }
 
 // build query url
-$url = 'http://localhost/search_listerdb_artistlist_json.php?start='.$displayfrom.'&length='.$displaynum.'&artist='.$artist.'&match='.$match;
+$url = listerdb_forward_agelimit('http://localhost/search_listerdb_artistlist_json.php?start='.$displayfrom.'&length='.$displaynum.'&artist='.$artist.'&match='.$match);
 
 ?>
 

--- a/search_listerdb_column_index.php
+++ b/search_listerdb_column_index.php
@@ -216,7 +216,7 @@ if(!empty($errmsg)){
 
 // 項目ヘッダリスト取得
    $errmsg = "";
-   $geturl = 'http://localhost/search_listerdb_column_json.php?start='.$displayfrom.'&length='.$displaynum.'&column='.urlencode($column);
+   $geturl = listerdb_forward_agelimit('http://localhost/search_listerdb_column_json.php?start='.$displayfrom.'&length='.$displaynum.'&column='.urlencode($column));
    $columnlist_json = file_get_contents($geturl);
    if(!$columnlist_json) {
       $errmsg = '項目リストの取得に失敗';

--- a/search_listerdb_column_index_bs5.php
+++ b/search_listerdb_column_index_bs5.php
@@ -83,6 +83,8 @@ function checkandbuild_column_headerlink($oneheader, $columnmany, $target, $colu
 $errmsg    = '';
 $columnmany = null;
 $geturl    = 'http://localhost/search_listerdb_column_json.php?start=' . $displayfrom . '&length=' . $displaynum . '&column=' . urlencode($column);
+// 年齢制限曲を含める設定 (Cookie) をサーバー内の JSON 呼び出しへ転送する
+$geturl    = listerdb_forward_agelimit($geturl);
 $json      = @file_get_contents($geturl);
 if (!$json) {
     $errmsg = '項目リストの取得に失敗しました';

--- a/search_listerdb_column_json.php
+++ b/search_listerdb_column_json.php
@@ -84,6 +84,11 @@ if(!empty($tie_up_group_name)) {
     $where_conditions[] = '(tie_up_group_ruby LIKE ' . $listerdb->quote('%'.kanabuild($tie_up_group_name).'%') .
                           ' OR tie_up_group_name LIKE ' . $listerdb->quote('%'.$tie_up_group_name.'%') . ')';
 }
+// 年齢制限タイアップ曲の絞り込み (既定は除外、include_agelimit=1 の利用者のみ含める)
+$agelimit_where = listerdb_agelimit_where();
+if ($agelimit_where !== '') {
+    $where_conditions[] = $agelimit_where;
+}
 $select_where = empty($where_conditions) ? '' : 'WHERE ' . implode(' AND ', $where_conditions);
 $select_where_limit = $select_where . ' GROUP BY '.$column. ' LIMIT '. $displaynum .' OFFSET '. $displayfrom;
 

--- a/search_listerdb_column_list.php
+++ b/search_listerdb_column_list.php
@@ -125,7 +125,7 @@ $getqueries['tie_up_group_name'] = $tie_up_group_name;
 }
 
 buildgetquery($getqueries);
-$url = 'http://localhost/search_listerdb_column_json.php?'.buildgetquery($getqueries);
+$url = listerdb_forward_agelimit('http://localhost/search_listerdb_column_json.php?'.buildgetquery($getqueries));
 //print $url;
 ?>
 

--- a/search_listerdb_column_list_bs5.php
+++ b/search_listerdb_column_list_bs5.php
@@ -62,6 +62,8 @@ if (!empty($header))            $getqueries['header']            = $header;
 if (!empty($rubycolumn))        $getqueries['headercolumn']      = $rubycolumn;
 if (!empty($maker_name))        $getqueries['maker_name']        = $maker_name;
 if (!empty($tie_up_group_name)) $getqueries['tie_up_group_name'] = $tie_up_group_name;
+// 年齢制限曲を含める設定 (Cookie) をサーバー内の JSON 呼び出しへ転送する
+if (listerdb_include_agelimit()) $getqueries['include_agelimit'] = 1;
 
 $url = 'http://localhost/search_listerdb_column_json.php?' . buildgetquery($getqueries);
 

--- a/search_listerdb_filelist.php
+++ b/search_listerdb_filelist.php
@@ -481,6 +481,8 @@ if(!empty($select_orderby_str) ){
 
 
 if(!empty($url)){
+    // 年齢制限曲を含める設定 (Cookie) をサーバー内の JSON 呼び出しへ転送する
+    if (listerdb_include_agelimit()) { $url = add_get_query($url, 'include_agelimit=1'); }
     $url = add_get_query($url , 'start='.$displayfrom.'&length='.$displaynum.'&'.$linkoption);
     $url = 'http://localhost/search_listerdb_filelist_json.php'.$url;
 }

--- a/search_listerdb_filelist_bs5.php
+++ b/search_listerdb_filelist_bs5.php
@@ -93,6 +93,9 @@ foreach ($ffields as $f) {
     $myformvalue_shown .= '<div class="col-md-4"><label class="form-label-sm">' . $f['label'] . '</label>'
         . '<input type="' . $type . '" name="' . $f['name'] . '" class="form-control-themed" value="' . htmlspecialchars($f['val'], ENT_QUOTES, 'UTF-8') . '"></div>';
 }
+// 年齢制限曲を含める設定 (Cookie) をサーバー内の JSON 呼び出しへ転送する
+// (ブラウザの Cookie はサーバー内 HTTP には乗らないため)
+if (listerdb_include_agelimit()) { $url = _fl_add($url, 'include_agelimit=1'); }
 if (!empty($match)) { $url = _fl_add($url, 'match=' . urlencode($match)); }
 if (!empty($select_orderby_str)) $url = _fl_add($url, 'orderby=' . urlencode($select_orderby_str));
 if (!empty($url)) {

--- a/search_listerdb_filelist_json.php
+++ b/search_listerdb_filelist_json.php
@@ -390,7 +390,10 @@ if( !empty($anyword ) ) {
   }
 } //else なんでも検索
 
-//add groupby 
+// 年齢制限タイアップ曲の絞り込み (既定は除外、include_agelimit=1 の利用者のみ含める)
+$select_where = listerdb_apply_agelimit($select_where);
+
+//add groupby
 $select_where = $select_where . ' GROUP BY song_name,found_file_size ';
 
 

--- a/search_listerdb_head_json.php
+++ b/search_listerdb_head_json.php
@@ -36,7 +36,8 @@ if( !$listerdb ) {
 
 if(!empty($list)) {
 
-  $sql = 'select DISTINCT program_category from t_found ;';
+  // 年齢制限タイアップ曲の絞り込み (既定は除外、含める設定の利用者のみ表示)
+  $sql = 'select DISTINCT program_category from t_found'. listerdb_apply_agelimit_clause('') .' ;';
   $alldbdata =  $lister->select($sql);
   if($alldbdata === false){
        echo json_encode(['error' => 'db_query_failed']);
@@ -47,15 +48,18 @@ if(!empty($list)) {
   $json = json_encode($returnarray,JSON_PRETTY_PRINT);
 
 }else {
-  // 検索条件
+  // 検索条件 (絞り込みを後から足せるよう WHERE と ORDER BY を分けて組み立てる)
   $select_where = "";
   if( !empty($program_category )  ) {
       if($program_category === 'ISNULL' ) {
-          $select_where = $select_where . ' WHERE program_category IS NULL ORDER BY found_head ASC';
+          $select_where = ' WHERE program_category IS NULL';
       }else{
-          $select_where = $select_where . ' WHERE program_category ='. $listerdb->quote($program_category) .'ORDER BY found_head ASC';
+          $select_where = ' WHERE program_category ='. $listerdb->quote($program_category);
       }
   }
+  // 年齢制限タイアップ曲の絞り込み (既定は除外、include_agelimit=1 の利用者のみ含める)
+  $select_where = listerdb_apply_agelimit_clause($select_where);
+  $select_where = $select_where . ' ORDER BY found_head ASC';
 
   $sql = 'select DISTINCT found_head from t_found '. $select_where.';';
   $alldbdata =  $lister->select($sql);

--- a/search_listerdb_json.php
+++ b/search_listerdb_json.php
@@ -67,6 +67,8 @@ $select_where = "";
 if(!empty($select_word) && !empty($select_column)) {
     $select_where = ' WHERE ' . $select_column . ' = ' . $listerdb->quote($select_word);
 }
+// 年齢制限タイアップ曲の絞り込み (既定は除外、含める設定の利用者のみ表示)
+$select_where = listerdb_apply_agelimit_clause($select_where);
 if(!empty($select_orderby)) {
     $select_where = $select_where . ' ORDER BY ' . $select_orderby . ' ' . $select_scending;
 }

--- a/search_listerdb_program_index.php
+++ b/search_listerdb_program_index.php
@@ -157,7 +157,7 @@ function sortcategorylist($categorylist){
 }
 
    $errmsg = "";
-   $geturl = 'http://localhost/search_listerdb_head_json.php?list=1';
+   $geturl = listerdb_forward_agelimit('http://localhost/search_listerdb_head_json.php?list=1');
    $categorylist_json = file_get_contents($geturl);
    if(!$categorylist_json) {
       $errmsg = 'カテゴリーリストの取得に失敗';
@@ -274,16 +274,16 @@ $allcategory_exists = 0;
 foreach ($categorylist as $category ){
 $cur_category = $category["program_category"];
 if($category["program_category"] == '全部'){
-  $url = 'http://localhost/search_listerdb_head_json.php';
+  $url = listerdb_forward_agelimit('http://localhost/search_listerdb_head_json.php');
   $allcategory_exists ++;
 } else {
-    $url = 'http://localhost/search_listerdb_head_json.php?program_category='.urlencode($category["program_category"]);
+    $url = listerdb_forward_agelimit('http://localhost/search_listerdb_head_json.php?program_category='.urlencode($category["program_category"]));
 }
 if($cur_category === NULL ) {
   $nullcategory_exists++;
 //  continue;
   $cur_category = 'その他';
-  $url = 'http://localhost/search_listerdb_head_json.php?program_category=ISNULL';
+  $url = listerdb_forward_agelimit('http://localhost/search_listerdb_head_json.php?program_category=ISNULL');
 }
 
 $headlist_json = file_get_contents($url);
@@ -365,7 +365,7 @@ print '</div>';
 // その他のカテゴリーは最後
 if($nullcategory_exists == 0 && !is_hidden_category('その他') ){
   $cur_category = 'その他';
-  $url = 'http://localhost/search_listerdb_head_json.php?program_category=ISNULL';
+  $url = listerdb_forward_agelimit('http://localhost/search_listerdb_head_json.php?program_category=ISNULL');
 
 $headlist_json = file_get_contents($url);
 if(!$headlist_json) {
@@ -433,7 +433,7 @@ print '</div>';
 if($allcategory_exists == 0 && !is_hidden_category('全部') ){
 // カテゴリ分けしない全部表示
   $cur_category = '全部';
-  $url = 'http://localhost/search_listerdb_head_json.php?'.$linkoption;
+  $url = listerdb_forward_agelimit('http://localhost/search_listerdb_head_json.php?'.$linkoption);
 
 print '<h2> ' . $cur_category . '</h2>';
 $headlist_json = file_get_contents($url);

--- a/search_listerdb_program_index_bs5.php
+++ b/search_listerdb_program_index_bs5.php
@@ -175,7 +175,9 @@ function print_index_grid($headlist, $lists, $lister_dbpath)
 // --- カテゴリリスト取得 ---
 $errmsg     = '';
 $categorylist = [];
-$geturl = 'http://localhost/search_listerdb_head_json.php?list=1';
+// 年齢制限曲を含める設定 (Cookie) は listerdb_forward_agelimit でサーバー内の
+// JSON 呼び出しへ転送する (ブラウザの Cookie は内部 HTTP に乗らないため)
+$geturl = listerdb_forward_agelimit('http://localhost/search_listerdb_head_json.php?list=1');
 $categorylist_json = @file_get_contents($geturl);
 if ($categorylist_json === false || $categorylist_json === '') {
     $errmsg = 'カテゴリーリストの取得に失敗しました。';
@@ -272,7 +274,7 @@ showuppermenu('program_name', $linkoption);
           $url = 'http://localhost/search_listerdb_head_json.php?program_category=' . urlencode($cur_category);
       }
 
-      $headlist_json = @file_get_contents($url);
+      $headlist_json = @file_get_contents(listerdb_forward_agelimit($url));
       if (!$headlist_json) continue;
       $headlist = json_decode($headlist_json, true);
       if (empty($headlist['data'])) continue;
@@ -287,7 +289,7 @@ showuppermenu('program_name', $linkoption);
 
   <?php if ($nullcategory_exists == 0 && !is_hidden_category('その他')): ?>
     <?php
-    $headlist_json = @file_get_contents('http://localhost/search_listerdb_head_json.php?program_category=ISNULL');
+    $headlist_json = @file_get_contents(listerdb_forward_agelimit('http://localhost/search_listerdb_head_json.php?program_category=ISNULL'));
     if ($headlist_json):
         $headlist = json_decode($headlist_json, true);
         if (!empty($headlist['data'])):
@@ -303,7 +305,7 @@ showuppermenu('program_name', $linkoption);
 
   <?php if ($allcategory_exists == 0 && !is_hidden_category('全部')): ?>
     <?php
-    $headlist_json = @file_get_contents('http://localhost/search_listerdb_head_json.php?' . $linkoption);
+    $headlist_json = @file_get_contents(listerdb_forward_agelimit('http://localhost/search_listerdb_head_json.php?' . $linkoption));
     if ($headlist_json):
         $headlist = json_decode($headlist_json, true);
         if ($headlist):

--- a/search_listerdb_programlist_fromhead.php
+++ b/search_listerdb_programlist_fromhead.php
@@ -48,7 +48,7 @@ if(array_key_exists("selectid", $_REQUEST)) {
 }
 
 // build query url
-$url = 'http://localhost/search_listerdb_programlist_json.php?start='.$displayfrom.'&length='.$displaynum.'&header='.urlencode($header).'&category='.urlencode($category);
+$url = listerdb_forward_agelimit('http://localhost/search_listerdb_programlist_json.php?start='.$displayfrom.'&length='.$displaynum.'&header='.urlencode($header).'&category='.urlencode($category));
 
 ?>
 

--- a/search_listerdb_programlist_fromhead_bs5.php
+++ b/search_listerdb_programlist_fromhead_bs5.php
@@ -25,6 +25,8 @@ $url = 'http://localhost/search_listerdb_programlist_json.php?start=' . $display
     . '&length=' . $displaynum
     . '&header=' . urlencode($header)
     . '&category=' . urlencode($category);
+// 年齢制限曲を含める設定 (Cookie) をサーバー内の JSON 呼び出しへ転送する
+if (listerdb_include_agelimit()) { $url .= '&include_agelimit=1'; }
 
 $errmsg      = '';
 $programlist = null;

--- a/search_listerdb_programlist_json.php
+++ b/search_listerdb_programlist_json.php
@@ -57,6 +57,8 @@ if( !empty($header ) && !empty($category ) ) {
 }else if( !empty($header ) ){
     $select_where = $select_where . ' WHERE found_head =' . $listerdb->quote($header);
 }
+// 年齢制限タイアップ曲の絞り込み (既定は除外、include_agelimit=1 の利用者のみ含める)
+$select_where = listerdb_apply_agelimit_clause($select_where);
 if (!empty($select_orderby) ){
     $select_where = $select_where .  ' ORDER BY '. $select_orderby . ' ' . $select_scending ;
 }

--- a/search_listerdb_songlist.php
+++ b/search_listerdb_songlist.php
@@ -225,6 +225,8 @@ if(!empty($select_orderby_str) ){
 
 
 if(!empty($url)){
+    // 年齢制限曲を含める設定 (Cookie) をサーバー内の JSON 呼び出しへ転送する
+    if (listerdb_include_agelimit()) { $url = add_get_query($url, 'include_agelimit=1'); }
     $url = add_get_query($url , 'start='.$displayfrom.'&length='.$displaynum.'&'.$linkoption);
     $url = 'http://localhost/search_listerdb_songlist_json.php'.$url;
 }

--- a/search_listerdb_songlist_bs5.php
+++ b/search_listerdb_songlist_bs5.php
@@ -73,6 +73,9 @@ foreach ($fields as $f) {
         . '<input type="' . $type . '" name="' . $f['name'] . '" class="form-control-themed" value="' . htmlspecialchars($f['val'], ENT_QUOTES, 'UTF-8') . '"></div>';
 }
 if (!empty($match)) { $url = _sq_add($url, 'match=' . urlencode($match)); $myrequestarray['match'] = $match; }
+// 年齢制限曲を含める設定 (Cookie) をサーバー内の JSON 呼び出しへ転送する
+// (ブラウザの Cookie はサーバー内 HTTP には乗らないため)
+if (listerdb_include_agelimit()) { $url = _sq_add($url, 'include_agelimit=1'); }
 if (!empty($select_orderby_str)) $url = _sq_add($url, 'orderby=' . urlencode($select_orderby_str));
 if (!empty($url)) {
     $url = _sq_add($url, 'start=' . $displayfrom . '&length=' . $displaynum . $linkoption);

--- a/search_listerdb_songlist_json.php
+++ b/search_listerdb_songlist_json.php
@@ -381,7 +381,10 @@ if( !empty($artist ) ){
   }
 } //else なんでも検索
 
-//add groupby 
+// 年齢制限タイアップ曲の絞り込み (既定は除外、include_agelimit=1 の利用者のみ含める)
+$select_where = listerdb_apply_agelimit($select_where);
+
+//add groupby
 //$select_where = $select_where . ' GROUP BY '.$listitem;
 // 曲名とタイアップ名で抽出する
 $select_where = $select_where . ' GROUP BY song_name, program_name';


### PR DESCRIPTION
## 概要

運用不具合調査 (2026-07-20 報告書) の「年齢制限フィルタで曲が見つからない」対応です。
リスターDB検索の年齢制限タイアップ曲 (`tie_up_age_limit >= 18`) を **既定で非表示** とし、利用者ごとに検索画面のチェックで含めるかを選択できるようにしました (Web・アプリ共通の仕組み)。

## 仕組み

- 検索画面に「年齢制限のある曲を検索結果に含める」チェックを配置 (BS5: search_bs5 / りすたーDB検索、BS3: リスターDB検索画面)
- 初回オン時のみ確認ダイアログを表示し、承諾を localStorage に記録。以降は確認なしで切り替え可能
- 選択は Cookie `YkariIncludeAgelimit=1` (365日) に保存され、そのブラウザの全リスターDB検索 (BS5/BS3/レガシー含む) に適用
- 中間ページはサーバー内 JSON 呼び出し (localhost への file_get_contents) に Cookie が乗らないため、URL パラメータ `include_agelimit=1` として転送
- アプリ用 API `api/lister_index.php` はリクエストパラメータ `include_agelimit=1` で全モードのフィルタを解除 (アプリ側 PR で対応予定。旧アプリはパラメータを送らないだけで従来どおり動作)

## 変更内容

- `commonfunc.php`: 判定 (`listerdb_include_agelimit`)・WHERE 生成・URL 転送・チェック UI 出力のヘルパー群を追加
- `js/agelimit_optin.js` (新規): チェック状態の復元・確認ダイアログ・Cookie/localStorage 管理
- Web 検索 JSON 全系統にフィルタ適用: songlist / filelist / programlist / artistlist / artistmany / column / head / レガシー search_listerdb_json
- 中間ページ (BS5×6・BS3×8) に転送処理を追加
- `api/lister_index.php`: `include_agelimit` 対応+空白のみの anyword で不正な SQL になる問題を修正
- `search_listerdb_artistmany_json.php`: 総件数クエリにもフィルタを適用 (ページング整合)

## 検証 (ローカル、テスト用 ListerDB: tie_up_age_limit = NULL / 0 / 18 の3曲)

- API・JSON 全系統: 既定で制限曲が出ず、`include_agelimit=1` (または Cookie) で出ることを確認
- 中間ページ全種: Cookie なし→制限曲なし / Cookie あり→制限曲ありを確認 (頭文字インデックスの活性化含む)
- UI (Playwright): 初回オンで確認ダイアログ → 承諾で Cookie+localStorage 設定 → 検索結果に制限曲表示 → リロード後もチェック維持 → オフで即時 Cookie 削除・非表示、キャンセル時は何も記録されないことを確認
- 全変更ファイル `php -l` OK

## 既存利用者への影響

これまで Web 検索では年齢制限曲が常に表示されていたため、**初期状態では表示されなくなります** (チェックをオンにすれば従来どおり)。この挙動変更は合意済みです。

11002 反映後は「七色の地図」で チェックオフ→出ない / オン→出る の実機確認を予定しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)