### PR TITLE
fix: Google認証のキャンセルとDriveスコープ未許可を適切にハンドリング

### DIFF
--- a/mypage_google_callback.php
+++ b/mypage_google_callback.php
@@ -28,6 +28,13 @@ if (empty($relay_secret)) {
     redirect_error('not_configured');
 }
 
+// ---- 中継サーバーからのエラー持ち帰り (キャンセル・スコープ拒否等) ----
+// payload 検証より先に処理する (以前はすべて no_payload に潰れていた)。
+// コードは表示側 (mypage_google_sync.php の $error_map) で文言に変換される
+if (!empty($_GET['error'])) {
+    redirect_error($_GET['error']);
+}
+
 // ---- payload を検証 ----
 $raw_payload = $_GET['payload'] ?? '';
 if (empty($raw_payload)) {

--- a/mypage_google_relay_server.php
+++ b/mypage_google_relay_server.php
@@ -6,6 +6,7 @@
  * 担当する処理:
  *   GET  ?action=auth&client_id=XXX&state=YYY  → Google OAuth へリダイレクト
  *   GET  ?code=XXX&state=YYY                   → コード交換 → ローカルサーバーへリダイレクト
+ *   GET  ?error=XXX&state=YYY                  → キャンセル・拒否の案内表示 (Web版はエラーコードを持ち帰り)
  *   POST ?action=refresh  (JSON body)           → トークンリフレッシュ API
  *
  * アプリ (ゆかナビ) 用の直接認証フロー:
@@ -13,6 +14,10 @@
  *   GET  ?code=XXX&state=<app用state>           → トークンを一時保存し「認証完了」を表示
  *   GET  ?action=app_poll&session=<64hex>       → 保存済みトークンを返して削除 (ワンタイム)
  *   POST ?action=app_refresh (JSON body)        → アプリ用トークンリフレッシュ (HMAC 不要)
+ *
+ * どちらのフローも、きめ細かい同意 (granular consent) で Google ドライブの
+ * チェックが外されたまま「続行」された場合は成功にせず、再試行を案内する
+ * (そのまま通すとログイン成功後の Drive 同期が 403 になるため)。
  *
  * 設定: mypage_google_relay_config.php を同ディレクトリに置く
  */
@@ -30,7 +35,9 @@ require $config_file;
 
 define('GOOGLE_AUTH_URL',   'https://accounts.google.com/o/oauth2/v2/auth');
 define('GOOGLE_TOKEN_URL',  'https://oauth2.googleapis.com/token');
+define('GOOGLE_REVOKE_URL', 'https://oauth2.googleapis.com/revoke');
 define('RELAY_REDIRECT_URI', 'https://ykr.moe/mypage_google_callback.php');
+define('DRIVE_APPDATA_SCOPE', 'https://www.googleapis.com/auth/drive.appdata');
 
 $action = $_GET['action'] ?? '';
 $method = $_SERVER['REQUEST_METHOD'];
@@ -205,6 +212,28 @@ if ($method === 'GET' && $action === 'auth') {
 }
 
 // ============================================================
+// GET ?error=XXX — Google からのコールバック (キャンセル・拒否)
+// 同意画面で「キャンセル」を押す等でここに来る。以前はどのハンドラにも
+// 当たらず素の 400「不正なリクエストです。」が表示されていた
+// (App Store 審査 2026-07-24 で「ログイン時にエラーが表示される」と指摘された画面)
+// ============================================================
+if ($method === 'GET' && !empty($_GET['error']) && empty($_GET['code'])) {
+    $state_json = decode_signed($_GET['state'] ?? '', $RELAY_SECRET);
+    $state_data = $state_json !== false ? json_decode($state_json, true) : null;
+
+    // Web 版のフロー: エラーコードをローカルサーバーへ持ち帰って画面に表示させる
+    if (!empty($state_data['return_url'])
+        && preg_match('#^https?://#i', $state_data['return_url'])) {
+        redirect_error($state_data['return_url'], 'access_denied');
+    }
+
+    // アプリのフロー (state が無い・不正な場合も同じ)。セッションを ok にしない
+    // だけで充分 — アプリはシートを閉じた時点で「中止」扱いになるため、
+    // ここではエラー画面ではなく案内だけを表示する
+    exit_cancel_page();
+}
+
+// ============================================================
 // GET ?code=XXX&state=YYY  — Google からのコールバック
 // ============================================================
 if ($method === 'GET' && !empty($_GET['code']) && !empty($_GET['state'])) {
@@ -227,6 +256,13 @@ if ($method === 'GET' && !empty($_GET['code']) && !empty($_GET['state'])) {
         $token_json = app_exchange_code($code, $RELAY_CLIENT_ID, $RELAY_CLIENT_SECRET);
         if ($token_json === null) {
             exit_no_redirect('Google からトークンを取得できませんでした。アプリからやり直してください。');
+        }
+        // きめ細かい同意で Drive のチェックが外されたまま「続行」された場合は
+        // 成功にしない (このまま通すとアプリはログイン成功後の同期で 403 になる)
+        $token_data = json_decode($token_json, true);
+        if (strpos($token_data['scope'] ?? '', DRIVE_APPDATA_SCOPE) === false) {
+            relay_revoke_token($token_data['access_token'] ?? ''); // 使えない権限は残さない
+            exit_drive_scope_page();
         }
         file_put_contents(app_session_file($state_data['app_session']), $token_json);
         header('Content-Type: text/html; charset=utf-8');
@@ -271,6 +307,12 @@ if ($method === 'GET' && !empty($_GET['code']) && !empty($_GET['state'])) {
     $token = json_decode($resp, true);
     if (empty($token['access_token'])) {
         redirect_error($return_url, 'token_exchange_failed');
+    }
+
+    // きめ細かい同意で Drive のチェックが外されたまま「続行」された場合 (アプリのフローと同じ)
+    if (strpos($token['scope'] ?? '', DRIVE_APPDATA_SCOPE) === false) {
+        relay_revoke_token($token['access_token']); // 使えない権限は残さない
+        redirect_error($return_url, 'drive_scope_denied');
     }
 
     // id_token からユーザー情報を取得（署名検証は省略、sub/email のみ使用）
@@ -359,6 +401,64 @@ function exit_no_redirect($msg) {
 }
 
 /**
+ * 案内ページの共通レイアウト (認証完了ページと同じ見た目)
+ */
+function exit_info_page($title, $heading, $lines) {
+    header('Content-Type: text/html; charset=utf-8');
+    $body = '';
+    foreach ($lines as $line) {
+        $body .= '<p>' . $line . '</p>';
+    }
+    echo '<!doctype html><html lang="ja"><head><meta charset="utf-8">'
+       . '<meta name="viewport" content="width=device-width, initial-scale=1">'
+       . '<title>' . $title . '</title></head>'
+       . '<body style="font-family:sans-serif; text-align:center; padding-top:4em;">'
+       . '<h2>' . $heading . '</h2>' . $body
+       . '</body></html>';
+    exit;
+}
+
+/**
+ * キャンセル・拒否時の案内 (エラー画面にはしない。アプリはシートを
+ * 閉じた時点で「中止」扱いになる)
+ */
+function exit_cancel_page() {
+    exit_info_page('ゆかナビ - ログイン中止',
+        'ログインは完了しませんでした',
+        [
+            'Google のログインがキャンセルされたか、アクセスが許可されませんでした。',
+            'このページを閉じて、ゆかナビ (または Web 版マイページ) から'
+                . 'もう一度お試しください。',
+        ]);
+}
+
+/**
+ * Drive スコープのチェックが外されたまま「続行」された場合の案内
+ */
+function exit_drive_scope_page() {
+    exit_info_page('ゆかナビ - 許可が必要です',
+        'Google ドライブへのアクセス許可が必要です',
+        [
+            'マイページのバックアップには「Google ドライブでのアプリ独自の設定データの'
+                . '参照、作成、削除」の許可が必要です。',
+            'このページを閉じてもう一度ログインし、同意画面のチェックボックスを'
+                . 'オンにしてから「続行」を押してください。',
+        ]);
+}
+
+/**
+ * 使わないトークンの失効 (ベストエフォート。失敗しても続行)
+ */
+function relay_revoke_token($access_token) {
+    if (empty($access_token)) {
+        return;
+    }
+    relay_http_post(GOOGLE_REVOKE_URL,
+        http_build_query(['token' => $access_token]),
+        ['Content-Type: application/x-www-form-urlencoded']);
+}
+
+/**
  * アプリセッション ID の形式チェック (32〜64桁の16進のみ。ファイル名に使うため)
  */
 function app_session_valid($session) {
@@ -407,6 +507,9 @@ function app_exchange_code($code, $client_id, $client_secret) {
         'access_token'  => $token['access_token'],
         'refresh_token' => $token['refresh_token'] ?? '',
         'expires_at'    => time() + (int)($token['expires_in'] ?? 3600),
+        // 実際に付与されたスコープ (スペース区切り)。呼び出し側の検証用で、
+        // アプリはこのフィールドを無視する
+        'scope'         => $token['scope'] ?? '',
     ]);
 }
 

--- a/mypage_google_sync.php
+++ b/mypage_google_sync.php
@@ -33,6 +33,11 @@ if (configbool("usemypage", true)) {
         'missing_token'  => 'Googleからトークンを取得できませんでした。',
         'sync_failed'    => '同期に失敗しました。しばらく経ってから再度お試しください。',
         'unlinked'       => 'Google連携を解除しました。',
+        // 中継サーバーから持ち帰るコード (mypage_google_relay_server.php)
+        'access_denied'  => 'Googleのログインがキャンセルされたか、アクセスが許可されませんでした。再度お試しください。',
+        'drive_scope_denied' => 'Googleドライブへのアクセスが許可されませんでした。同意画面で「Googleドライブでのアプリ独自の設定データの参照、作成、削除」にチェックを入れて「続行」を押してください。',
+        'state_expired'  => '認証の有効期限が切れました。再度お試しください。',
+        'token_exchange_failed' => 'Googleからトークンを取得できませんでした。再度お試しください。',
     ];
     if (!empty($_GET['error'])) {
         $msg      = $error_map[$_GET['error']] ?? ('エラーが発生しました: ' . htmlspecialchars($_GET['error'], ENT_QUOTES, 'UTF-8'));


### PR DESCRIPTION
## 概要

App Store 審査 (2026-07-24 / ゆかナビ iOS 1.0.0 (10)) で「Google でログインしようとするとエラーメッセージが表示される」(Guideline 2.1(a)) と却下された問題の対応。原因は relay (`mypage_google_relay_server.php`) の2つの取りこぼしで、**アプリのバイナリ変更は不要**。

## 原因と修正

### 1. 同意画面で「キャンセル」→ 素の 400 エラーがシート内に表示
Google は拒否時に `?error=access_denied&state=...` でコールバックするが、relay にハンドラが無く、最後の catch-all の **400「不正なリクエストです。」** がアプリ内シート (SFSafariViewController) に表示されていた。審査員の見た「エラーメッセージ」はこれが濃厚。

→ `error` パラメータのハンドラを追加:
- アプリのフロー: 「ログインは完了しませんでした / このページを閉じて…」の案内ページ (200) を表示。セッションは ok にしないため、現行アプリはシートを閉じた時点で「ログインを中止しました」の正常系トーストになる
- Web版のフロー: `?error=access_denied` を return_url へ持ち帰り、画面にメッセージ表示

### 2. きめ細かい同意 (granular consent) で Drive のチェックを外したまま「続行」
Google の同意画面はドライブ権限が**初期オフのチェックボックス**になっており、チェック無しで続行するとスコープ不足のまま `status: ok` になり、ログイン直後の Drive 同期が **403** → アプリに「同期に失敗: Google Drive エラー (HTTP 403)」の赤トーストが出ていた。

→ トークン交換後に付与スコープ (`scope`) に `drive.appdata` が含まれるか検証。不足時は成功にせず「チェックをオンにして再試行」の案内ページを表示し、使えない権限は revoke してから捨てる (アプリ・Web版の両フロー)。

### 3. 付随修正 (Web版)
relay からのエラーコードがローカルサーバーの `mypage_google_callback.php` で `no_payload` に潰れていたのを修正し、`mypage_google_sync.php` の error_map に `access_denied` / `drive_scope_denied` / `state_expired` / `token_exchange_failed` の文言を追加。

## テスト

- `php -l` 3ファイルとも構文エラーなし
- ローカル PHP サーバーでのスモークテスト:
  - `?error=access_denied&state=不正` → 200 案内ページ ✓
  - `?error=access_denied&state=Web版署名付き` → 302 `return_url?error=access_denied` ✓
  - `?action=app_auth` → 従来どおり Google へ 302 ✓
  - `?action=app_poll` (未知セッション) → `{"status":"pending"}` ✓
  - パラメータ無し → 従来どおり 400 ✓
- 実機テスト (マージ後・ykr.moe 反映後): iOS の TestFlight から (a) 同意画面でキャンセル → 案内ページ+シートを閉じて「中止しました」、(b) チェック無し続行 → 案内ページ、(c) チェック有り続行 → ログイン成功、を確認予定

## デプロイ

ヘッダーコメントどおり、`mypage_google_relay_server.php` を **`mypage_google_callback.php` にリネームして ykr.moe に配置**(手動)。ローカルサーバー側 2 ファイルは次回の部屋サーバー更新で反映。

🤖 Generated with [Claude Code](https://claude.com/claude-code)